### PR TITLE
Fix the structure of api_callable

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -41,19 +41,50 @@ var through2 = require('through2');
 var setTimeout = require('timers').setTimeout;
 
 /**
+ * @callback Callback
+ * @param {?Error} err - an error, if something goes wrong for the API.
+ * @param {?Object} response - the response object for the API call.
+ */
+
+/**
+ * The actual interface of an API call - this interface follows the
+ * actual interface for gRPC.
+ * @callback APICall
+ * @param {Object} argument - the request object.
+ * @param {Callback} callback - the callback function to be called
+ *   when the API call finishes.
+ * @param {grpc.Metadata} metadata - the gRPC metadata (like header
+ *   information).
+ * @param {Object} options - the additional options such as deadline.
+ */
+
+/**
+ * The result of createApiCall. Similar to APICall but some parameters
+ * can be customizable through callOptions.
+ * @callback APICallable
+ * @param {Object} argument - the request object.
+ * @param {Callback} callback - the callback function to be called
+ *   when the API call finishes.
+ * @param {grpc.Metadata} metadata - the gRPC metadata object (lik header
+ *   information).
+ * @param {CallOptions} callOptions - the CallOptions to customize the
+ *   parameter of the API calls.
+ */
+
+/**
  * Updates aFunc so that it gets called with the timeout as its final arg.
  *
  * This converts a function, aFunc, into another function with updated deadline.
  *
- * @param {function()} aFunc - a function to be updated
- * @param {number} timeout - to be added to the original function as it final
- *   positional arg.
- * @returns {function()} the original function updated to the timeout arg
+ * @param {APICall} aFunc - a function to be updated
+ * @param {CallSettings} callSettings - the current call settings.
+ * @returns {APICallable} the original function updated to the timeout arg
  */
