### PR TITLE
Explicitly specify node version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 sudo: false
 language: node_js
 node_js:
-  - "5"
-  - "5.1"
-  - "4"
-  - "4.2"
-  - "4.1"
-  - "4.0"
+  - 5
+  - 5.1
+  - 4
+  - 4.2
+  - 4.1
+  - 4.0
+  - 0.12
 script:
   - npm test
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "bugs": {
     "url": "https://github.com/googleapis/gax-nodejs/issues"
   },
-  "homepage": "https://github.com/googleapis/gax-nodejs#readme"
+  "homepage": "https://github.com/googleapis/gax-nodejs#readme",
+  "engines": {
+    "node": ">=0.12.0"
+  }
 }


### PR DESCRIPTION
0.12.0 is the least version which gcloud-node supports, we want to
keep this as far as possible.