### PR TITLE
Specify convertFieldsToCamelCase to true by default

### DIFF
--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -89,7 +89,7 @@ GrpcClient.prototype.load = function(args) {
   } else if (!Array.isArray(args)) {
     args = [args];
   }
-  if (args.length == 1) {
+  if (args.length === 1) {
     args.push('proto', {convertFieldsToCamelCase: true});
   }
   return this.grpc.load.apply(this.grpc, args);

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -102,7 +102,6 @@ GrpcClient.prototype.load = function(args) {
  * @param {string} serviceName - The fullly-qualified name of the service.
  * @param {Object} clientConfig - A dictionary of the client config.
  * @param {Object} configOverrides - A dictionary of overriding configs.
- * @param {number} timeout - The timeout parameter.
  * @param {Object} pageDescriptors - A dictionary of method names to page
  *   descriptor instances.
  * @param {Object} bundleDescriptors - A dictionary of method names to bundle
@@ -115,7 +114,6 @@ GrpcClient.prototype.constructSettings = function constructSettings(
     serviceName,
     clientConfig,
     configOverrides,
-    timeout,
     pageDescriptors,
     bundleDescriptors,
     headers) {
@@ -128,7 +126,6 @@ GrpcClient.prototype.constructSettings = function constructSettings(
       clientConfig,
       configOverrides,
       this.grpc.status,
-      timeout,
       pageDescriptors,
       bundleDescriptors,
       {metadata: metadata});

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -89,6 +89,9 @@ GrpcClient.prototype.load = function(args) {
   } else if (!Array.isArray(args)) {
     args = [args];
   }
+  if (args.length == 1) {
+    args.push('proto', {convertFieldsToCamelCase: true});
+  }
   return this.grpc.load.apply(this.grpc, args);
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "chai": "*",
     "eventemitter2": "~2.0.2",
     "google-auto-auth": "~0.2.4",
-    "grpc": "~0.15.0",
+    "grpc": "~1.0",
     "lodash": "~4.11.1",
     "through2": "~2.0.1"
   },


### PR DESCRIPTION
This is wanted for idiomatic nodejs clients -- all of the internal
fields will be lowercased_underscore style.

Fixes #43, and #41.