### PR TITLE
Use Promise for holding values

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -33,60 +33,23 @@
 'use strict';
 
 /**
- * CredentialsHolder holds the credentials obtained using getGrpcCredentials.
+ * Creates a promise which resolves a auth credential.
  *
- * It provides a method, get, that is used to obtain the credentials and store
- * them.
- *
- * @param {function(callback, opts)} getCredentials - the callback used to
- *   obtain the credentials
- *
- * @param {string|string[]} opt_scopes - the scope or scopes to use when
- *   obtaining the credentials.
- *
- * @constructor
+ * @param {function()} getCredentials - the callback used to
+ *   obtain the credentials.
+ * @param {Object} opts - the optional arguments to be passed to
+ *   getCredentials.
+ * @returns A promise which resolves to the credential.
  */
-function CredentialsHolder(getCredentials, opt_scopes) {
-  /**
-   * A credentials obtained by getCredentials
-   */
-  this.credentials = null;
-
-  /**
-   * The callback used to obtain the credentials
-   */
-  this.getCredentials = getCredentials;
-
-  /**
-   * The scopes to use to create the credentials
-   */
-  this.scopes = opt_scopes;
-}
-
-/**
- * get obtains the credential instance to be used.
- *
- * The callback is a standard node callback, i.e it will be called with either
- * - (err) if a problem occurs obtaining the credentials
- * - (null, credentials)
- *
- * @param {function} callback - to be invoked once credentials are obtained.
- */
-CredentialsHolder.prototype.get = function get(callback) {
-  var storeCredentials = function storeCredentials(err, credentials) {
-    if (err) {
-      callback(err);
-    } else {
-      this.credentials = credentials;
-      callback(null, this.credentials);
-    }
-  }.bind(this);
-
-  if (!this.credentials) {
-    this.getCredentials(storeCredentials, {scopes: this.scopes});
-  } else {
-    callback(null, this.credentials);
-  }
+exports.createCredPromise = function createCredPromise(
+    getCredentials, opts) {
+  return new Promise(function(resolve, reject) {
+    getCredentials(function(err, credentials) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(credentials);
+      }
+    }, opts);
+  });
 };
-
-exports.CredentialsHolder = CredentialsHolder;

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -36,7 +36,7 @@ var grpc = require('grpc');
 var GoogleAuth = require('google-auth-library');
 var AuthFactory = new GoogleAuth();
 
