### PR TITLE
Buffer.from fix and logic fix.

### DIFF
--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -270,7 +270,7 @@ Operation.prototype.startPolling_ = function() {
   var maxDelay = this.backoffSettings.maxRetryDelayMillis;
   var delay = this.backoffSettings.initialRetryDelayMillis;
   var deadline = now.getTime() + this.backoffSettings.totalTimeoutMillis;
-  var previousMetadataBytes = Buffer.from ? Buffer.from("") : new Buffer("");
+  var previousMetadataBytes;
   if (this.currentOperation.metadata) {
     previousMetadataBytes = this.currentOperation.metadata.value;
   }
@@ -297,7 +297,8 @@ Operation.prototype.startPolling_ = function() {
       }
 
       if (!result) {
-        if (!rawResponse.metadata.value.equals(previousMetadataBytes)) {
+        if (rawResponse.metadata && (!previousMetadataBytes ||
+              !rawResponse.metadata.value.equals(previousMetadataBytes))) {
           nextTick(emit, 'progress', metadata, rawResponse);
           previousMetadataBytes = rawResponse.metadata.value;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -827,10 +827,13 @@ describe('streaming', function() {
 
 describe('longrunning', function() {
   function createBuffer(str) {
-    if (Buffer.from) {
-      return Buffer.from(str);
+    var buffer;
+    try {
+      buffer = Buffer.from(str);
+    } catch (_) {
+      buffer = new Buffer(str);
     }
-    return new Buffer(str);
+    return buffer;
   }
 
   var RESPONSE_VAL = 'response';


### PR DESCRIPTION
It appears that `Buffer.from("")` does not work for node versions `>4.0.x` but `<4.5.x` and does not work for node versions `>5.0.x` and `<5.10.x`. This fix removes the use of Buffer.from in the implementation.

This also adds additional logic to checking if there is an update to the metadata.

