### PR TITLE
Introduce per-page iteration

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -120,38 +120,33 @@ function retryable(aFunc, retry) {
 
 /**
  * Creates a function that returns a stream to performs page-streaming.
- * @param {function()} a_func - an API call that is page streaming.
- * @param {string} requestPageTokenField - The field of the page token in the
- *   request.
- * @param {string} responsePageTokenField - The field of the next page token in
- *   the response.
- * @param {string} resourceField - The field to be streamed.
+ * @param {function()} aFunc - an API call that is page streaming.
+ * @param {gax.PageDescriptor} pageDescriptor - indicates the structure
+ *   of page streaming to be performed.
+ * @param {Object} pageToken - If set and page streaming is over pages of
+ *   the response, indicates the page_token to be passed to the API call.
+ * @param {boolean} flattenPages - If true, the returned iterable is over
+ *   ``resourceField``; otherwise the returned iterable is over the pages
+ *   of the response, each of which is an iterable over ``resourceField``.
  * @returns {function()} A function for the page streaming. By default, it
  *   returns a stream over the specified field, but if callback function
  *   is specified at the end, it invokes the callback function with the response
  *   object and returns null.
  */
 function pageStreamable(aFunc,
-                        requestPageTokenField,
-                        responsePageTokenField,
-                        resourceField) {
+                        pageDescriptor,
+                        pageToken,
+                        flattenPages) {
   return function pageStreaming(argument, callback, metadata, options) {
     if (callback) {
-      aFunc(argument, callback, metadata, options);
-      return null;
+      console.warn('callback is specified, but we don\'t use callbacks for ' +
+                   'page streaming APIs.');
     }
 
-    var streamFinished = false;
-    var stream = through2.obj(function(chunk, enc, callback) {
-      var resources = chunk[resourceField];
-      for (var i in resources) {
-        this.push(resources[i]);
-      }
-      callback();
-    });
-    stream.on('finish', function() {
-      streamFinished = true;
-    });
+    var stream = through2.obj();
+    if (!flattenPages && pageToken != gax.FIRST_PAGE) {
+      argument[pageDescriptor.requestPageTokenField] = pageToken;
+    }
 
     function streaming() {
       aFunc(argument, function(err, response) {
@@ -160,20 +155,33 @@ function pageStreamable(aFunc,
           stream.end();
           return;
         }
-        stream.write(response);
-        if (streamFinished) {
+        if (!stream.writable) {
           return;
         }
-        var nextPageToken = response[responsePageTokenField];
+        if (flattenPages) {
+          var resources = response[pageDescriptor.resourceField];
+          for (var i in resources) {
+            if (!stream.writable) {
+              break;
+            }
+            stream.write(resources[i]);
+          }
+        } else {
+          stream.write(response);
+        }
+        if (!stream.writable) {
+          return;
+        }
+        var nextPageToken = response[pageDescriptor.responsePageTokenField];
         if (!nextPageToken) {
           stream.end();
           return;
         }
-        argument[requestPageTokenField] = nextPageToken;
-        streaming();
+        argument[pageDescriptor.requestPageTokenField] = nextPageToken;
+        setTimeout(streaming, 0);
       }, metadata, options);
     }
-    streaming();
+    setTimeout(streaming, 0);
     return stream;
   };
 }
@@ -210,9 +218,9 @@ exports.createApiCall = function createApiCall(func, settings) {
     assert(!settings.bundler, 'The API call has incompatible settings: ' +
         'bundling and page streaming');
     return pageStreamable(apiCall,
-                          settings.pageDescriptor.requestPageTokenField,
-                          settings.pageDescriptor.responsePageTokenField,
-                          settings.pageDescriptor.resourceField);
+                          settings.pageDescriptor,
+                          settings.pageToken,
+                          settings.flattenPages);
   }
   // TODO: support bundling
   return apiCall;

--- a/lib/gax.js
+++ b/lib/gax.js
@@ -46,6 +46,8 @@ var assert = require('chai').assert;
  */
 var OPTION_INHERIT = exports.OPTION_INHERIT = {};
 
+var FIRST_PAGE = exports.FIRST_PAGE = {};
+
 /**
  * @param {Object} settings - An object containing parameters of this settings.
  * @param {number} settings.timeout - The client-side timeout for API calls.
@@ -55,6 +57,13 @@ var OPTION_INHERIT = exports.OPTION_INHERIT = {};
  * @param {PageDescriptor} settings.pageDescriptor - indicates the structure
  *   of page streaming to be performed. If set to null, page streaming
  *   is disabled.
+ * @param {boolean} settings.flattenPages - If there is no ``pageDescriptor``,
+ *   this attrbute has no meaning. Otherwise, determines whether a page streamed
+ *   response should make the page structure transparent to the user by
+ *   flattening the repeated field in the returned generator.
+ * @param {number} settings.pageToken - If there is no ``pageDescriptor``, this
+ *   attribute has no meaning. Otherwise, determines the page token used in the
+ *   page streaming request.
  * @param {Object} settings.bundler - orchestrates bundling. If null, bundling
  *   is not performed.
  */
@@ -63,6 +72,9 @@ function CallSettings(settings) {
   this.timeout = settings.timeout || 30;
   this.retry = settings.retry;
   this.pageDescriptor = settings.pageDescriptor;
+  this.flattenPages =
+      ('flattenPages' in settings) ? settings.flattenPages : true;
+  this.pageToken = settings.pageToken;
   this.bundler = settings.bundler;
 }
 exports.CallSettings = CallSettings;
@@ -81,27 +93,33 @@ CallSettings.prototype.merge = function merge(options) {
   }
   var timeout;
   var retry;
-  var pageDescriptor;
-  if (options.timeout == OPTION_INHERIT) {
+  var flattenPages;
+  var pageToken;
+  if (options.timeout === OPTION_INHERIT) {
     timeout = this.timeout;
   } else {
     timeout = options.timeout;
   }
-  if (options.retry == OPTION_INHERIT) {
+  if (options.retry === OPTION_INHERIT) {
     retry = this.retry;
   } else {
     retry = options.retry;
   }
-  if (options.isPageStreaming) {
-    pageDescriptor = this.pageDescriptor;
+
+  if (options.pageToken === OPTION_INHERIT) {
+    flattenPages = this.flattenPages;
+    pageToken = this.pageToken;
   } else {
-    pageDescriptor = null;
+    flattenPages = false;
+    pageToken = options.pageToken;
   }
 
   return new CallSettings({
     timeout: timeout,
     retry: retry,
-    pageDescriptor: pageDescriptor,
+    pageDescriptor: this.pageDescriptor,
+    flattenPages: flattenPages,
+    pageToken: pageToken,
     bundler: this.bundler});
 };
 
@@ -127,8 +145,11 @@ CallSettings.prototype.merge = function merge(options) {
  * @param {number} options.timeout - The client-side timeout for API calls.
  * @param {RetryOptions} options.retry - determines whether and how to retry
  *   on transient errors. When set to null, the call will not retry.
- * @param {boolean} isPageStreaming - If set and the call is configured for
- *   page streaming, page streaming is performed.
+ * @param {Object} options.pageToken - If set and the call is configured for
+ *   page streaming, page streaming is performed per-page, starting with this
+ *   pageToken. Use ``INITIAL_PAGE`` for the first request.  If unset and the
+ *   call is configured for page streaming, page streaming is performed
+ *   per-resource.
  */
 function CallOptions(options) {
   if ('timeout' in options) {
@@ -141,10 +162,10 @@ function CallOptions(options) {
   } else {
     this.retry = OPTION_INHERIT;
   }
-  if ('isPageStreaming' in options) {
-    this.isPageStreaming = options.isPageStreaming;
+  if ('pageToken' in options) {
+    this.pageToken = options.pageToken;
   } else {
-    this.isPageStreaming = OPTION_INHERIT;
+    this.pageToken = OPTION_INHERIT;
   }
 }
 exports.CallOptions = CallOptions;

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -28,11 +28,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*jshint expr: true*/
+
 'use strict';
 
 var apiCallable = require('../lib/api_callable');
 var gax = require('../lib/gax');
-var assert = require('chai').assert;
+var expect = require('chai').expect;
 var sinon = require('sinon');
 
 var FAKE_STATUS_CODE_1 = 1;
@@ -47,15 +49,15 @@ function fail(argument, callback, metadata, options) {
 describe('createApiCall', function() {
   it('calls api call', function(done) {
     var settings = new gax.CallSettings();
-    var deadline_arg;
+    var deadlineArg;
     function func(argument, callback, metadata, options) {
-      deadline_arg = options.deadline;
+      deadlineArg = options.deadline;
       callback(null, 42);
     }
     var apiCall = apiCallable.createApiCall(func, settings);
     apiCall(null, function(err, resp) {
-      assert.equal(resp, 42);
-      assert(deadline_arg, 'deadline is not set');
+      expect(resp).to.eq(42);
+      expect(deadlineArg).to.be.ok;
       done();
     }, null, {});
   });
@@ -70,10 +72,10 @@ describe('page streaming', function() {
       [FAKE_STATUS_CODE_1], new gax.BackoffSettings(0, 0, 0, 0, 0, 0, 100));
   var settings = new gax.CallSettings({retry: retryOptions,
                                        pageDescriptor: pageDescriptor});
-  var deadline_arg = null;
+  var deadlineArg = null;
 
   function func(request, callback, metadata, options) {
-    deadline_arg = options.deadline;
+    deadlineArg = options.deadline;
     var pageToken = request.pageToken || 0;
     if (pageToken >= pageSize * pagesToStream) {
       callback(null, {'nums': []});
@@ -91,24 +93,89 @@ describe('page streaming', function() {
     var counter = 0;
     apiCall({}, null, null, {})
       .on('data', function(data) {
-            assert(deadline_arg, 'deadline is not set');
-            assert.equal(data, counter);
+            expect(deadlineArg).to.be.ok;
+            expect(data).to.eq(counter);
             counter++;
           })
       .on('end', function() {
-            assert.equal(counter, pageSize * pagesToStream);
+            expect(counter).to.eq(pageSize * pagesToStream);
             done();
           });
   });
 
-  it('returns an object if callback is specified', function(done) {
+  it('stops if in the middle', function(done) {
     var apiCall = apiCallable.createApiCall(func, settings);
-    apiCall({}, function(err, resp) {
-      assert(!err);
-      assert(deadline_arg, 'deadline is not set');
-      assert.deepEqual(resp, {'nums': [0, 1, 2], 'nextPageToken': 3});
+    var counter = 0;
+    var stream = apiCall({}, null, null, {});
+    stream.on('data', function(data) {
+      expect(deadlineArg).to.be.ok;
+      expect(data).to.eq(counter);
+      counter++;
+      if (counter == 4) {
+        stream.end();
+      }
+    }).on('end', function() {
+      expect(counter).to.eq(4);
       done();
-    }, null, {});
+    });
+  });
+
+  it('iterate over pages', function(done) {
+    var mySettings = settings.merge(
+        new gax.CallOptions({pageToken: gax.FIRST_PAGE}));
+    var apiCall = apiCallable.createApiCall(func, mySettings);
+    var counter = 0;
+    apiCall({}, null, null, {})
+      .on('data', function(data) {
+        expect(deadlineArg).to.be.ok;
+        expect(data).to.be.an('object');
+        expect(data.nums).to.be.an('array');
+        counter++;
+        if (counter <= pagesToStream) {
+          expect(data).to.have.any.keys(['nextPageToken']);
+        } else {
+          expect(data).to.not.have.any.keys(['nextPageToken']);
+        }
+      }).on('end', function() {
+        expect(counter).to.eq(pagesToStream + 1);
+        done();
+      });
+  });
+
+  it('stops in the middle of per-page iterfation, and resume it later',
+     function(done) {
+    function takeSingleResponse(pageToken) {
+      return new Promise(function(resolve, reject) {
+        var mySettings = settings.merge(
+            new gax.CallOptions({pageToken: pageToken}));
+        var apiCall = apiCallable.createApiCall(func, mySettings);
+        var stream = apiCall({}, null, null, {});
+        stream.on('data', function(resp) {
+          stream.end();
+          resolve(resp);
+        }).on('error', function(err) {
+          reject(err);
+        });
+      });
+    }
+    takeSingleResponse(gax.FIRST_PAGE).then(function(resp) {
+      expect(deadlineArg).to.be.ok;
+      expect(resp).to.be.an('object');
+      var expected = [];
+      for (var i = 0; i < pageSize; i++) {
+        expected.push(i);
+      }
+      expect(resp).to.eql({'nums': expected, 'nextPageToken': pageSize});
+      return takeSingleResponse(resp.nextPageToken);
+    }).then(function(resp) {
+      expect(resp).to.be.an('object');
+      var expected = [];
+      for (var i = 0; i < pageSize; i++) {
+        expected.push(i + pageSize);
+      }
+      expect(resp).to.eql({'nums': expected, 'nextPageToken': pageSize * 2});
+      done();
+    })['catch'](done);
   });
 
   it('retries on failure', function(done) {
@@ -125,12 +192,12 @@ describe('page streaming', function() {
     var dataCount = 0;
     apiCall({}, null, null, {})
       .on('data', function(data) {
-            assert.equal(data, dataCount);
+            expect(data).to.eq(dataCount);
             dataCount++;
           })
       .on('end', function() {
-            assert.equal(dataCount, pageSize * pagesToStream);
-            assert.isAbove(callCount, pagesToStream);
+            expect(dataCount).to.eq(pageSize * pagesToStream);
+            expect(callCount).to.be.above(pagesToStream);
             done();
           });
   });
@@ -155,9 +222,9 @@ describe('retryable', function() {
     }
     var apiCall = apiCallable.createApiCall(func, settings);
     apiCall(null, function(err, resp) {
-      assert.equal(resp, 1729);
-      assert.equal(toAttempt, 0);
-      assert(deadlineArg);
+      expect(resp).to.eq(1729);
+      expect(toAttempt).to.eq(0);
+      expect(deadlineArg).to.be.ok;
       done();
     }, null, {});
   });
@@ -169,10 +236,10 @@ describe('retryable', function() {
     var spy = sinon.spy(fail);
     var apiCall = apiCallable.createApiCall(spy, settings);
     apiCall(null, function(err, resp) {
-      assert(err);
-      assert(err.cause);
-      assert.equal(err.cause.code, FAKE_STATUS_CODE_1);
-      assert.equal(spy.callCount, 1);
+      expect(err).to.be.ok;
+      expect(err.cause).to.be.an('error');
+      expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
+      expect(spy.callCount).to.eq(1);
       done();
     }, null, {});
   });
@@ -180,9 +247,9 @@ describe('retryable', function() {
   it('aborts retries', function(done) {
     var apiCall = apiCallable.createApiCall(fail, settings);
     apiCall(null, function(err, resp) {
-      assert(err);
-      assert(err.cause);
-      assert.equal(err.cause.code, FAKE_STATUS_CODE_1);
+      expect(err).to.be.ok;
+      expect(err).to.be.an('error');
+      expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
       done();
     }, null, {});
   });
@@ -192,10 +259,10 @@ describe('retryable', function() {
     var spy = sinon.spy(fail);
     var apiCall = apiCallable.createApiCall(spy, settings);
     apiCall(null, function(err, resp) {
-      assert(err);
-      assert(err.cause);
-      assert.equal(err.cause.code, FAKE_STATUS_CODE_1);
-      assert.equal(spy.callCount, toAttempt);
+      expect(err).to.be.ok;
+      expect(err.cause).to.be.an('error');
+      expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
+      expect(spy.callCount).to.eq(toAttempt);
       done();
     }, null, {});
   });
@@ -209,10 +276,10 @@ describe('retryable', function() {
     var spy = sinon.spy(func);
     var apiCall = apiCallable.createApiCall(spy, settings);
     apiCall(null, function(err, resp) {
-      assert(err);
-      assert(err.cause);
-      assert.equal(err.cause.code, FAKE_STATUS_CODE_2);
-      assert.equal(spy.callCount, 1);
+      expect(err).to.be.ok;
+      expect(err.cause).to.be.an('error');
+      expect(err.cause.code).to.eq(FAKE_STATUS_CODE_2);
+      expect(spy.callCount).to.eq(1);
       done();
     }, null, {});
   });
@@ -223,8 +290,8 @@ describe('retryable', function() {
     }
     var apiCall = apiCallable.createApiCall(func, settings);
     apiCall(null, function(err, resp) {
-      assert(!err);
-      assert.equal(resp, null);
+      expect(err).to.be.null;
+      expect(resp).to.be.null;
       done();
     }, null, {});
   });
@@ -239,18 +306,18 @@ describe('retryable', function() {
         spy, new gax.CallSettings({timeout: 0, retry: retryOptions}));
 
     apiCall(null, function(err, resp) {
-      assert(err);
-      assert(err.cause);
-      assert.equal(err.cause.code, FAKE_STATUS_CODE_1);
+      expect(err).to.be.ok;
+      expect(err.cause).to.be.an('error');
+      expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
       var now = new Date();
-      assert.isAtLeast(now.getTime() - startTime.getTime(),
-                       backoff.totalTimeoutMillis);
+      expect(now.getTime() - startTime.getTime()).to.be.at.least(
+          backoff.totalTimeoutMillis);
       var callsLowerBound = backoff.totalTimeoutMillis / (
           backoff.maxRetryDelayMillis + backoff.maxRpcTimeoutMillis);
       var callsUpperBound = (backoff.totalTimeoutMillis /
           backoff.initialRetryDelayMillis);
-      assert.isAbove(spy.callCount, callsLowerBound);
-      assert.isBelow(spy.callCount, callsUpperBound);
+      expect(spy.callCount).to.be.above(callsLowerBound);
+      expect(spy.callCount).to.be.below(callsUpperBound);
       done();
     }, null, {});
   });


### PR DESCRIPTION
Similar style as Python is doing. As the consequence of this --
and the existing behavior probably confuses users -- page-streaming
methods always return a stream, and the callback is simply ignored.

The callback argument is kept for the compatibility.

Also noticed that test/api_callable.js is using assertion while
other tests are BDD style, fixed the style as well.