-var CredentialsHolder = require('./auth').CredentialsHolder;
+var createCredPromise = require('./auth').createCredPromise;
 
 /**
  * To authorize requests through gRPC, we must get the raw google-auth-library
@@ -46,6 +46,10 @@ var CredentialsHolder = require('./auth').CredentialsHolder;
  *
  * @param {function} callback - The callback function.
  * @param {object} opts - options values for configuring auth
+ * @param {string|[]string} opts.scopes - the scope or scopes to use when
+ *   obtaining the credentials.
+ * @param {object} opts.sslCreds - when specified, this is used instead
+ *   of default credentials.
  * @param {?error} callback.err - An error getting an auth client.
  */
 function getCredentials(callback, opts) {
@@ -70,73 +74,24 @@ function getCredentials(callback, opts) {
 }
 
 /**
- * StubHolder holds an rpc stub.
- *
- * It provides a method, get, that is used to obtain the stub.
+ * Creates a promise which resolves to an rpc stub.
  *
  * @param {string} servicePath - The domain name of the API remote host.
  * @param {integer} port - The port on which to connect to the remote host.
- * @param {function} createStub - The constructor used to create grpc stub instance.
+ * @param {function} createStub - The constructor used to create a grpc stub
+ *   instance.
  * @param {object} options - optional settings for configuring
- * @param {function(callback, opts)} options.getCredentials - the callback used to
- *   obtain the credentials
+ * @param {function(callback, opts)} options.getCredentials - the callback used
+ *   to obtain the credentials
  * @param {string|string[]} option.scopes - the scope or scopes to use when
  *   obtaining the credentials used by the stub.
- *
- * @constructor
+ * @returns {Promise} A promise which resolves to an rpc stub.
  */
-function StubHolder(servicePath, port, createStub, options) {
-  /**
-   * A createStub the constructor used to create the grpc stub instance.
-   */
-  this.CreateStub = createStub;
-
-  /**
-   * A stub for accesing a grpc service.
-   */
-  this.stub = null;
-
-  /**
-   * The domain name of the API remote host.
-   */
-  this.servicePath = servicePath;
-
-  /**
-   * The port on which to access the service.
-   */
-  this.port = port;
-
-  /**
-   * A CredentialsHolders for accessing the credentials.
-   */
-  this.credsHolder = new CredentialsHolder(
-      options.getCredentials || getCredentials,
-      options.scopes);
-}
-
-/**
- * get obtains the stub instance.
- *
- * The callback is a standard node callback, i.e it will be called with either
- * - (err) if a problem occurs initializing the stub
- * - (null, credentials)
- *
- * @param {function} callback - to be invoked once the stub is initialized.
- */
-StubHolder.prototype.get = function get(callback) {
-  var buildStub = function buildStub(err, credentials) {
-    if (err) {
-      callback(err);
-    } else {
-      this.stub = new this.CreateStub(this.servicePath + ':' + this.port,
-                                      credentials);
-      callback(null, this.stub);
-    }
-  }.bind(this);
-
-  if (!this.stub) {
-    this.credsHolder.get(buildStub);
-  } else {
-    callback(null, this.stub);
-  }
+exports.createStub = function createStub(
+    servicePath, port, CreateStub, options) {
+  var creds = createCredPromise(options.getCredentials || getCredentials,
+                                options.scopes, options);
+  return creds.then(function buildStub(credentials) {
+    return new CreateStub(servicePath + ':' + port, credentials);
+  });
 };

--- a/test/auth.js
+++ b/test/auth.js
@@ -34,47 +34,54 @@
 
 var _ = require('lodash');
 var expect = require('chai').expect;
+var sinon = require('sinon');
 
-var CredentialsHolder = require('../lib/auth').CredentialsHolder;
+var createCredPromise = require('../lib/auth').createCredPromise;
 
-describe('CredentialsHolder', function() {
+describe('credential promise', function() {
 
-  describe('constructor', function() {
-    it('credentials starts out null', function() {
-      var holder = new CredentialsHolder(_.noop);
-      expect(holder.credentials).to.eql(null);
+  var dummyCreds = {};
+  var getCredentials = function(callback) {
+    callback(null, dummyCreds);
+  };
+
+  it('resolves the credential', function(done) {
+    var credP = createCredPromise(getCredentials);
+    credP.then(function(cred) {
+      expect(cred).to.eq(dummyCreds);
+      done();
+    }).catch(function(err) {
+      done(err);
     });
   });
 
-  describe('method `get`', function() {
-    it('invokes the callback to set the credential', function(done) {
-      var dummyCreds = {};
-      var getCredentials = function(callback) {
-        callback(null, dummyCreds);
-      };
-      var holder = new CredentialsHolder(getCredentials);
-
-      var thenCheckHasCreds = function thenCheckHasCreds() {
-        expect(holder.credentials).to.eq(dummyCreds);
-        done();
-      };
-      holder.get(thenCheckHasCreds);
+  it('keeps credential', function(done) {
+    var getCredentialsSpy = sinon.spy(getCredentials);
+    var credP = createCredPromise(getCredentialsSpy);
+    var checkCredSpy = sinon.spy(function checkCred(cred) {
+      expect(cred).to.eq(dummyCreds);
     });
-
-    it('propagates errors from the credential callback', function(done) {
-      var testError = new Error('this is used in a test');
-      var getCredentials = function(callback) {
-        callback(testError);
-      };
-      var holder = new CredentialsHolder(getCredentials);
-
-      var thenCheckHasCreds = function thenCheckHasCreds(err) {
-        expect(err).to.eq(testError);
-        expect(holder.credentials).to.eq(null);
-        done();
-      };
-      holder.get(thenCheckHasCreds);
+    Promise.all([credP.then(checkCredSpy), credP.then(checkCredSpy)]).then(
+        function() {
+      expect(getCredentialsSpy.callCount).to.eq(1);
+      expect(checkCredSpy.callCount).to.eq(2);
+      done();
+    }).catch(function(err) {
+      done(err);
     });
   });
 
+  it('propagates errors from the credential callback', function(done) {
+    var testError = new Error('this is used in a test');
+    var getCredentials = function(callback) {
+      callback(testError);
+    };
+    var credP = createCredPromise(getCredentials);
+    credP.catch(function(err) {
+      expect(err).to.eq(testError);
+      done();
+    }).catch(function(err) {
+      done(err);
+    });
+  });
 });


### PR DESCRIPTION
I've noticed that Promise fits well to the holder pattern we've
introduced for auth and credentials. This reduces the code
significantly, and Promise would be beneficial thanks to
its composability (and because it's a language feature).