### PR TITLE
Add jsdoc generation rules

### DIFF
--- a/jsdoc.conf
+++ b/jsdoc.conf
@@ -1,0 +1,3 @@
+{
+    "plugins": ["plugins/markdown"]
+}

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -41,14 +41,30 @@ var through2 = require('through2');
 var setTimeout = require('timers').setTimeout;
 
 /**
+ * @callback APICallback
+ * @param {?Error} error
+ * @param {?Object} response
+ */
+
+/**
+ * @callback APIFunc
+ * @param {Object} argument
+ * @param {APICallback} callback
+ * @param {grpc.Metadata} metadata
+ * @param {Object} options
+ */
+
+/**
  * Updates aFunc so that it gets called with the timeout as its final arg.
  *
  * This converts a function, aFunc, into another function with updated deadline.
  *
- * @param {function()} aFunc - a function to be updated
+ * @private
+ *
+ * @param {APIFunc} aFunc - a function to be updated
  * @param {number} timeout - to be added to the original function as it final
  *   positional arg.
- * @returns {function()} the original function updated to the timeout arg
+ * @returns {APIFunc} the original function updated to the timeout arg
  */
 function addTimeoutArg(aFunc, timeout) {
   return function timeoutFunc(argument, callback, metadata, options) {
@@ -62,11 +78,13 @@ function addTimeoutArg(aFunc, timeout) {
  * Creates a function equivalent to aFunc, but that retries on certain
  * exceptions.
  *
- * @param {function()} aFunc - A function.
+ * @private
+ *
+ * @param {APIFunc} aFunc - A function.
  * @param {RetryOptions} retry - Configures the exceptions upon which the
  *   function eshould retry, and the parameters to the exponential backoff retry
  *   algorithm.
- * @returns {function()} A function that will retry on exception.
+ * @returns {APIFunc} A function that will retry on exception.
  */
 function retryable(aFunc, retry) {
   var delayMult = retry.backoffSettings.retryDelayMultiplier;
@@ -120,18 +138,21 @@ function retryable(aFunc, retry) {
 
 /**
  * Creates a function that returns a stream to performs page-streaming.
- * @param {function()} aFunc - an API call that is page streaming.
+ *
+ * @private
+ *
+ * @param {APIFunc} aFunc - an API call that is page streaming.
  * @param {gax.PageDescriptor} pageDescriptor - indicates the structure
  *   of page streaming to be performed.
  * @param {Object} pageToken - If set and page streaming is over pages of
  *   the response, indicates the page_token to be passed to the API call.
  * @param {boolean} flattenPages - If true, the returned iterable is over
- *   ``resourceField``; otherwise the returned iterable is over the pages
- *   of the response, each of which is an iterable over ``resourceField``.
- * @returns {function()} A function for the page streaming. By default, it
- *   returns a stream over the specified field, but if callback function
- *   is specified at the end, it invokes the callback function with the response
- *   object and returns null.
+ *   `resourceField`; otherwise the returned iterable is over the pages
+ *   of the response, each of which is an iterable over `resourceField`.
+ * @returns {APIFunc} A function for the page streaming. By default, it returns
+ *   a stream over the specified field, but if callback function  is specified
+ *   at the end, it invokes the callback function with the response object and
+ *   returns null.
  */
 function pageStreamable(aFunc,
                         pageDescriptor,
@@ -189,22 +210,22 @@ function pageStreamable(aFunc,
 /**
  * Converts an rpc call into an API call governed by the settings.
  *
- * In typical usage, ``func`` will be a callable used to make an rpc request.
+ * In typical usage, `func` will be a callable used to make an rpc request.
  * This will mostly likely be a bound method from a request stub used to make
  * an rpc call.
  *
  * The result is created by applying a series of function decorators defined
- * in this module to ``func``.  ``settings`` is used to determine which
- * function decorators to apply.
+ * in this module to `func`.  `settings` is used to determine which function
+ * decorators to apply.
  *
- * The result is another callable which for most values of ``settings`` has
- * has the same signature as the original. Only when ``settings`` configures
+ * The result is another callable which for most values of `settings` has
+ * has the same signature as the original. Only when `settings` configures
  * bundling does the signature change.
- * @param {function()} func - is used to make a bare rpc call
+ * @param {APIFunc} func - is used to make a bare rpc call
  * @param {CallSettings} settings - provides the settings for this call
- * @returns {function()} func - a bound method on a request stub used
+ * @returns {APIFunc} func - a bound method on a request stub used
  *   to make an rpc call
- * @throws - if ``settings`` has incompatible values, e.g, if bundling
+ * @throws - if `settings` has incompatible values, e.g, if bundling
  *   and page_streaming are both configured
  */
 exports.createApiCall = function createApiCall(func, settings) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -33,13 +33,27 @@
 'use strict';
 
 /**
+ * @callback GetCredentialsFunc
+ *
+ * To authorize requests through gRPC, we must get the raw google-auth-library
+ * auth client object.
+ *
+ * @param {function()} callback - The callback function.
+ * @param {Object} opts - options values for configuring auth
+ * @param {(String|String[])} opts.scopes - the scope or scopes to use when
+ *   obtaining the credentials.
+ * @param {Object} opts.sslCreds - when specified, this is used instead
+ *   of default credentials.
+ */
+
+/**
  * Creates a promise which resolves a auth credential.
  *
- * @param {function()} getCredentials - the callback used to
+ * @param {GetCredentialsFunc} getCredentials - the callback used to
  *   obtain the credentials.
  * @param {Object} opts - the optional arguments to be passed to
  *   getCredentials.
- * @returns A promise which resolves to the credential.
+ * @returns {Promise} A promise which resolves to the credential.
  */
 exports.createCredPromise = function createCredPromise(
     getCredentials, opts) {

--- a/lib/gax.js
+++ b/lib/gax.js
@@ -180,6 +180,10 @@ exports.CallOptions = CallOptions;
 /**
  * Describes the structure of a page-streaming call.
  *
+ * @property {String} requestPageTokenField
+ * @property {String} responsePageTokenField
+ * @property {String} resourceField
+ *
  * @constructor
  */
 function PageDescriptor(requestPageTokenField,
@@ -421,44 +425,44 @@ function mergeRetryOptions(retry, overrides) {
  * The `clientConfig` parameter is parsed from a client configuration JSON
  * file of the form:
  *
- *   {
- *     "interfaces": {
- *       "google.fake.v1.ServiceName": {
- *         "retry_codes": {
- *           "idempotent": ["UNAVAILABLE", "DEADLINE_EXCEEDED"],
- *           "non_idempotent": []
- *         },
- *         "retry_params": {
- *           "default": {
- *             "initial_retry_delay_millis": 100,
- *             "retry_delay_multiplier": 1.2,
- *             "max_retry_delay_millis": 1000,
- *             "initial_rpc_timeout_millis": 2000,
- *             "rpc_timeout_multiplier": 1.5,
- *             "max_rpc_timeout_millis": 30000,
- *             "total_timeout_millis": 45000
- *           }
- *         },
- *         "methods": {
- *           "CreateFoo": {
- *             "retry_codes_name": "idempotent",
- *             "retry_params_name": "default"
+ *     {
+ *       "interfaces": {
+ *         "google.fake.v1.ServiceName": {
+ *           "retry_codes": {
+ *             "idempotent": ["UNAVAILABLE", "DEADLINE_EXCEEDED"],
+ *             "non_idempotent": []
  *           },
- *           "Publish": {
- *             "retry_codes_name": "non_idempotent",
- *             "retry_params_name": "default",
- *             "bundling": {
- *               "element_count_threshold": 40,
- *               "element_count_limit": 200,
- *               "request_byte_threshold": 90000,
- *               "request_byte_limit": 100000,
- *               "delay_threshold_millis": 100
+ *           "retry_params": {
+ *             "default": {
+ *               "initial_retry_delay_millis": 100,
+ *               "retry_delay_multiplier": 1.2,
+ *               "max_retry_delay_millis": 1000,
+ *               "initial_rpc_timeout_millis": 2000,
+ *               "rpc_timeout_multiplier": 1.5,
+ *               "max_rpc_timeout_millis": 30000,
+ *               "total_timeout_millis": 45000
+ *             }
+ *           },
+ *           "methods": {
+ *             "CreateFoo": {
+ *               "retry_codes_name": "idempotent",
+ *               "retry_params_name": "default"
+ *             },
+ *             "Publish": {
+ *               "retry_codes_name": "non_idempotent",
+ *               "retry_params_name": "default",
+ *               "bundling": {
+ *                 "element_count_threshold": 40,
+ *                 "element_count_limit": 200,
+ *                 "request_byte_threshold": 90000,
+ *                 "request_byte_limit": 100000,
+ *                 "delay_threshold_millis": 100
+ *               }
  *             }
  *           }
  *         }
  *       }
  *     }
- *   }
  *
  * @param {String} serviceName - The fully-qualified name of this
  *   service, used as a key into the client config file (in the

--- a/lib/gax.js
+++ b/lib/gax.js
@@ -69,6 +69,8 @@ var FIRST_PAGE = exports.FIRST_PAGE = {};
  *   the page streaming request.
  * @param {Object} settings.bundler - orchestrates bundling. If null, bundling
  *   is not performed.
+ *
+ * @constructor
  */
 function CallSettings(settings) {
   settings = settings || {};
@@ -153,6 +155,8 @@ CallSettings.prototype.merge = function merge(options) {
  *   pageToken. Use {@link FIRST_PAGE} for the first request.  If unset and
  *   the call is configured for page streaming, page streaming is performed
  *   per-resource.
+ *
+ * @constructor
  */
 function CallOptions(options) {
   if ('timeout' in options) {
@@ -175,6 +179,8 @@ exports.CallOptions = CallOptions;
 
 /**
  * Describes the structure of a page-streaming call.
+ *
+ * @constructor
  */
 function PageDescriptor(requestPageTokenField,
                         responsePageTokenField,
@@ -187,10 +193,13 @@ exports.PageDescriptor = PageDescriptor;
 
 /**
  * Per-call configurable settings for retrying upon transient failure.
- * @property {string[]} retryCodes - a list of Google API canonical error codes
+ *
+ * @property {String[]} retryCodes - a list of Google API canonical error codes
  *   upon which a retry should be attempted.
  * @property {BackoffSettings} backoffSettings - configures the retry
  *   exponential backoff algorithm.
+ *
+ * @constructor
  */
 function RetryOptions(retryCodes, backoffSettings) {
   this.retryCodes = retryCodes;
@@ -200,6 +209,7 @@ exports.RetryOptions = RetryOptions;
 
 /**
  * Parameters to the exponential backoff algorithm for retrying.
+ *
  * @property {number} initialRetryDelayMillis - the initial delay time,
  *   in milliseconds, between the completion of the first failed request and the
  *   initiation of the first retrying request.
@@ -219,6 +229,8 @@ exports.RetryOptions = RetryOptions;
  * @property {number} totalTimeoutMillis - the total time, in milliseconds,
  *   starting from when the initial request is sent, after which an error will
  *   be returned, regardless of the retrying attempts made meanwhile.
+ *
+ * @constructor
  */
 function BackoffSettings(initialRetryDelayMillis,
                          retryDelayMultiplier,
@@ -242,6 +254,7 @@ exports.BackoffSettings = BackoffSettings;
  *
  * The xxxThreshold attributes are used to configure when the bundled request
  * should be made. All properties default to 0.
+ *
  * @param {Object} options - An object to hold optional parameters. See
  *   properties for the content of options.
  * @property {number} elementCountThreshold - the bundled request will be sent
@@ -266,6 +279,8 @@ exports.BackoffSettings = BackoffSettings;
  *   the resulting under-approximation.
  * @property {number} delayThreshold - the bundled request will be sent this
  *   amount of time after the first element in the bundle was added to it.
+ *
+ * @constructor
  */
 function BundleOptions(options) {
   var elementCountThreshold = options.elementCountThreshold || 0;
@@ -292,9 +307,15 @@ exports.BundleOptions = BundleOptions;
 /**
  * Helper for {@link constructSettings}
  *
- * @param {Object} bundleConfig - An object specifying a bundle parameters,
- *   the value for 'bundling' field in a method config (See
- *   {@link constructSettings} for information on this config.)
+ * @private
+ *
+ * @param {Object} methodConfig - A dictionary representing a single
+ *   `methods` entry of the standard API client config file. (See
+ *   {@link constructSettings} for information on this yaml.)
+ * @param {BundleOptions|OPTION_INHERIT} methodRetryOverride -
+ *   If set to {@link OPTION_INHERIT}, the retry settings are derived from
+ *   method config. Otherwise, this parameter overrides
+ *   methodConfig.
  * @returns An Executor that configures bundling, or null if this
  *   method should not bundle.
  */
@@ -317,14 +338,16 @@ function constructBundling(bundleConfig) {
 /**
  * Helper for {@link constructSettings}
  *
+ * @private
+ *
  * @param {Object} methodConfig - A dictionary representing a single
- *   ``methods`` entry of the standard API client config file. (See
+ *   `methods` entry of the standard API client config file. (See
  *   {@link constructSettings} for information on this yaml.)
  * @param {?Object} retryCodes - A dictionary parsed from the
- *   ``retry_codes_def`` entry of the standard API client config
+ *   `retry_codes_def` entry of the standard API client config
  *   file. (See {@link constructSettings} for information on this yaml.)
  * @param {Object} retryParams - A dictionary parsed from the
- *   ``retry_params`` entry of the standard API client config
+ *   `retry_params` entry of the standard API client config
  *   file. (See {@link constructSettings} for information on this yaml.)
  * @param {Object} retryNames - A dictionary mapping the string names
  *   used in the standard API client config file to API response
@@ -360,13 +383,15 @@ function constructRetry(methodConfig, retryCodes, retryParams, retryNames) {
 }
 
 /**
- * Helper for `{@link constructSettings}
+ * Helper for {@link constructSettings}
  *
  * Takes two retry options, and merges them into a single RetryOption instance.
  *
+ * @private
+ *
  * @param {RetryOptions} retry - The base RetryOptions.
  * @param {RetryOptions} overrides - The RetryOptions used for overriding
- *   +retry+. Use the values if it is not null. If entire ``overrides`` is null,
+ *   `retry`. Use the values if it is not null. If entire `overrides` is null,
  *   ignore the base retry and return null.
  * @returns {?RetryOptions} The merged RetryOptions.
  */

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -39,18 +39,23 @@ var AuthFactory = new GoogleAuth();
 var createCredPromise = require('./auth').createCredPromise;
 
 /**
+ * @callback CredentialsCallback
+ * @param {?Error} err - An error if authentication failed.
+ * @param {?grpc.ChannelCredentials} creds - A gRPC credentials if succeeded.
+ */
+
+/**
  * To authorize requests through gRPC, we must get the raw google-auth-library
  * auth client object.
  *
  * @private
  *
- * @param {function} callback - The callback function.
- * @param {object} opts - options values for configuring auth
- * @param {string|[]string} opts.scopes - the scope or scopes to use when
+ * @param {CredentialsCallback} callback - The callback function.
+ * @param {Object} opts - options values for configuring auth
+ * @param {(String|String[])} opts.scopes - the scope or scopes to use when
  *   obtaining the credentials.
- * @param {object} opts.sslCreds - when specified, this is used instead
+ * @param {Object} opts.sslCreds - when specified, this is used instead
  *   of default credentials.
- * @param {?error} callback.err - An error getting an auth client.
  */
 function getCredentials(callback, opts) {
   AuthFactory.getApplicationDefault(function(err, auth) {
@@ -77,15 +82,15 @@ function getCredentials(callback, opts) {
 /**
  * Creates a promise which resolves to an rpc stub.
  *
- * @param {string} servicePath - The domain name of the API remote host.
- * @param {integer} port - The port on which to connect to the remote host.
+ * @param {String} servicePath - The domain name of the API remote host.
+ * @param {Number} port - The port on which to connect to the remote host.
  * @param {function} createStub - The constructor used to create a grpc stub
  *   instance.
- * @param {object} options - optional settings for configuring
- * @param {function(callback, opts)} options.getCredentials - the callback used
- *   to obtain the credentials
- * @param {string|string[]} option.scopes - the scope or scopes to use when
- *   obtaining the credentials used by the stub.
+ * @param {Object} options - optional settings. This options will be passed
+ *   to `getCredentials`.
+ * @param {GetCredentialsFunc} options.getCredentials - the callback used
+ *   to obtain the credentials. If not specified, use the default
+ *   implementation.
  * @returns {Promise} A promise which resolves to an rpc stub.
  */
 exports.createStub = function createStub(

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -84,7 +84,7 @@ function getCredentials(callback, opts) {
  *
  * @param {String} servicePath - The domain name of the API remote host.
  * @param {Number} port - The port on which to connect to the remote host.
- * @param {function} createStub - The constructor used to create a grpc stub
+ * @param {function()} createStub - The constructor used to create a grpc stub
  *   instance.
  * @param {Object} options - optional settings. This options will be passed
  *   to `getCredentials`.

--- a/lib/parser_extras.js
+++ b/lib/parser_extras.js
@@ -96,6 +96,8 @@ function updateBindingLiterals(segments) {
  * Validates them, and transforms them into the object used by the
  * PathTemplate class.
  *
+ * @private
+ *
  * @param {Segments[]} segments the parsed segments
  * @param {Object} initializes the attributes of a PathTemplate
  * @throws {TypeError} if multiple path wildcards exist

--- a/lib/parser_extras.js
+++ b/lib/parser_extras.js
@@ -38,6 +38,8 @@ var _ = require('lodash');
 /**
  * Checks that segments only has one terminal segment that is a path wildcard.
  *
+ * @private
+ *
  * @param {Segments[]} segments the parsed segments
  * @throws {TypeError} if there are too many
  */
@@ -59,6 +61,8 @@ function allowOnePathWildcard(segments) {
 /**
  * Counts the number of terminal segments.
  *
+ * @private
+ *
  * @param {Segments[]} segments the parsed segments
  * @return {number} the number of terminal segments in the template
  */
@@ -71,6 +75,8 @@ function countTerminals(segments) {
 
 /**
  * Updates missing literals of each of the binding segments.
+ *
+ * @private
  *
  * @param {Segments[]} segments the parsed segments
  */

--- a/lib/path_template.js
+++ b/lib/path_template.js
@@ -45,7 +45,7 @@ exports.PathTemplate = PathTemplate;
 
 
 /**
- * @param {string} data the of the template
+ * @param {String} data the of the template
  *
  * @constructor
  */
@@ -65,8 +65,8 @@ function PathTemplate(data) {
 /**
  * Matches a fully-qualified path template string.
  *
- * @param {string} path a fully-qualified path template string
- * @returns {object} contains var names matched to binding values
+ * @param {String} path a fully-qualified path template string
+ * @returns {Object} contains var names matched to binding values
  * @throws {TypeError} if path can't be matched to this template
  */
 PathTemplate.prototype.match = function match(path) {
@@ -112,9 +112,9 @@ PathTemplate.prototype.match = function match(path) {
 
 /**
  * Renders a path template using the provided bindings.
- * @param {object} bindings a mapping of var names to binding strings
  *
- * @returns {string} a rendered representation of the path template
+ * @param {Object} bindings a mapping of var names to binding strings
+ * @returns {String} a rendered representation of the path template
  * @throws {TypeError} if a key is missing, or if a sub-template cannot be
  *   parsed
  */

--- a/lib/path_template.js
+++ b/lib/path_template.js
@@ -33,7 +33,7 @@
 'use strict';
 
 
-/**
+/*
  * Path template utility.
  */
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chai": "*",
     "codecov": "~1.0",
     "istanbul": "~0.3.15",
+    "jsdoc": "~3.4.0",
     "jshint": "~2.5",
     "mocha": "~2.2.5",
     "pegjs": "~0.9.0",
@@ -20,6 +21,7 @@
   },
   "scripts": {
     "codecov": "istanbul cover _mocha -- --reporter spec --slow 500 --timeout 5000 && codecov",
+    "doc": "jsdoc lib package.json README.md -c ./jsdoc.conf -d doc",
     "lint": "jshint lib test",
     "gen-parser": "pegjs lib/path_template_parser.pegjs",
     "test": "istanbul test _mocha -- --reporter spec --slow 500 --timeout 5000"


### PR DESCRIPTION
This adds jsdoc generation rules to package.json, and made a few fixes on comment styles.

Also attached the result of the doc htmls.