### PR TITLE
Fix 'progress' event.

### DIFF
--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -294,8 +294,7 @@ Operation.prototype.startPolling_ = function() {
       }
 
       if (!result) {
-        if (Buffer.compare(
-              rawResponse.metadata.value, previousMetadataBytes) !== 0) {
+        if (!rawResponse.metadata.value.equals(previousMetadataBytes)) {
           nextTick(emit, 'progress', metadata, rawResponse);
           previousMetadataBytes = rawResponse.metadata.value;
         }

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -294,7 +294,8 @@ Operation.prototype.startPolling_ = function() {
       }
 
       if (!result) {
-        if (rawResponse.metadata.value !== previousMetadataBytes) {
+        if (Buffer.compare(
+              rawResponse.metadata.value, previousMetadataBytes) !== 0) {
           nextTick(emit, 'progress', metadata, rawResponse);
           previousMetadataBytes = rawResponse.metadata.value;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -814,15 +814,15 @@ describe('streaming', function() {
 });
 
 describe('longrunning', function() {
-  var RESPONSE_VAL = {test: 'response'};
+  var RESPONSE_VAL = 'response';
   var RESPONSE = {
     typyeUrl: 'mock.proto.message',
-    value: JSON.stringify(RESPONSE_VAL)
+    value: Buffer.from(RESPONSE_VAL)
   };
-  var METADATA_VAL = {test: 'metadata'};
+  var METADATA_VAL = 'metadata';
   var METADATA = {
     typeUrl: 'mock.proto.Message',
-    value: JSON.stringify(METADATA_VAL)
+    value: Buffer.from(METADATA_VAL)
   };
   var OPERATION_NAME = 'operation_name';
   var SUCCESSFUL_OP = {
@@ -853,7 +853,7 @@ describe('longrunning', function() {
     error: ERROR,
     response: null
   };
-  var mockDecoder = function(val) { return JSON.parse(val); };
+  var mockDecoder = function(val) { return val.toString(); };
 
   function createLongrunningCall(func, client) {
     var settings = new gax.CallSettings();
@@ -1097,10 +1097,10 @@ describe('longrunning', function() {
         var func = function(argument, metadata, options, callback) {
           callback(null, PENDING_OP);
         };
-        var updatedMetadataVal = {test: 'updated'};
+        var updatedMetadataVal = 'updated';
         var updatedMetadata = {
           typeUrl: 'mock.proto.Message',
-          value: JSON.stringify(updatedMetadataVal)
+          value: Buffer.from(updatedMetadataVal)
         };
         var updatedOp = {
           result: null,

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -814,15 +814,22 @@ describe('streaming', function() {
 });
 
 describe('longrunning', function() {
+  function createBuffer(str) {
+    if (Buffer.from) {
+      return Buffer.from(str);
+    }
+    return new Buffer(str);
+  }
+
   var RESPONSE_VAL = 'response';
   var RESPONSE = {
     typyeUrl: 'mock.proto.message',
-    value: Buffer.from(RESPONSE_VAL)
+    value: createBuffer(RESPONSE_VAL)
   };
   var METADATA_VAL = 'metadata';
   var METADATA = {
     typeUrl: 'mock.proto.Message',
-    value: Buffer.from(METADATA_VAL)
+    value: createBuffer(METADATA_VAL)
   };
   var OPERATION_NAME = 'operation_name';
   var SUCCESSFUL_OP = {
@@ -1100,7 +1107,7 @@ describe('longrunning', function() {
         var updatedMetadataVal = 'updated';
         var updatedMetadata = {
           typeUrl: 'mock.proto.Message',
-          value: Buffer.from(updatedMetadataVal)
+          value: createBuffer(updatedMetadataVal)
         };
         var updatedOp = {
           result: null,


### PR DESCRIPTION
Comparing `Buffer` objects using the `!==` operator always returns `true`. Switching this comparison to use `Buffer.compare` will cause the `progress` event to work correctly.

Resolves [google-cloud-node#1875](https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1875).