### PR TITLE
Let apiCallable return undefined when callback is supplied.

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -35,6 +35,7 @@
 
 'use strict';
 
+var nextTick = require('process-nextick-args');
 var setTimeout = require('timers').setTimeout;
 
 /**
@@ -67,18 +68,25 @@ var setTimeout = require('timers').setTimeout;
  * @private
  */
 function PromiseCanceller(callback) {
-  this.promise = new Promise(function(resolve, reject) {
-    this.resolve = resolve;
-    this.reject = reject;
-  }.bind(this));
   if (callback) {
-    this.promise = this.promise.then(function(response) {
-      var args = [null];
-      args.push.apply(args, response);
-      callback.apply(null, args);
-    }, callback);
+    this.callback = callback;
+    return;
   }
-  this.promise.cancel = this.cancel.bind(this);
+
+  var self = this;
+  this.promise = new Promise(function(resolve, reject) {
+    self.callback = function(err) {
+      self.completed = true;
+      if (err) {
+        reject(err);
+      } else {
+        resolve(Array.prototype.slice.call(arguments, 1));
+      }
+    };
+  });
+  this.promise.cancel = function() {
+    self.cancel();
+  };
   this.cancelFunc = null;
   this.completed = false;
 }
@@ -94,26 +102,7 @@ PromiseCanceller.prototype.cancel = function() {
   if (this.cancelFunc) {
     this.cancelFunc();
   } else {
-    this.reject(new Error('cancelled'));
-  }
-};
-
-/**
- * A callback-styled method.
- *
- * This will be used for the final parameter of API call.
- * @param {Error=} err
- *   The error when something goes wrong.
- * @param {Object=} response
- *   The response object when succeeds.
- */
-PromiseCanceller.prototype.callback = function(err) {
-  this.completed = true;
-  if (err) {
-    this.reject(err);
-  } else {
-    // Resolves to an array of the remaining arguments.
-    this.resolve(Array.prototype.slice.call(arguments, 1));
+    this.callback(new Error('cancelled'));
   }
 };
 
@@ -130,8 +119,15 @@ PromiseCanceller.prototype.call = function(aFunc, argument) {
   if (this.completed) {
     return;
   }
-  var canceller = aFunc(argument, this.callback.bind(this));
-  this.cancelFunc = canceller.cancel.bind(canceller);
+  var callback = this.callback;
+  var canceller = aFunc(argument, function() {
+    var args = Array.prototype.slice.call(arguments, 0);
+    args.unshift(callback);
+    nextTick.apply(null, args);
+  });
+  this.cancelFunc = function() {
+    canceller.cancel();
+  };
 };
 
 /**
@@ -288,11 +284,13 @@ NormalApiCaller.prototype.call = function(
 };
 
 NormalApiCaller.prototype.fail = function(canceller, err) {
-  canceller.reject(err);
+  canceller.callback(err);
 };
 
 NormalApiCaller.prototype.result = function(canceller) {
-  return canceller.promise;
+  if (canceller.promise) {
+    return canceller.promise;
+  }
 };
 
 exports.NormalApiCaller = NormalApiCaller;
@@ -337,12 +335,7 @@ exports.createApiCall = function createApiCall(
     }).then(function(apiCall) {
       apiCaller.call(apiCall, request, thisSettings, status);
     }).catch(function(err) {
-      // setTimeout is necessary to raise an error outside of the promise.
-      // Otherwise the error won't be thrown to the outer environment but
-      // used for rejecting the promise itself.
-      setTimeout(function() {
-        apiCaller.fail(status, err);
-      }, 0);
+      apiCaller.fail(status, err);
     });
     return apiCaller.result(status);
   };

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -37,6 +37,7 @@
 
 var nextTick = require('process-nextick-args');
 var setTimeout = require('timers').setTimeout;
+var util = require('util');
 
 /**
  * @callback APICallback
@@ -57,36 +58,22 @@ var setTimeout = require('timers').setTimeout;
  * @param {Object} argument
  * @param {CallOptions} callOptions
  * @param {APICallback} callback
- * @return {Promise|Stream}
+ * @return {Promise|Stream|undefined}
  */
 
 /**
- * PromiseCanceller manages a promise which has cancel function.
+ * Canceller manages callback, API calls, and cancellation
+ * of the API calls.
  * @param {APICallback=} callback
- *   The callback to be called when the promise is fulfilled.
+ *   The callback to be called asynchronously when the API call
+ *   finishes.
  * @constructor
+ * @property {APICallback} callback
+ *   The callback function to be called.
  * @private
  */
