### PR TITLE
Allow accessing gax version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,3 +51,4 @@ exports.BundleOptions = gax.BundleOptions;
 exports.BundleDescriptor = gax.BundleDescriptor;
 exports.constructSettings = gax.constructSettings;
 exports.BundleExecutor = require('./lib/bundling').BundleExecutor;
+exports.version = require('./package').version;


### PR DESCRIPTION
For googleapis/toolkit#467, we'll have to reveal the version of gax.