### PR TITLE
Introduce event emitter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,10 @@
 'use strict';
 
 var gax = require('./lib/gax');
+var apiCallable = require('./lib/api_callable');
 
-exports.createApiCall = require('./lib/api_callable').createApiCall;
+exports.createApiCall = apiCallable.createApiCall;
+exports.EventEmitter = apiCallable.EventEmitter;
 exports.createStub = require('./lib/grpc').createStub;
 exports.PathTemplate = require('./lib/path_template').PathTemplate;
 exports.CallSettings = gax.CallSettings;

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -107,7 +107,7 @@ function EventEmitter(callback) {
     }
     if (err) {
       if (this._state == EventEmitter.States.STARTED &&
-          this.listeners('error') > 0) {
+          this.listeners('error').length > 0) {
         this.emit('error', err);
       }
       if (this._state == EventEmitter.States.CANCEL_SCHEDULED) {

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -39,6 +39,7 @@ var assert = require('chai').assert;
 var gax = require('./gax');
 var through2 = require('through2');
 var setTimeout = require('timers').setTimeout;
+var eventemitter2 = require('eventemitter2');
 
 /**
  * @callback APICallback
@@ -59,8 +60,121 @@ var setTimeout = require('timers').setTimeout;
  * @param {Object} argument
  * @param {CallOptions} callOptions
  * @param {APICallback} callback
- * @returns {Object}
+ * @returns {EventEmitter|Stream}
  */
+
+/**
+ * EventEmitter is a custom version of event emitter for the API call.
+ *
+ * In addition to normal events, it has a method 'cancel' to stop the
+ * ongoing event.
+ *
+ * This relies on eventemitter2.EventEmitter2 rather than the builtin
+ * EventEmitter in Node.JS, considering the case this code might be used
+ * in other environment (like browser JS).
+ *
+ * @property {Promise} result - A promise resolves to the result value
+ *   of the API (or fails when API call fails or is canceled).
+ * @param {?APICallback} callback - the callback to be called when
+ *   the API call ends.
+ * @constructor
+ */
+function EventEmitter(callback) {
+  eventemitter2.EventEmitter2.call(this);
+
+  this._state = EventEmitter.States.STARTED;
+
+  var resultResolver;
+  var resultRejector;
+  this.result = new Promise(function(resolve, reject) {
+    resultResolver = resolve;
+    resultRejector = reject;
+  });
+
+  // onFailure will be called when the task is canceled or the API result
+  // has failed.
+  this._onFailure = function onFailure(err) {
+    resultRejector(err);
+    if (callback) {
+      callback(err);
+    }
+  };
+
+  this._callback = function emitResults(err, response) {
+    if (this._state == EventEmitter.States.FINISHED ||
+        this._state == EventEmitter.States.CANCELED) {
+      return;
+    }
+    if (err) {
+      if (this._state == EventEmitter.States.STARTED &&
+          this.listeners('error') > 0) {
+        this.emit('error', err);
+      }
+      if (this._state == EventEmitter.States.CANCEL_SCHEDULED) {
+        this._state = EventEmitter.States.CANCELED;
+      } else {
+        this._state = EventEmitter.States.FINISHED;
+      }
+      resultRejector(err);
+      if (callback) {
+        callback(err);
+      }
+    } else if (this._state == EventEmitter.States.STARTED) {
+      this._state = EventEmitter.States.FINISHED;
+      this.emit('data', response);
+      resultResolver(response);
+      if (callback) {
+        callback(null, response);
+      }
+    }
+  }.bind(this);
+}
+exports.EventEmitter = EventEmitter;
+
+EventEmitter.prototype = Object.create(
+    eventemitter2.EventEmitter2.prototype);
+EventEmitter.prototype.constructor = EventEmitter;
+
+/**
+ * The internal states for EventEmitter.
+ * @private
+ * @enum {number}
+ * @readonly
+ */
+EventEmitter.States = {
+  STARTED: 0,
+  FINISHED: 1,
+  CANCEL_SCHEDULED: 2,
+  CANCELED: 3
+};
+
+/**
+ * Specifies the underlying event handler for the actual API call controls.
+ * @private
+ */
+EventEmitter.prototype._setEventHandler = function setEventHandler(handler) {
+  this._eventHandler = handler;
+  if (this._eventHandler &&
+      this._state == EventEmitter.States.CANCEL_SCHEDULED) {
+    this.cancel();
+  }
+};
+
+/**
+ * Cancels the ongoing API call.
+ */
+EventEmitter.prototype.cancel = function cancel() {
+  if (this._state == EventEmitter.States.CANCELED ||
+      this._state == EventEmitter.States.FINISHED) {
+    return;
+  }
+  this._state = EventEmitter.States.CANCEL_SCHEDULED;
+  if (this._eventHandler) {
+    this._eventHandler.cancel();
+    this._callback(new Error('canceled'));
+  }
+};
+
 
 /**
  * Updates aFunc so that it gets called with the timeout as its final arg.
@@ -82,7 +196,7 @@ function addTimeoutArg(aFunc, timeout, otherArgs) {
     var now = new Date();
     var options = otherArgs.options || {};
     options.deadline = new Date(now.getTime() + timeout);
-    aFunc(argument, otherArgs.metadata, options, callback);
+    return aFunc(argument, otherArgs.metadata, options, callback);
   };
 }
 
@@ -118,34 +232,46 @@ function retryable(aFunc, retry, otherArgs) {
    * by the options in ``retry``.
    */
   return function retryingFunc(argument, callback) {
-    if (now.getTime() >= deadline) {
-      callback(error);
-      return;
-    }
-    var toCall = addTimeoutArg(aFunc, timeout, otherArgs);
-    toCall(argument, function(err, response) {
-      if (!err) {
-        callback(null, response);
+    var eventEmitter = new EventEmitter();
+
+    function repeat(err, response) {
+      // Canceled or cancel scheduled.
+      if (eventEmitter._state != EventEmitter.States.STARTED) {
         return;
       }
-      if (retry.retryCodes.indexOf(err.code) < 0) {
-        error = new Error('Exception occurred in retry method that was ' +
-            'not classified as transient');
-        error.cause = err;
+
+      if (now.getTime() >= deadline) {
         callback(error);
-      } else {
-        error = new Error('Retry total timeout exceeded with exception');
-        error.cause = err;
-        var toSleep = Math.random() * delay;
-        setTimeout(function() {
-                     now = new Date();
-                     delay = Math.min(delay * delayMult, maxDelay);
-                     timeout = Math.min(timeout * timeoutMult, maxTimeout,
-                                        deadline - now.getTime());
-                     retryingFunc(argument, callback);
-                   }, toSleep);
+        return;
       }
-    });
+
+      var toCall = addTimeoutArg(aFunc, timeout, otherArgs);
+      eventEmitter._setEventHandler(toCall(argument, function(err, response) {
+        if (!err) {
+          callback(null, response);
+          return;
+        }
+        if (retry.retryCodes.indexOf(err.code) < 0) {
+          error = new Error('Exception occurred in retry method that was ' +
+              'not classified as transient');
+          error.cause = err;
+          callback(error);
+        } else {
+          error = new Error('Retry total timeout exceeded with exception');
+          error.cause = err;
+          var toSleep = Math.random() * delay;
+          setTimeout(function() {
+                       now = new Date();
+                       delay = Math.min(delay * delayMult, maxDelay);
+                       timeout = Math.min(timeout * timeoutMult, maxTimeout,
+                                          deadline - now.getTime());
+                       repeat(argument, callback);
+                     }, toSleep);
+        }
+      }));
+    }
+    repeat();
+    return eventEmitter;
   };
 }
 
@@ -159,10 +285,10 @@ function retryable(aFunc, retry, otherArgs) {
 function normalApiCall() {
   return {
     init: function(callback) {
-      return callback;
+      return new EventEmitter(callback);
     },
-    call: function(apiCall, argument, settings, callback) {
-      apiCall(argument, callback);
+    call: function(apiCall, argument, settings, emitter) {
+      emitter._setEventHandler(apiCall(argument, emitter._callback));
     }
   };
 }
@@ -178,12 +304,13 @@ function normalApiCall() {
  */
 function pageStreamable(pageDescriptor) {
   return {
-    init: function(callback) {
+    init: function createStream(callback) {
+      var stream = through2.obj();
       if (callback) {
-        console.warn('callback is specified, but callbacks are ignored for ' +
-                     'page streaming API calls.');
+        stream.on('data', function(data) { callback(null, data); });
+        stream.on('error', callback);
       }
-      return through2.obj();
+      return stream;
     },
     call: function pageStreaming(apiCall, argument, settings, stream) {
       if (!settings.flattenPages && settings.pageToken != gax.FIRST_PAGE) {
@@ -272,11 +399,10 @@ exports.createApiCall = function createApiCall(funcWithAuth, settings) {
     }).then(function (apiCall) {
       apiCaller.call(apiCall, request, thisSettings, result);
     })['catch'](function(err) {
-      // TODO: emit errors to result when normal API call returns event
-      // emitter.
-      if (callback) {
-        callback(err);
-      }
+      // setTimeout is necessary to raise an error outside of the promise.
+      // Otherwise the error won't be thrown to the outer environment but
+      // used for rejecting the promise itself.
+      setTimeout(function() { result.emit('error', err); }, 0);
     });
     return result;
   };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "google-gax",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Google API Extensions",
   "main": "index.js",
   "dependencies": {
     "chai": "*",
+    "eventemitter2": "1.0.2",
     "google-auth-library": "0.9.8",
     "grpc": "~0.14.1",
     "lodash": "~4.11.1",

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -36,6 +36,7 @@ var apiCallable = require('../lib/api_callable');
 var gax = require('../lib/gax');
 var expect = require('chai').expect;
 var sinon = require('sinon');
+var eventemitter2 = require('eventemitter2');
 
 var FAKE_STATUS_CODE_1 = 1;
 var FAKE_STATUS_CODE_2 = 2;
@@ -80,6 +81,114 @@ describe('createApiCall', function() {
       expect(resp).most(expectedDeadline);
       done();
     });
+  });
+});
+
+describe('EventEmitter', function() {
+  it('calls api call', function(done) {
+    var deadlineArg;
+    function func(argument, metadata, options, callback) {
+      deadlineArg = options.deadline;
+      callback(null, 42);
+    }
+    var apiCall = createApiCall(func, new gax.CallSettings());
+    apiCall(null).on('data', function(response) {
+      expect(response).to.eq(42);
+      expect(deadlineArg).to.be.ok;
+      done();
+    }).on('error', done);
+  });
+
+  it('cancels api call', function(done) {
+    function func(argument, metadata, options, callback) {
+      setTimeout(function() { callback(null, 42); }, 0);
+      var emitter = new eventemitter2.EventEmitter2();
+      emitter.cancel = done;
+      return emitter;
+    }
+    var apiCall = createApiCall(func, new gax.CallSettings());
+    var eventEmitter = apiCall(null);
+    eventEmitter.on('data', function(response) {
+      done(new Error('should not reach'));
+    }).on('error', done);
+    eventEmitter.cancel();
+  });
+
+  it('cancels with callback', function(done) {
+    function func(argument, metadata, options, callback) {
+      setTimeout(function() { callback(null, 42); }, 0);
+      var emitter = new eventemitter2.EventEmitter2();
+      emitter.cancel = function() {};
+      return emitter;
+    }
+    var apiCall = createApiCall(func, new gax.CallSettings());
+    var eventEmitter = apiCall(null, null, function(err, response) {
+      expect(err).to.be.an.instanceOf(Error);
+      done();
+    });
+    eventEmitter.on('error', done);
+    eventEmitter.cancel();
+  });
+
+  it('resolves the promise', function(done) {
+    var deadlineArg;
+    function func(argument, metadata, options, callback) {
+      deadlineArg = options.deadline;
+      callback(null, 42);
+    }
+    var apiCall = createApiCall(func, new gax.CallSettings());
+    apiCall(null).result.then(function(response) {
+      expect(response).to.eq(42);
+      expect(deadlineArg).to.be.ok;
+      done();
+    });
+  });
+
+  it('rejects the promise on cancel', function(done) {
+    function func(argument, metadata, options, callback) {
+      setTimeout(function() { callback(null, 42); }, 0);
+      var emitter = new eventemitter2.EventEmitter2();
+      emitter.cancel = function() {};
+      return emitter;
+    }
+    var apiCall = createApiCall(func, new gax.CallSettings());
+    var eventEmitter = apiCall(null);
+    eventEmitter.result.then(
+        function(result) { done(new Error('should not reach')); },
+        function(err) {
+          expect(err).to.be.an.instanceOf(Error);
+          done();
+        });
+    eventEmitter.cancel();
+  });
+
+  it('cancels retrying call', function(done) {
+    var retryOptions = new gax.RetryOptions(
+        [FAKE_STATUS_CODE_1], new gax.BackoffSettings(0, 0, 0, 0, 0, 0, 100));
+    var settings = new gax.CallSettings({timeout: 0, retry: retryOptions});
+
+    var callCount = 0;
+    function func(argument, metadata, options, callback) {
+      callCount++;
+      var err = null;
+      var response = null;
+      if (callCount <= 3) {
+        err = new Error();
+        err.code = FAKE_STATUS_CODE_1;
+      } else {
+        response = 42;
+      }
+      setTimeout(function() { callback(err, response); }, 10);
+      var emitter = new eventemitter2.EventEmitter2();
+      emitter.cancel = done;
+      return emitter;
+    }
+    var apiCall = createApiCall(func, settings);
+    var eventEmitter = apiCall(null);
+    eventEmitter.on('data', function(response) {
+      done(new Error('should not reach'));
+    }).on('error', done);
+    setTimeout(eventEmitter.cancel.bind(eventEmitter), 15);
   });
 });
 
@@ -245,6 +354,51 @@ describe('retryable', function() {
       expect(resp).to.eq(1729);
       expect(toAttempt).to.eq(0);
       expect(deadlineArg).to.be.ok;
+      done();
+    });
+  });
+
+  it('retries the API call with promise', function(done) {
+    var toAttempt = 3;
+    var deadlineArg;
+    function func(argument, metadata, options, callback) {
+      deadlineArg = options.deadline;
+      toAttempt--;
+      if (toAttempt > 0) {
+        fail(argument, metadata, options, callback);
+        return;
+      }
+      callback(null, 1729);
+    }
+    var apiCall = createApiCall(func, settings);
+    apiCall(null, null).result.then(function(resp) {
+      expect(resp).to.eq(1729);
+      expect(toAttempt).to.eq(0);
+      expect(deadlineArg).to.be.ok;
+      done();
+    })['catch'](function(err) { done(err); });
+  });
+
+  it('cancels in the middle of retries', function(done) {
+    var callCount = 0;
+    var deadlineArg;
+    var eventEmitter;
+    function func(argument, metadata, options, callback) {
+      deadlineArg = options.deadline;
+      callCount++;
+      if (callCount <= 2) {
+        fail(argument, metadata, options, callback);
+        return;
+      }
+      setTimeout(eventEmitter.cancel.bind(eventEmitter), 0);
+      setTimeout(callback.bind(null, null, 1729), 10);
+    }
+    var apiCall = createApiCall(func, settings);
+    eventEmitter = apiCall(null, null);
+    eventEmitter.result.then(function(resp) {
+      done(new Error('should not reach'));
+    }, function(err) {
+      expect(err).to.be.an.instanceOf(Error);
       done();
     });
   });


### PR DESCRIPTION
Fixes #20 and #21.

This introduces a dependency on eventemitter2 instead of using
NodeJS default EventEmitter considering the portability with
browserJS environment.