-function addTimeoutArg(aFunc, timeout) {
-  return function timeoutFunc(argument, callback, metadata, options) {
+function addTimeoutArg(aFunc, callSettings) {
+  return function timeoutFunc(argument, callback, metadata, callOptions) {
     var now = new Date();
-    options.deadline = new Date(now.getTime() + timeout);
+    var timeout = callSettings.merge(callOptions).timeout;
+    var options = {'deadline': new Date(now.getTime() + timeout)};
     aFunc(argument, callback, metadata, options);
   };
 }
@@ -62,42 +93,36 @@ function addTimeoutArg(aFunc, timeout) {
  * Creates a function equivalent to aFunc, but that retries on certain
  * exceptions.
  *
- * @param {function()} aFunc - A function.
+ * @param {APICall} aFunc - A function.
  * @param {RetryOptions} retry - Configures the exceptions upon which the
  *   function eshould retry, and the parameters to the exponential backoff retry
  *   algorithm.
- * @returns {function()} A function that will retry on exception.
+ * @returns {APICallable} A function that will retry on exception.
  */
-function retryable(aFunc, retry) {
-  var delayMult = retry.backoffSettings.retryDelayMultiplier;
-  var maxDelay = retry.backoffSettings.maxRetryDelayMillis;
-  var timeoutMult = retry.backoffSettings.rpcTimeoutMultiplier;
-  var maxTimeout = retry.backoffSettings.maxRpcTimeoutMillis;
-
-  var delay = retry.backoffSettings.initialRetryDelayMillis;
-  var timeout = retry.backoffSettings.initialRpcTimeoutMillis;
+function retryable(aFunc, callSettings) {
+  var delayMult;
+  var maxDelay;
+  var timeoutMult;
+  var maxTimeout;
+  var delay;
+  var now;
+  var deadline;
+  var retryCodes;
   var error = new Error('Retry total timeout exceeded before any' +
       'response was received');
-  var now = new Date();
-  var deadline = now.getTime() + retry.backoffSettings.totalTimeoutMillis;
-  /**
-   * Equivalent to ``aFunc``, but retries upon transient failure.
-   *
-   * Retrying is done through an exponential backoff algorithm configured
-   * by the options in ``retry``.
-   */
-  return function retryingFunc(argument, callback, metadata, options) {
+
+  function retryingFunc(argument, callback, metadata, callOptions) {
     if (now.getTime() >= deadline) {
       callback(error);
       return;
     }
-    var toCall = addTimeoutArg(aFunc, timeout);
+    var toCall = addTimeoutArg(aFunc, callSettings);
     toCall(argument, function(err, response) {
       if (!err) {
         callback(null, response);
         return;
       }
-      if (retry.retryCodes.indexOf(err.code) < 0) {
+      if (retryCodes.indexOf(err.code) < 0) {
         error = new Error('Exception occurred in retry method that was ' +
             'not classified as transient');
         error.cause = err;
@@ -109,24 +134,51 @@ function retryable(aFunc, retry) {
         setTimeout(function() {
                      now = new Date();
                      delay = Math.min(delay * delayMult, maxDelay);
-                     timeout = Math.min(timeout * timeoutMult, maxTimeout,
-                                        deadline - now.getTime());
-                     retryingFunc(argument, callback, metadata, options);
+                     var settings = callSettings.merge(callOptions);
+                     var timeout = Math.min(settings.timeout * timeoutMult,
+                                            maxTimeout,
+                                            deadline - now.getTime());
+                     callOptions.timeout = timeout;
+                     retryingFunc(argument, callback, metadata, callOptions);
                    }, toSleep);
       }
-    }, metadata, options);
+    }, metadata, callOptions);
+  }
+
+  return function retryCallable(argument, callback, metadata, callOptions) {
+    var settings = callSettings.merge(callOptions);
+    var apiCall;
+    if (settings.retry) {
+      var retry = settings.retry;
+      delayMult = retry.backoffSettings.retryDelayMultiplier;
+      maxDelay = retry.backoffSettings.maxRetryDelayMillis;
+      timeoutMult = retry.backoffSettings.rpcTimeoutMultiplier;
+      maxTimeout = retry.backoffSettings.maxRpcTimeoutMillis;
+      delay = retry.backoffSettings.initialRetryDelayMillis;
+
+      retryCodes = retry.retryCodes;
+      // Recreate the callOptions parameter to allow updating timeout parameter.
+      callOptions = new gax.CallOptions(callOptions || {});
+      callOptions.timeout = retry.backoffSettings.initialRpcTimeoutMillis;
+      now = new Date();
+      deadline = now.getTime() + retry.backoffSettings.totalTimeoutMillis;
+      apiCall = retryingFunc;
+    } else {
+      apiCall = addTimeoutArg(aFunc, settings);
+    }
+    apiCall(argument, callback, metadata, callOptions);
   };
 }
 
 /**
  * Creates a function that returns a stream to performs page-streaming.
- * @param {function()} a_func - an API call that is page streaming.
+ * @param {APICallable} a_func - an API call that is page streaming.
  * @param {string} requestPageTokenField - The field of the page token in the
  *   request.
  * @param {string} responsePageTokenField - The field of the next page token in
  *   the response.
  * @param {string} resourceField - The field to be streamed.
- * @returns {function()} A function for the page streaming. By default, it
+ * @returns {APICallable} A function for the page streaming. By default, it
  *   returns a stream over the specified field, but if callback function
  *   is specified at the end, it invokes the callback function with the response
  *   object and returns null.
@@ -135,9 +187,9 @@ function pageStreamable(aFunc,
                         requestPageTokenField,
                         responsePageTokenField,
                         resourceField) {
-  return function pageStreaming(argument, callback, metadata, options) {
+  return function pageStreaming(argument, callback, metadata, callOptions) {
     if (callback) {
-      aFunc(argument, callback, metadata, options);
+      aFunc(argument, callback, metadata, callOptions);
       return null;
     }
 
@@ -171,7 +223,7 @@ function pageStreamable(aFunc,
         }
         argument[requestPageTokenField] = nextPageToken;
         streaming();
-      }, metadata, options);
+      }, metadata, callOptions);
     }
     streaming();
     return stream;
@@ -192,20 +244,15 @@ function pageStreamable(aFunc,
  * The result is another callable which for most values of ``settings`` has
  * has the same signature as the original. Only when ``settings`` configures
  * bundling does the signature change.
- * @param {function()} func - is used to make a bare rpc call
+ * @param {APICall} func - is used to make a bare rpc call
  * @param {CallSettings} settings - provides the settings for this call
- * @returns {function()} func - a bound method on a request stub used
+ * @returns {APICallable} func - a bound method on a request stub used
  *   to make an rpc call
  * @throws - if ``settings`` has incompatible values, e.g, if bundling
  *   and page_streaming are both configured
  */
 exports.createApiCall = function createApiCall(func, settings) {
-  var apiCall;
-  if (settings.retry && settings.retry.retryCodes) {
-    apiCall = retryable(func, settings.retry);
-  } else {
-    apiCall = addTimeoutArg(func, settings.timeout);
-  }
+  var apiCall = retryable(func, settings);
   if (settings.pageDescriptor) {
     assert(!settings.bundler, 'The API call has incompatible settings: ' +
         'bundling and page streaming');


### PR DESCRIPTION
This is related to googleapis/gax-python#104 -- allow
creating an APICallable first, and the created callable will
accept an instance of CallOptions.