### PR TITLE
Support more gRPC streaming events.

### DIFF
--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -109,7 +109,7 @@ StreamProxy.prototype.cancel = function() {
   } else {
     this._isCancelCalled = true;
   }
-}
+};
 
 /**
  * Specifies the target stream.

--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -70,6 +70,7 @@ function StreamProxy(type, callback) {
   this._callback = callback;
   this._writeQueue = [];
   this._isEndCalled = false;
+  this._isCancelCalled = false;
   this.on('finish', this._onFinish.bind(this));
 }
 
@@ -102,6 +103,14 @@ StreamProxy.prototype._onFinish = function() {
   }
 };
 
+StreamProxy.prototype.cancel = function() {
+  if (this.stream) {
+    this.stream.cancel();
+  } else {
+    this._isCancelCalled = true;
+  }
+}
+
 /**
  * Specifies the target stream.
  * @param {ApiCall} apiCall - the API function to be called.
@@ -110,11 +119,17 @@ StreamProxy.prototype._onFinish = function() {
 StreamProxy.prototype.setStream = function(apiCall, argument) {
   var stream = apiCall(argument, this._callback);
   this.stream = stream;
-  stream.on('error', this.emit.bind(this, 'error'));
+  (['error', 'metadata', 'status']).forEach(function(event) {
+    stream.on(event, this.emit.bind(this, event));
+  }.bind(this));
+  // We also want to supply the status data as 'response'.
+  stream.on('status', this.emit.bind(this, 'response'));
   if (this.type !== StreamType.CLIENT_STREAMING) {
     stream.on('data', this.emit.bind(this, 'data'));
     // Pushing null causes an ending process of the readable stream.
     stream.on('end', this.push.bind(this, null));
+    // This is required in case there's no 'data' handler exists.
+    this.resume();
   }
   if (this.type !== StreamType.SERVER_STREAMING) {
     this._writeQueue.forEach(function(data) {
@@ -123,6 +138,9 @@ StreamProxy.prototype.setStream = function(apiCall, argument) {
     this._writeQueue = [];
     if (this._isEndCalled) {
       stream.end();
+    }
+    if (this._isCancelCalled) {
+      stream.cancel();
     }
   }
 };

--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -122,13 +122,26 @@ StreamProxy.prototype.setStream = function(apiCall, argument) {
   (['error', 'metadata', 'status']).forEach(function(event) {
     stream.on(event, this.emit.bind(this, event));
   }.bind(this));
-  // We also want to supply the status data as 'response'.
-  stream.on('status', this.emit.bind(this, 'response'));
+  // We also want to supply the status data as 'response' event to support
+  // the behavior of google-cloud-node expects.
+  // see: https://github.com/GoogleCloudPlatform/google-cloud-node/pull/1775#issuecomment-259141029
+  // https://github.com/GoogleCloudPlatform/google-cloud-node/blob/116436fa789d8b0f7fc5100b19b424e3ec63e6bf/packages/common/src/grpc-service.js#L355
+  stream.on('metadata', function(metadata) {
+    // Create a response object with succeeds.
+    // TODO: unify this logic with the decoration of gRPC response when it's added.
+    // see: https://github.com/googleapis/gax-nodejs/issues/65
+    this.emit('response', {
+      code: 200,
+      details: '',
+      message: 'OK',
+      metadata: metadata
+    });
+  }.bind(this));
   if (this.type !== StreamType.CLIENT_STREAMING) {
     stream.on('data', this.emit.bind(this, 'data'));
     // Pushing null causes an ending process of the readable stream.
     stream.on('end', this.push.bind(this, null));
-    // This is required in case there's no 'data' handler exists.
+    // This is required in case no 'data' handler exists.
     this.resume();
   }
   if (this.type !== StreamType.SERVER_STREAMING) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -669,4 +669,79 @@ describe('streaming', function() {
     s.write(arg);
     s.end();
   });
+
+  it('forwards metadata and status', function(done) {
+    var responseMetadata = {'metadata': true};
+    var status = {'code': 0, 'metadata': responseMetadata};
+    function func(metadata, options) {
+      var s = through2.obj();
+      setTimeout(s.emit.bind(s, 'metadata', responseMetadata), 10);
+      s.on('end', s.emit.bind(s, 'status', status));
+      return s;
+    }
+    var apiCall = createStreamingCall(
+        func, streaming.StreamType.BIDI_STREAMING);
+    var s = apiCall(null, null);
+    var receivedMetadata;
+    var receivedStatus;
+    var receivedResponse;
+    s.on('metadata', function(data) {
+      receivedMetadata = data;
+    });
+    s.on('status', function(data) {
+      receivedStatus = data;
+    });
+    s.on('response', function(data) {
+      receivedResponse = data;
+    });
+    s.on('end', function() {
+      expect(receivedMetadata).to.deep.eq(responseMetadata);
+      expect(receivedStatus).to.deep.eq(status);
+      expect(receivedResponse).to.deep.eq(status);
+      done();
+    });
+    expect(s.readable).to.be.true;
+    expect(s.writable).to.be.true;
+    setTimeout(s.end.bind(s), 50);
+  });
+
+  it('cancels in the middle', function(done) {
+    function schedulePush(s, c) {
+      if (!s.readable) {
+        return;
+      }
+      setTimeout(function() {
+        s.push(c);
+        schedulePush(s, c + 1);
+      }, 10);
+    }
+    var cancelCalled = false;
+    var cancelError = new Error('cancelled');
+    function func(metadata, options) {
+      var s = through2.obj();
+      schedulePush(s, 0);
+      s.cancel = function() {
+        s.end();
+        s.emit('error', cancelError);
+      };
+      return s;
+    }
+    var apiCall = createStreamingCall(
+        func, streaming.StreamType.SERVER_STREAMING);
+    var s = apiCall(null, null);
+    var counter = 0;
+    s.on('data', function(data) {
+      expect(data).to.eq(counter);
+      counter++;
+      if (counter == 5) {
+        s.cancel();
+      } else if (counter > 5) {
+        done(new Error('should not reach'));
+      }
+    });
+    s.on('error', function(err) {
+      expect(err).to.eq(cancelError);
+      done();
+    });
+  })
 });

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -671,8 +671,8 @@ describe('streaming', function() {
   });
 
   it('forwards metadata and status', function(done) {
-    var responseMetadata = {'metadata': true};
-    var status = {'code': 0, 'metadata': responseMetadata};
+    var responseMetadata = {metadata: true};
+    var status = {code: 0, metadata: responseMetadata};
     function func(metadata, options) {
       var s = through2.obj();
       setTimeout(s.emit.bind(s, 'metadata', responseMetadata), 10);
@@ -715,7 +715,6 @@ describe('streaming', function() {
         schedulePush(s, c + 1);
       }, 10);
     }
-    var cancelCalled = false;
     var cancelError = new Error('cancelled');
     function func(metadata, options) {
       var s = through2.obj();
@@ -730,12 +729,13 @@ describe('streaming', function() {
         func, streaming.StreamType.SERVER_STREAMING);
     var s = apiCall(null, null);
     var counter = 0;
+    var expectedCount = 5;
     s.on('data', function(data) {
       expect(data).to.eq(counter);
       counter++;
-      if (counter == 5) {
+      if (counter === expectedCount) {
         s.cancel();
-      } else if (counter > 5) {
+      } else if (counter > expectedCount) {
         done(new Error('should not reach'));
       }
     });
@@ -743,5 +743,5 @@ describe('streaming', function() {
       expect(err).to.eq(cancelError);
       done();
     });
-  })
+  });
 });

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -673,6 +673,12 @@ describe('streaming', function() {
   it('forwards metadata and status', function(done) {
     var responseMetadata = {metadata: true};
     var status = {code: 0, metadata: responseMetadata};
+    var expectedResponse = {
+      code: 200,
+      message: 'OK',
+      details: '',
+      metadata: responseMetadata
+    };
     function func(metadata, options) {
       var s = through2.obj();
       setTimeout(s.emit.bind(s, 'metadata', responseMetadata), 10);
@@ -697,7 +703,7 @@ describe('streaming', function() {
     s.on('end', function() {
       expect(receivedMetadata).to.deep.eq(responseMetadata);
       expect(receivedStatus).to.deep.eq(status);
-      expect(receivedResponse).to.deep.eq(status);
+      expect(receivedResponse).to.deep.eq(expectedResponse);
       done();
     });
     expect(s.readable).to.be.true;


### PR DESCRIPTION
- 'metadata' and 'status' events are meaningful and should be
  forwarded.
- gRPC streaming results have 'cancel' method, this method call
  needs to be forwarded as well.

Fixes #67