### PR TITLE
Fix server-streaming request pattern.

### DIFF
--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -187,14 +187,21 @@ GrpcStreamable.prototype.init = function(settings, callback) {
 };
 
 GrpcStreamable.prototype.wrap = function(func) {
-  if (this.descriptor.type === StreamType.CLIENT_STREAMING) {
-    return function(argument, metadata, options, callback) {
-      return func(metadata, options, callback);
-    };
-  } else if (this.descriptor.type === StreamType.BIDI_STREAMING) {
-    return function(argument, metadata, options, callback) {
-      return func(metadata, options);
-    };
+  switch (this.descriptor.type) {
+    case StreamType.SERVER_STREAMING:
+      return function(argument, metadata, options, callback) {
+        return func(argument, metadata, options);
+      };
+    case StreamType.CLIENT_STREAMING:
+      return function(argument, metadata, options, callback) {
+        return func(metadata, options, callback);
+      };
+    case StreamType.BIDI_STREAMING:
+      return function(argument, metadata, options, callback) {
+        return func(metadata, options);
+      };
+    default:
+      console.error('Unknown stream type', this.descriptor.type);
   }
   return func;
 };

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -658,6 +658,7 @@ describe('streaming', function() {
 
   it('handles server streaming', function(done) {
     var spy = sinon.spy(function(argument, metadata, options) {
+      expect(arguments.length).to.eq(3);
       var s = through2.obj();
       s.push({resources: [1, 2]});
       s.push({resources: [3, 4, 5]});
@@ -686,6 +687,7 @@ describe('streaming', function() {
 
   it('handles client streaming', function(done) {
     function func(metadata, options, callback) {
+      expect(arguments.length).to.eq(3);
       var s = through2.obj();
       var written = [];
       s.on('end', function() {
@@ -714,6 +716,7 @@ describe('streaming', function() {
 
   it('handles bidi streaming', function(done) {
     function func(metadata, options) {
+      expect(arguments.length).to.eq(2);
       var s = through2.obj();
       return s;
     }


### PR DESCRIPTION
- server-streaming: 3 arguments (request, metadata, options).
  The callback must not exist.
- client-streaming: 3 arguments (metadata, options, callback).
  The request must not exist.
- bidi-streaming: 2 arguments (metadata, options).
  Both request and callback must not exist.

Also added test cases.