### PR TITLE
Fixed a Server streaming request bug.

### DIFF
--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -196,7 +196,12 @@ GrpcStreamable.prototype.wrap = function(func) {
       return func(metadata, options);
     };
   }
-  return func;
+  // this.descriptor.type === StreamType.SERVER_STREAMING
+  // The grpc module uses arguejs which will throw an error if the callback
+  // is passed in. The callback argument must be dropped.
+  return function(argument, metadata, options, callback) {
+    return func(argument, metadata, options);
+  };
 };
 
 GrpcStreamable.prototype.call = function(apiCall, argument, settings, stream) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
The [grpc serverStreamRequest](https://github.com/grpc/grpc/blob/master/src/node/src/client.js#L543) does not take in a callback and will through an error if passed in. It seems we stopped the callback from being passed in for [BIDI streaming](https://github.com/googleapis/gax-nodejs/blob/master/lib/streaming.js#L194) but not for Server streaming.