### PR TITLE
LRO: getOperation should return a promise when callback is not specified.

### DIFF
--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -209,7 +209,7 @@ Operation.prototype.cancel = function() {
  *
  * @param {getOperationCallback} callback - Callback to handle the polled
  * operation result and metadata.
- * @return {Promise} - This returns a promise if a callback is not specified.
+ * @return {Promise|undefined} - This returns a promise if a callback is not specified.
  * The promise resolves to an array where the first element is the unpacked
  * result, the second element is the metadata, and the third element is the raw
  * response of the api call. The promise rejects if the operation returns an

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -219,15 +219,21 @@ Operation.prototype.getOperation = function(callback) {
   var self = this;
   var operationsClient = this.longrunningDescriptor.operationsClient;
 
-  if (this.latestResponse.done) {
-    this.unpackResponse_(this.latestResponse, callback);
+  function promisifyResponse() {
     if (!callback) {
-      if (this.latestResponse.error) {
-        return Promise.reject(this.latestResponse.error);
+      if (self.latestResponse.error) {
+        var error = new Error(self.latestReponse.error.message);
+        error.code = self.latestReponse.error.code;
+        return Promise.reject(error);
       }
-      return Promise.resolve([this.result, this.metadata, this.latestResponse]);
+      return Promise.resolve([self.result, self.metadata, self.latestResponse]);
     }
     return;
+  }
+
+  if (this.latestResponse.done) {
+    this.unpackResponse_(this.latestResponse, callback);
+    return promisifyResponse();
   }
 
   this.currentCallPromise_ =
@@ -237,12 +243,7 @@ Operation.prototype.getOperation = function(callback) {
     .then(function(responses) {
       self.latestResponse = responses[0];
       self.unpackResponse_(responses[0], callback);
-      if (!callback) {
-        if (self.latestResponse.error) {
-          throw self.latestResponse.error;
-        }
-        return [self.result, self.metadata, self.latestResponse];
-      }
+      return promisifyResponse();
     });
 
   if (!callback) {

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -184,8 +184,8 @@ Operation.prototype.listenForEvents_ = function() {
  * request.
  */
 Operation.prototype.cancel = function() {
-  if (this.currentCallPromise) {
-    this.currentCallPromise.cancel();
+  if (this.currentCallPromise_) {
+    this.currentCallPromise_.cancel();
   }
   var operationsClient = this.longrunningDescriptor.operationsClient;
   return operationsClient.cancelOperation({name: this.latestResponse.name});
@@ -230,10 +230,10 @@ Operation.prototype.getOperation = function(callback) {
     return;
   }
 
-  this.currentCallPromise =
+  this.currentCallPromise_ =
       operationsClient.getOperation({name: this.latestResponse.name});
 
-  this.currentCallPromise
+  var noCallbackPromise = this.currentCallPromise_
     .then(function(responses) {
       self.latestResponse = responses[0];
       self.unpackResponse_(responses[0], callback);
@@ -246,7 +246,7 @@ Operation.prototype.getOperation = function(callback) {
     });
 
   if (!callback) {
-    return this.currentCallPromise;
+    return noCallbackPromise;
   }
 };
 

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -209,6 +209,11 @@ Operation.prototype.cancel = function() {
  *
  * @param {getOperationCallback} callback - Callback to handle the polled
  * operation result and metadata.
+ * @return {Promise} - This returns a promise if a callback is not specified.
+ * The promise resolves to an array where the first element is the unpacked
+ * result, the second element is the metadata, and the third element is the raw
+ * response of the api call. The promise rejects if the operation returns an
+ * error.
  */
 Operation.prototype.getOperation = function(callback) {
   var self = this;
@@ -216,6 +221,12 @@ Operation.prototype.getOperation = function(callback) {
 
   if (this.latestResponse.done) {
     this.unpackResponse_(this.latestResponse, callback);
+    if (!callback) {
+      if (this.latestResponse.error) {
+        return Promise.reject(this.latestResponse.error);
+      }
+      return Promise.resolve([this.result, this.metadata, this.latestResponse]);
+    }
     return;
   }
 
@@ -226,9 +237,17 @@ Operation.prototype.getOperation = function(callback) {
     .then(function(responses) {
       self.latestResponse = responses[0];
       self.unpackResponse_(responses[0], callback);
-    }).catch(function(err) {
-      callback(err);
+      if (!callback) {
+        if (self.latestResponse.error) {
+          throw self.latestResponse.error;
+        }
+        return [self.result, self.metadata, self.latestResponse];
+      }
     });
+
+  if (!callback) {
+    return this.currentCallPromise;
+  }
 };
 
 Operation.prototype.unpackResponse_ = function(op, callback) {

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -1055,8 +1055,8 @@ describe('longrunning', function() {
               expect(metadata).to.deep.eq(METADATA_VAL);
               expect(rawResponse).to.deep.eq(SUCCESSFUL_OP);
               expect(client.getOperation.callCount).to.eq(1);
+              done();
             })).to.be.undefined;
-          done();
         }).catch(function(error) {
           done(error);
         });
@@ -1098,6 +1098,7 @@ describe('longrunning', function() {
         }).then(function(responses) {
           done(new Error('Should not get here.'));
         }).catch(function(error) {
+          expect(error).to.be.an('error');
           done();
         });
       });

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -1015,7 +1015,7 @@ describe('longrunning', function() {
         });
       });
 
-      it('it makes an api call to get the updated operation', function(done) {
+      it('makes an api call to get the updated operation', function(done) {
         var func = function(argument, metadata, options, callback) {
           callback(null, PENDING_OP);
         };
@@ -1035,6 +1035,70 @@ describe('longrunning', function() {
           });
         }).catch(function(error) {
           done(error);
+        });
+      });
+
+      it('does not return a promise when given a callback.', function(done) {
+        var func = function(argument, metadata, options, callback) {
+          callback(null, PENDING_OP);
+        };
+        var client = mockOperationsClient();
+        var apiCall = createLongrunningCall(func, client);
+        apiCall().then(function(responses) {
+          var operation = responses[0];
+          expect(operation.getOperation(
+            function(err, result, metadata, rawResponse) {
+              if (err) {
+                done(err);
+              }
+              expect(result).to.deep.eq(RESPONSE_VAL);
+              expect(metadata).to.deep.eq(METADATA_VAL);
+              expect(rawResponse).to.deep.eq(SUCCESSFUL_OP);
+              expect(client.getOperation.callCount).to.eq(1);
+            })).to.be.undefined;
+          done();
+        }).catch(function(error) {
+          done(error);
+        });
+      });
+
+      it('returns a promise that resolves to the correct data', function(done) {
+        var func = function(argument, metadata, options, callback) {
+          callback(null, PENDING_OP);
+        };
+        var client = mockOperationsClient();
+        var apiCall = createLongrunningCall(func, client);
+        apiCall().then(function(responses) {
+          var operation = responses[0];
+          return operation.getOperation();
+        }).then(function(responses) {
+          var result = responses[0];
+          var metadata = responses[1];
+          var rawResponse = responses[2];
+
+          expect(result).to.deep.eq(RESPONSE_VAL);
+          expect(metadata).to.deep.eq(METADATA_VAL);
+          expect(rawResponse).to.deep.eq(SUCCESSFUL_OP);
+          expect(client.getOperation.callCount).to.eq(1);
+          done();
+        }).catch(function(error) {
+          done(error);
+        });
+      });
+
+      it('returns a promise that rejects an operation error.', function(done) {
+        var func = function(argument, metadata, options, callback) {
+          callback(null, ERROR_OP);
+        };
+        var client = mockOperationsClient();
+        var apiCall = createLongrunningCall(func, client);
+        apiCall().then(function(responses) {
+          var operation = responses[0];
+          return operation.getOperation();
+        }).then(function(responses) {
+          done(new Error('Should not get here.'));
+        }).catch(function(error) {
+          done();
         });
       });
     });


### PR DESCRIPTION
Resolves #97
