### PR TITLE
Minor fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,5 +48,6 @@ exports.PageDescriptor = gax.PageDescriptor;
 exports.RetryOptions = gax.RetryOptions;
 exports.BackoffSettings = gax.BackoffSettings;
 exports.BundleOptions = gax.BundleOptions;
+exports.BundleDescriptor = gax.BundleDescriptor;
 exports.constructSettings = gax.constructSettings;
 exports.BundleExecutor = require('./lib/bundling').BundleExecutor;

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -114,6 +114,6 @@ exports.createStub = function createStub(
  */
 exports.createByteLengthFunction = function createByteLengthFunction(message) {
   return function getByteLength(obj) {
-    return message.encoder(obj).buffer.length;
+    return message.encode(obj).buffer.length;
   };
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "chai": "*",
     "eventemitter2": "1.0.2",
     "google-auth-library": "0.9.8",
-    "grpc": "~0.14.1",
+    "grpc": "~0.15.0",
     "lodash": "~4.11.1",
     "through2": "~2.0.1"
   },


### PR DESCRIPTION
- BundleDescriptor must be exposed (it's used by Gapic generated code)
- encoder() is wrong, encode() is correct.
- update to gRPC-0.15.0