### PR TITLE
Add the support of 'timeout_millis' field.

### DIFF
--- a/lib/gax.js
+++ b/lib/gax.js
@@ -64,7 +64,7 @@ var bundling = require('./bundling');
  */
 function CallSettings(settings) {
   settings = settings || {};
-  this.timeout = settings.timeout || 30;
+  this.timeout = settings.timeout || 30 * 1000;
   this.retry = settings.retry;
   this.pageDescriptor = settings.pageDescriptor;
   this.flattenPages =
@@ -544,8 +544,6 @@ function mergeRetryOptions(retry, overrides) {
  * @param {Object} retryNames - A dictionary mapping the strings
  *   referring to response status codes to objects representing
  *   those codes.
- * @param {number} timeout - The timeout parameter for all API calls
- *   in this dictionary.
  * @param {Object} pageDescriptors - A dictionary of method names to
  *   {@link PageDescriptor} objects for methods that are page streaming-enabled.
  * @param {Object} bundleDescriptors - A dictionary of method names to
@@ -557,7 +555,7 @@ function mergeRetryOptions(retry, overrides) {
  */
 exports.constructSettings = function constructSettings(
     serviceName, clientConfig, configOverrides,
-    retryNames, timeout, pageDescriptors, bundleDescriptors, otherArgs) {
+    retryNames, pageDescriptors, bundleDescriptors, otherArgs) {
   pageDescriptors = pageDescriptors || {};
   bundleDescriptors = bundleDescriptors || {};
   otherArgs = otherArgs || {};
@@ -581,10 +579,16 @@ exports.constructSettings = function constructSettings(
                                serviceConfig.retry_params,
                                retryNames);
     var bundlingConfig = methodConfig.bundling;
+    var timeout = methodConfig.timeout_millis;
     if (methodName in overridingMethods) {
       var overridingMethod = overridingMethods[methodName];
-      if (overridingMethod && 'bundling' in overridingMethod) {
-        bundlingConfig = overridingMethod.bundling;
+      if (overridingMethod) {
+        if ('bundling' in overridingMethod) {
+          bundlingConfig = overridingMethod.bundling;
+        }
+        if ('timeout_millis' in overridingMethod) {
+          timeout = overridingMethod.timeout_millis;
+        }
       }
       retry = mergeRetryOptions(
           retry,

--- a/test/gax.js
+++ b/test/gax.js
@@ -65,6 +65,7 @@ A_CONFIG.interfaces[SERVICE_NAME] = {
   },
   'methods': {
     'BundlingMethod': {
+      'timeout_millis': 40000,
       'retry_codes_name': 'foo_retry',
       'retry_params_name': 'default',
       'bundling': {
@@ -117,10 +118,10 @@ describe('gax construct settings', function() {
   it('creates settings', function() {
     var otherArgs = {'key': 'value'};
     var defaults = gax.constructSettings(
-        SERVICE_NAME, A_CONFIG, {}, RETRY_DICT, 30, PAGE_DESCRIPTORS,
+        SERVICE_NAME, A_CONFIG, {}, RETRY_DICT, PAGE_DESCRIPTORS,
         BUNDLE_DESCRIPTORS, otherArgs);
     var settings = defaults.bundlingMethod;
-    expect(settings.timeout).to.eq(30);
+    expect(settings.timeout).to.eq(40000);
     expect(settings.bundler).to.be.an.instanceOf(bundling.BundleExecutor);
     expect(settings.pageDescriptor).to.eq(null);
     expectRetryOptions(settings.retry);
@@ -128,7 +129,7 @@ describe('gax construct settings', function() {
     expect(settings.otherArgs).eql(otherArgs);
 
     settings = defaults.pageStreamingMethod;
-    expect(settings.timeout).to.eq(30);
+    expect(settings.timeout).to.eq(30000);
     expect(settings.bundler).to.eq(null);
     expect(settings.pageDescriptor).to.be.an.instanceOf(gax.PageDescriptor);
     expectRetryOptions(settings.retry);
@@ -147,16 +148,16 @@ describe('gax construct settings', function() {
       }
     };
     var defaults = gax.constructSettings(
-        SERVICE_NAME, A_CONFIG, overrides, RETRY_DICT, 30, PAGE_DESCRIPTORS,
+        SERVICE_NAME, A_CONFIG, overrides, RETRY_DICT, PAGE_DESCRIPTORS,
         BUNDLE_DESCRIPTORS);
 
     var settings = defaults.bundlingMethod;
-    expect(settings.timeout).to.eq(30);
+    expect(settings.timeout).to.eq(40000);
     expect(settings.bundler).to.eq(null);
     expect(settings.pageDescriptor).to.eq(null);
 
     settings = defaults.pageStreamingMethod;
-    expect(settings.timeout).to.eq(30);
+    expect(settings.timeout).to.eq(30000);
     expect(settings.pageDescriptor).to.be.an.instanceOf(gax.PageDescriptor);
     expect(settings.retry).to.eq(null);
   });
@@ -182,13 +183,14 @@ describe('gax construct settings', function() {
       'methods': {
         'BundlingMethod': {
           'retry_params_name': 'default',
-          'retry_codes_name': 'baz_retry'
+          'retry_codes_name': 'baz_retry',
+          'timeout_millis': 50000
         }
       }
     };
 
     var defaults = gax.constructSettings(
-        SERVICE_NAME, A_CONFIG, overrides, RETRY_DICT, 30, PAGE_DESCRIPTORS,
+        SERVICE_NAME, A_CONFIG, overrides, RETRY_DICT, PAGE_DESCRIPTORS,
         BUNDLE_DESCRIPTORS);
 
     var settings = defaults.bundlingMethod;
@@ -196,6 +198,7 @@ describe('gax construct settings', function() {
     expect(backoff.initialRetryDelayMillis).to.eq(1000);
     expect(settings.retry.retryCodes).to.eql([RETRY_DICT.code_a]);
     expect(settings.bundler).to.be.an.instanceOf(bundling.BundleExecutor);
+    expect(settings.timeout).to.eq(50000);
 
     /* page_streaming_method is unaffected because it's not specified in
      * overrides. 'bar_retry' or 'default' definitions in overrides should


### PR DESCRIPTION
Also, the default value for timeout in CallSettings is actually
wrong -- just '30' means 30 milliseconds.