-function PromiseCanceller(callback) {
-  if (callback) {
-    this.callback = callback;
-    return;
-  }
-
-  var self = this;
-  this.promise = new Promise(function(resolve, reject) {
-    self.callback = function(err) {
-      self.completed = true;
-      if (err) {
-        reject(err);
-      } else {
-        resolve(Array.prototype.slice.call(arguments, 1));
-      }
-    };
-  });
-  this.promise.cancel = function() {
-    self.cancel();
-  };
+function Canceller(callback) {
+  this.callback = callback;
   this.cancelFunc = null;
   this.completed = false;
 }
@@ -94,7 +81,7 @@ function PromiseCanceller(callback) {
 /**
  * Cancels the ongoing promise.
  */
-PromiseCanceller.prototype.cancel = function() {
+Canceller.prototype.cancel = function() {
   if (this.completed) {
     return;
   }
@@ -115,20 +102,45 @@ PromiseCanceller.prototype.cancel = function() {
  * @param {Object} argument
  *   A request object.
  */
-PromiseCanceller.prototype.call = function(aFunc, argument) {
+Canceller.prototype.call = function(aFunc, argument) {
   if (this.completed) {
     return;
   }
-  var callback = this.callback;
+  var self = this;
   var canceller = aFunc(argument, function() {
+    self.completed = true;
     var args = Array.prototype.slice.call(arguments, 0);
-    args.unshift(callback);
+    args.unshift(self.callback);
     nextTick.apply(null, args);
   });
   this.cancelFunc = function() {
     canceller.cancel();
   };
 };
+
+/**
+ * PromiseCanceller is Canceller, but it holds a promise when
+ * the API call finishes.
+ * @constructor
+ * @private
+ */
+function PromiseCanceller() {
+  var self = this;
+  this.promise = new Promise(function(resolve, reject) {
+    Canceller.call(self, function(err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(Array.prototype.slice.call(arguments, 1));
+      }
+    });
+  });
+  this.promise.cancel = function() {
+    self.cancel();
+  };
+}
+
+util.inherits(PromiseCanceller, Canceller);
 
 /**
  * Updates aFunc so that it gets called with the timeout as its final arg.
@@ -271,7 +283,11 @@ function NormalApiCaller() {
 }
 
 NormalApiCaller.prototype.init = function(settings, callback) {
-  return new PromiseCanceller(callback);
+  if (callback) {
+    return new Canceller(callback);
+  } else {
+    return new PromiseCanceller();
+  }
 };
 
 NormalApiCaller.prototype.wrap = function(func) {

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -285,9 +285,8 @@ function NormalApiCaller() {
 NormalApiCaller.prototype.init = function(settings, callback) {
   if (callback) {
     return new Canceller(callback);
-  } else {
-    return new PromiseCanceller();
   }
+  return new PromiseCanceller();
 };
 
 NormalApiCaller.prototype.wrap = function(func) {

--- a/lib/page_streaming.js
+++ b/lib/page_streaming.js
@@ -31,6 +31,7 @@
 'use strict';
 
 var extend = require('extend');
+var nextTick = require('process-nextick-args');
 var util = require('util');
 var NormalApiCaller = require('./api_callable').NormalApiCaller;
 var ReadableStream = require('readable-stream');
@@ -106,10 +107,10 @@ PagedIteration.prototype.call = function(
       canceller.callback(null, allResources);
       return;
     }
-    setTimeout(apiCall.bind(null, argument, pushResources), 0);
+    nextTick(apiCall, argument, pushResources);
   }
 
-  setTimeout(apiCall.bind(null, argument, pushResources), 0);
+  nextTick(apiCall, argument, pushResources);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "google-proto-files": "^0.8.3",
     "grpc": "~1.0",
     "lodash": "~4.11.1",
+    "process-nextick-args": "^1.0.7",
     "readable-stream": "~2.0.6"
   },
   "devDependencies": {

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -171,6 +171,18 @@ describe('Promise', function() {
     }).catch(done);
     setTimeout(promise.cancel.bind(promise), 15);
   });
+
+  it('does not return promise when callback is supplied', function(done) {
+    function func(argument, metadata, options, callback) {
+      callback(null, 42);
+    }
+    var apiCall = createApiCall(func);
+    expect(apiCall(null, null, function(err, response) {
+      expect(err).to.be.null;
+      expect(response).to.eq(42);
+      done();
+    })).to.be.undefined;
+  });
 });
 
 describe('paged iteration', function() {
@@ -218,7 +230,7 @@ describe('paged iteration', function() {
       expect(err).to.be.null;
       expect(results).to.deep.equal(expected);
       done();
-    }).catch(done);
+    });
   });
 
   it('returns a response when autoPaginate is false', function(done) {
@@ -271,7 +283,7 @@ describe('paged iteration', function() {
         done();
       }
     }
-    apiCall({}, {autoPaginate: false}, callback).catch(done);
+    apiCall({}, {autoPaginate: false}, callback);
   });
 
   it('retries on failure', function(done) {
@@ -363,7 +375,7 @@ describe('retryable', function() {
       expect(toAttempt).to.eq(0);
       expect(deadlineArg).to.be.ok;
       done();
-    }).catch(done);
+    });
   });
 
   it('retries the API call with promise', function(done) {
@@ -385,7 +397,7 @@ describe('retryable', function() {
       expect(toAttempt).to.eq(0);
       expect(deadlineArg).to.be.ok;
       done();
-    }).catch(function(err) { done(err); });
+    }).catch(done);
   });
 
   it('cancels in the middle of retries', function(done) {
@@ -571,7 +583,7 @@ describe('bundleable', function() {
       } else {
         callback([obj]);
       }
-    }).catch(done);
+    });
     apiCall(createRequest([1, 2, 3], 'id'), null).then(callback).catch(done);
   });
 


### PR DESCRIPTION
fixes #74. This also includes the fix for #69, to detach the
callback from unhandled promises.