### PR TITLE
Fix testing nodejs versions in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
   - 5
-  - 5.1
   - 4
-  - 4.2
-  - 4.1
-  - 4.0
   - 0.12
 script:
   - npm test


### PR DESCRIPTION
- Add v6 -- which is going to be active LTS version soon.
- Remove unnecessary versions. Simply keep tracking the latest
  versions of each of LTS.
- Although gcloud-node does not verify v5 -- and it's not going
  to be LTS, it's probably good to check v5 behavior for now.
  We can remove it when Node switches to v6 as the new LTS.

cf: https://github.com/nodejs/LTS and
https://github.com/GoogleCloudPlatform/gcloud-node/blob/master/.travis.yml