### PR TITLE
Refactor createApiCall

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -59,6 +59,7 @@ var setTimeout = require('timers').setTimeout;
  * @param {Object} argument
  * @param {CallOptions} callOptions
  * @param {APICallback} callback
+ * @returns {Object}
  */
 
 /**
@@ -149,107 +150,133 @@ function retryable(aFunc, retry, otherArgs) {
 }
 
 /**
- * Creates a function that returns a stream to performs page-streaming.
+ * Creates an API caller for normal methods.
+ *
+ * @private
+ *
+ * @returns {Object} a caller to handle individual APIs.
+ */
+function normalApiCall() {
+  return {
+    init: function(callback) {
+      return callback;
+    },
+    call: function(apiCall, argument, settings, callback) {
+      apiCall(argument, callback);
+    }
+  };
+};
+
+/**
+ * Creates an API caller that returns a stream to performs page-streaming.
  *
  * @private
  *
  * @param {gax.PageDescriptor} pageDescriptor - indicates the structure
  *   of page streaming to be performed.
- * @returns {function()} A function for the page streaming. It takes the actual
- *   API call and returns a stream.
+ * @returns {Object} A caller which creates a stream and handles the streaming.
  */
 function pageStreamable(pageDescriptor) {
-  return function pageStreaming(apiCall, argument, settings, callback) {
-    if (callback) {
-      console.warn('callback is specified, but callbacks are ignored for ' +
-                   'page streaming API calls.');
-    }
+  return {
+    init: function(callback) {
+      if (callback) {
+        console.warn('callback is specified, but cllbacks are ignored for ' +
+                     'page streaming API calls.');
+      }
+      return through2.obj();
+    },
+    call: function pageStreaming(apiCall, argument, settings, stream) {
+      if (!settings.flattenPages && settings.pageToken != gax.FIRST_PAGE) {
+        argument[pageDescriptor.requestPageTokenField] = settings.pageToken;
+      }
 
-    var stream = through2.obj();
-    if (!settings.flattenPages && settings.pageToken != gax.FIRST_PAGE) {
-      argument[pageDescriptor.requestPageTokenField] = settings.pageToken;
-    }
-
-    function streaming() {
-      apiCall(argument, function(err, response) {
-        if (err) {
-          stream.emit('error', err);
-          stream.end();
-          return;
-        }
-        if (!stream.writable) {
-          return;
-        }
-        if (settings.flattenPages) {
-          var resources = response[pageDescriptor.resourceField];
-          for (var i in resources) {
-            if (!stream.writable) {
-              break;
-            }
-            stream.write(resources[i]);
+      function streaming() {
+        apiCall(argument, function(err, response) {
+          if (err) {
+            stream.emit('error', err);
+            stream.end();
+            return;
           }
-        } else {
-          stream.write(response);
-        }
-        if (!stream.writable) {
-          return;
-        }
-        var nextPageToken = response[pageDescriptor.responsePageTokenField];
-        if (!nextPageToken) {
-          stream.end();
-          return;
-        }
-        argument[pageDescriptor.requestPageTokenField] = nextPageToken;
-        setTimeout(streaming, 0);
-      });
+          if (!stream.writable) {
+            return;
+          }
+          if (settings.flattenPages) {
+            var resources = response[pageDescriptor.resourceField];
+            for (var i in resources) {
+              if (!stream.writable) {
+                break;
+              }
+              stream.write(resources[i]);
+            }
+          } else {
+            stream.write(response);
+          }
+          if (!stream.writable) {
+            return;
+          }
+          var nextPageToken = response[pageDescriptor.responsePageTokenField];
+          if (!nextPageToken) {
+            stream.end();
+            return;
+          }
+          argument[pageDescriptor.requestPageTokenField] = nextPageToken;
+          setTimeout(streaming, 0);
+        });
+      }
+      setTimeout(streaming, 0);
     }
-    setTimeout(streaming, 0);
-    return stream;
   };
 }
 
 /**
  * Converts an rpc call into an API call governed by the settings.
  *
- * In typical usage, `func` will be a callable used to make an rpc request.
- * This will mostly likely be a bound method from a request stub used to make
- * an rpc call.
+ * In typical usage, `func` will be a promsie to a callable used to make an rpc
+ * request. This will mostly likely be a bound method from a request stub used
+ * to make an rpc call. It is not a direct function but a Promise instance,
+ * because of its asynchronism (typically, obtaining the auth information).
  *
- * The result is created by applying a series of function decorators defined
- * in this module to `func`.  `settings` is used to determine which function
- * decorators to apply.
+ * The result is a function which manages the API call with the given settings
+ * and the options on the invocation.
  *
- * The result is another callable which for most values of `settings` has
- * has the same signature as the original. Only when `settings` configures
- * bundling does the signature change.
- * @param {APIFunc} func - is used to make a bare rpc call
+ * @param {Promise.<APIFunc>} func - is a promise to be used to make a bare rpc
+ *   call.
  * @param {CallSettings} settings - provides the settings for this call
  * @returns {APICall} func - a bound method on a request stub used
- *   to make an rpc call
+ *   to make an rpc call.
  * @throws - if `settings` has incompatible values, e.g, if bundling
- *   and page_streaming are both configured
+ *   and page_streaming are both configured.
  */
 exports.createApiCall = function createApiCall(func, settings) {
-  var apiCaller = function(apiCall, request, thisSettings, callback) {
-    return apiCall(request, callback);
-  };
+  var apiCaller;
   if (settings.pageDescriptor) {
     assert(!settings.bundler, 'The API call has incompatible settings: ' +
         'bundling and page streaming');
     apiCaller = pageStreamable(settings.pageDescriptor);
+  } else {
+    apiCaller = normalApiCall();
   }
   // TODO: support bundling
 
-  function apiCallInner(request, callback, callOptions) {
+  return function apiCallInner(request, callOptions, callback) {
     var thisSettings = settings.merge(callOptions);
-    var apiCall;
-    if (thisSettings.retry && thisSettings.retry.retryCodes) {
-      apiCall = retryable(func, thisSettings.retry, thisSettings.otherArgs);
-    } else {
-      apiCall = addTimeoutArg(
-          func, thisSettings.timeout, thisSettings.otherArgs);
-    }
-    return apiCaller(apiCall, request, thisSettings, callback);
-  }
-  return apiCallInner;
+    var result = apiCaller.init(callback);
+    func.then(function(func) {
+      if (thisSettings.retry && thisSettings.retry.retryCodes) {
+        return retryable(func, thisSettings.retry, thisSettings.otherArgs);
+      } else {
+        return addTimeoutArg(
+            func, thisSettings.timeout, thisSettings.otherArgs);
+      }
+    }).then(function (apiCall) {
+      apiCaller.call(apiCall, request, thisSettings, result);
+    })['catch'](function(err) {
+      // TODO: emit errors to result when normal API call returns event
+      // emitter.
+      if (callback) {
+        callback(err);
+      }
+    });
+    return result;
+  };
 };

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -180,7 +180,7 @@ function pageStreamable(pageDescriptor) {
   return {
     init: function(callback) {
       if (callback) {
-        console.warn('callback is specified, but cllbacks are ignored for ' +
+        console.warn('callback is specified, but callbacks are ignored for ' +
                      'page streaming API calls.');
       }
       return through2.obj();

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -165,7 +165,7 @@ function normalApiCall() {
       apiCall(argument, callback);
     }
   };
-};
+}
 
 /**
  * Creates an API caller that returns a stream to performs page-streaming.

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -239,15 +239,16 @@ function pageStreamable(pageDescriptor) {
  * The result is a function which manages the API call with the given settings
  * and the options on the invocation.
  *
- * @param {Promise.<APIFunc>} func - is a promise to be used to make a bare rpc
- *   call.
+ * @param {Promise.<APIFunc>} funcWithAuth - is a promise to be used to make
+ *   a bare rpc call. This is a Promise instead of a bare function because
+ *   the rpc call will be involeved with asynchronous authentications.
  * @param {CallSettings} settings - provides the settings for this call
  * @returns {APICall} func - a bound method on a request stub used
  *   to make an rpc call.
  * @throws - if `settings` has incompatible values, e.g, if bundling
  *   and page_streaming are both configured.
  */
-exports.createApiCall = function createApiCall(func, settings) {
+exports.createApiCall = function createApiCall(funcWithAuth, settings) {
   var apiCaller;
   if (settings.pageDescriptor) {
     assert(!settings.bundler, 'The API call has incompatible settings: ' +
@@ -261,7 +262,7 @@ exports.createApiCall = function createApiCall(func, settings) {
   return function apiCallInner(request, callOptions, callback) {
     var thisSettings = settings.merge(callOptions);
     var result = apiCaller.init(callback);
-    func.then(function(func) {
+    funcWithAuth.then(function(func) {
       if (thisSettings.retry && thisSettings.retry.retryCodes) {
         return retryable(func, thisSettings.retry, thisSettings.otherArgs);
       } else {

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -46,16 +46,20 @@ function fail(argument, metadata, options, callback) {
   callback(error);
 }
 
+function createApiCall(func, settings) {
+  return apiCallable.createApiCall(Promise.resolve(func), settings);
+};
+
 describe('createApiCall', function() {
   it('calls api call', function(done) {
     var settings = new gax.CallSettings();
     var deadlineArg;
     function func(argument, metadata, options, callback) {
       deadlineArg = options.deadline;
-      callback(null, 42);
+      callback(null, argument);
     }
-    var apiCall = apiCallable.createApiCall(func, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(func, settings);
+    apiCall(42, null, function(err, resp) {
       expect(resp).to.eq(42);
       expect(deadlineArg).to.be.ok;
       done();
@@ -67,15 +71,15 @@ describe('createApiCall', function() {
     function func(argument, metadata, options, callback) {
       callback(null, options.deadline.getTime());
     }
-    var apiCall = apiCallable.createApiCall(func, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(func, settings);
+    apiCall(null, new gax.CallOptions({'timeout': 200}), function(err, resp) {
       var now = new Date();
       var originalDeadline = now.getTime() + 100;
       var expectedDeadline = now.getTime() + 200;
       expect(resp).above(originalDeadline);
       expect(resp).most(expectedDeadline);
       done();
-    }, new gax.CallOptions({'timeout': 200}));
+    });
   });
 });
 
@@ -105,7 +109,7 @@ describe('page streaming', function() {
   }
 
   it('returns page-streamable', function(done) {
-    var apiCall = apiCallable.createApiCall(func, settings);
+    var apiCall = createApiCall(func, settings);
     var counter = 0;
     apiCall({}, null)
       .on('data', function(data) {
@@ -120,7 +124,7 @@ describe('page streaming', function() {
   });
 
   it('stops if in the middle', function(done) {
-    var apiCall = apiCallable.createApiCall(func, settings);
+    var apiCall = createApiCall(func, settings);
     var counter = 0;
     var stream = apiCall({}, null);
     stream.on('data', function(data) {
@@ -139,7 +143,7 @@ describe('page streaming', function() {
   it('iterate over pages', function(done) {
     var mySettings = settings.merge(
         new gax.CallOptions({pageToken: gax.FIRST_PAGE}));
-    var apiCall = apiCallable.createApiCall(func, mySettings);
+    var apiCall = createApiCall(func, mySettings);
     var counter = 0;
     apiCall({}, null)
       .on('data', function(data) {
@@ -164,7 +168,7 @@ describe('page streaming', function() {
       return new Promise(function(resolve, reject) {
         var mySettings = settings.merge(
             new gax.CallOptions({pageToken: pageToken}));
-        var apiCall = apiCallable.createApiCall(func, mySettings);
+        var apiCall = createApiCall(func, mySettings);
         var stream = apiCall({}, null);
         stream.on('data', function(resp) {
           stream.end();
@@ -204,7 +208,7 @@ describe('page streaming', function() {
         func(request, metadata, options, callback);
       }
     }
-    var apiCall = apiCallable.createApiCall(failingFunc, settings);
+    var apiCall = createApiCall(failingFunc, settings);
     var dataCount = 0;
     apiCall({}, null)
       .on('data', function(data) {
@@ -236,8 +240,8 @@ describe('retryable', function() {
       }
       callback(null, 1729);
     }
-    var apiCall = apiCallable.createApiCall(func, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(func, settings);
+    apiCall(null, null, function(err, resp) {
       expect(resp).to.eq(1729);
       expect(toAttempt).to.eq(0);
       expect(deadlineArg).to.be.ok;
@@ -250,8 +254,8 @@ describe('retryable', function() {
         [], new gax.BackoffSettings(1, 2, 3, 4, 5, 6, 7));
     var settings = new gax.CallSettings({timeout: 0, retry: retryOptions});
     var spy = sinon.spy(fail);
-    var apiCall = apiCallable.createApiCall(spy, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(spy, settings);
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.ok;
       expect(err.cause).to.be.an('error');
       expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
@@ -261,8 +265,8 @@ describe('retryable', function() {
   });
 
   it('aborts retries', function(done) {
-    var apiCall = apiCallable.createApiCall(fail, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(fail, settings);
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.ok;
       expect(err).to.be.an('error');
       expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
@@ -273,8 +277,8 @@ describe('retryable', function() {
   it.skip('times out', function(done) {
     var toAttempt = 3;
     var spy = sinon.spy(fail);
-    var apiCall = apiCallable.createApiCall(spy, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(spy, settings);
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.ok;
       expect(err.cause).to.be.an('error');
       expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);
@@ -290,8 +294,8 @@ describe('retryable', function() {
       callback(error);
     }
     var spy = sinon.spy(func);
-    var apiCall = apiCallable.createApiCall(spy, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(spy, settings);
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.ok;
       expect(err.cause).to.be.an('error');
       expect(err.cause.code).to.eq(FAKE_STATUS_CODE_2);
@@ -304,8 +308,8 @@ describe('retryable', function() {
     function func(argument, metadata, options, callback) {
       callback(null, null);
     }
-    var apiCall = apiCallable.createApiCall(func, settings);
-    apiCall(null, function(err, resp) {
+    var apiCall = createApiCall(func, settings);
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.null;
       expect(resp).to.be.null;
       done();
@@ -318,10 +322,10 @@ describe('retryable', function() {
 
     var backoff = new gax.BackoffSettings(3, 2, 24, 5, 2, 80, 2500);
     var retryOptions = new gax.RetryOptions([FAKE_STATUS_CODE_1], backoff);
-    var apiCall = apiCallable.createApiCall(
+    var apiCall = createApiCall(
         spy, new gax.CallSettings({timeout: 0, retry: retryOptions}));
 
-    apiCall(null, function(err, resp) {
+    apiCall(null, null, function(err, resp) {
       expect(err).to.be.ok;
       expect(err.cause).to.be.an('error');
       expect(err.cause.code).to.eq(FAKE_STATUS_CODE_1);

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -48,7 +48,7 @@ function fail(argument, metadata, options, callback) {
 
 function createApiCall(func, settings) {
   return apiCallable.createApiCall(Promise.resolve(func), settings);
-};
+}
 
 describe('createApiCall', function() {
   it('calls api call', function(done) {


### PR DESCRIPTION
Currently createApiCall assumes to receive a function and
a CallSettings instance, and then returns a function.

On the reality, however, the API function can't be a normal
function but a Promise to a function (due to the asynchronous-ness
of auth library) and therefore, it's hard to handle the return
value of the code upon usage.

With this refactoring, the generated code can simply invokes
createApiCall with a Promise stub, and it simplifies the return
values.

This is a preparation to #20, which requires a different type of
return value to non-page-streaming functions, and #22 which will
also return a value.

This also reduces the size of the generated code because the
pattern used in the API call can be simplified. See
https://github.com/jmuk/toolkit/commit/ec23b2508a9e32350c803fcdf003acb5a1847214
to see how it's simplified.