### PR TITLE
Allow type of promise used to be varying.

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -121,12 +121,14 @@ Canceller.prototype.call = function(aFunc, argument) {
 /**
  * PromiseCanceller is Canceller, but it holds a promise when
  * the API call finishes.
+ * @param {Module} PromiseModule - A module that implements the ES6 specification of
+ * promise.
  * @constructor
  * @private
  */
-function PromiseCanceller() {
+function PromiseCanceller(PromiseModule) {
   var self = this;
-  this.promise = new Promise(function(resolve, reject) {
+  this.promise = new PromiseModule(function(resolve, reject) {
     Canceller.call(self, function(err) {
       if (err) {
         reject(err);
@@ -286,7 +288,7 @@ NormalApiCaller.prototype.init = function(settings, callback) {
   if (callback) {
     return new Canceller(callback);
   }
-  return new PromiseCanceller();
+  return new PromiseCanceller(settings.promise);
 };
 
 NormalApiCaller.prototype.wrap = function(func) {

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -121,14 +121,14 @@ Canceller.prototype.call = function(aFunc, argument) {
 /**
  * PromiseCanceller is Canceller, but it holds a promise when
  * the API call finishes.
- * @param {Module} PromiseModule - A module that implements the ES6 specification of
- * promise.
+ * @param {Function} PromiseCtor - A constructor for a promise that implements
+ * the ES6 specification of promise.
  * @constructor
  * @private
  */
-function PromiseCanceller(PromiseModule) {
+function PromiseCanceller(PromiseCtor) {
   var self = this;
-  this.promise = new PromiseModule(function(resolve, reject) {
+  this.promise = new PromiseCtor(function(resolve, reject) {
     Canceller.call(self, function(err) {
       if (err) {
         reject(err);

--- a/lib/gax.js
+++ b/lib/gax.js
@@ -59,6 +59,9 @@
  * @property {boolean=} isBundling - If set to false and the call is configured
  *   for bundling, bundling is not performed.
  * @property {BackoffSettings=} longrunning - BackoffSettings used for polling.
+ * @property {Module=} promise - A module that implements the ES6
+ * specification of promise which will be used to create promises. If not
+ * provided, native promises will be used.
  * @example
  * // suppress bundling for bundled method.
  * api.bundlingMethod(
@@ -148,6 +151,9 @@
  *   the page streaming request.
  * @param {Object} settings.otherArgs - Additional arguments to be passed to
  *   the API calls.
+ * @param {Module=} settings.promise - A module that implements the ES6
+ * specification of promise which will be used to create promises. If not
+ * provided, native promises will be used.
  *
  * @constructor
  */
@@ -163,6 +169,7 @@ function CallSettings(settings) {
   this.isBundling = ('isBundling' in settings) ? settings.isBundling : true;
   this.longrunning =
       ('longrunning' in settings) ? settings.longrunning : null;
+  this.promise = ('promise' in settings) ? settings.promise : Promise;
 }
 exports.CallSettings = CallSettings;
 
@@ -185,6 +192,7 @@ CallSettings.prototype.merge = function merge(options) {
   var otherArgs = this.otherArgs;
   var isBundling = this.isBundling;
   var longrunning = this.longrunning;
+  var promise = this.promise;
   if ('timeout' in options) {
     timeout = options.timeout;
   }
@@ -224,6 +232,10 @@ CallSettings.prototype.merge = function merge(options) {
     longrunning = options.longrunning;
   }
 
+  if ('promise' in options) {
+    promise = options.promise;
+  }
+
   return new CallSettings({
     timeout: timeout,
     retry: retry,
@@ -232,7 +244,9 @@ CallSettings.prototype.merge = function merge(options) {
     autoPaginate: autoPaginate,
     pageToken: pageToken,
     otherArgs: otherArgs,
-    isBundling: isBundling});
+    isBundling: isBundling,
+    promise: promise
+  });
 };
 
 /**
@@ -515,12 +529,15 @@ function mergeRetryOptions(retry, overrides) {
  *   those codes.
  * @param {Object} otherArgs - the non-request arguments to be passed to the API
  *   calls.
+ * @param {Module=} promise - A module that implements the ES6
+ * specification of promise which will be used to create promises. If not
+ * provided, native promises will be used.
  * @return {Object} A mapping from method name to CallSettings, or null if the
  *   service is not found in the config.
  */
 exports.constructSettings = function constructSettings(
     serviceName, clientConfig, configOverrides,
-    retryNames, otherArgs) {
+    retryNames, otherArgs, promise) {
   otherArgs = otherArgs || {};
   var defaults = {};
 
@@ -564,7 +581,8 @@ exports.constructSettings = function constructSettings(
       retry: retry,
       bundleOptions:
         bundlingConfig ? createBundleOptions(bundlingConfig) : null,
-      otherArgs: otherArgs
+      otherArgs: otherArgs,
+      promise: promise || Promise
     });
   }
   return defaults;

--- a/lib/gax.js
+++ b/lib/gax.js
@@ -59,7 +59,7 @@
  * @property {boolean=} isBundling - If set to false and the call is configured
  *   for bundling, bundling is not performed.
  * @property {BackoffSettings=} longrunning - BackoffSettings used for polling.
- * @property {Module=} promise - A module that implements the ES6
+ * @property {Function=} promise - A constructor for a promise that implements the ES6
  * specification of promise which will be used to create promises. If not
  * provided, native promises will be used.
  * @example
@@ -151,9 +151,9 @@
  *   the page streaming request.
  * @param {Object} settings.otherArgs - Additional arguments to be passed to
  *   the API calls.
- * @param {Module=} settings.promise - A module that implements the ES6
- * specification of promise which will be used to create promises. If not
- * provided, native promises will be used.
+ * @param {Function=} settings.promise - A constructor for a promise that
+ * implements the ES6 specification of promise. If not provided, native promises
+ * will be used.
  *
  * @constructor
  */
@@ -529,9 +529,8 @@ function mergeRetryOptions(retry, overrides) {
  *   those codes.
  * @param {Object} otherArgs - the non-request arguments to be passed to the API
  *   calls.
- * @param {Module=} promise - A module that implements the ES6
- * specification of promise which will be used to create promises. If not
- * provided, native promises will be used.
+ * @param {Function=} promise - A constructor for a promise that implements the
+ * ES6 specification of promise. If not provided, native promises will be used.
  * @return {Object} A mapping from method name to CallSettings, or null if the
  *   service is not found in the config.
  */

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -48,6 +48,9 @@ var gax = require('./gax');
  * @param {Object=} options.grpc - When specified, this will be used
  *   for the 'grpc' module in this context. By default, it will load the grpc
  *   module in the standard way.
+ * @param {Module=} options.promise - A module that implements the ES6
+ * specification of promise which will be used to create promises. If not
+ * provided, native promises will be used.
  * @constructor
  */
 function GrpcClient(options) {
@@ -57,6 +60,7 @@ function GrpcClient(options) {
   options = options || {};
   this.auth = options.auth || autoAuth(options);
   this.grpc = options.grpc || require('grpc');
+  this.promise = options.promise || Promise;
 }
 module.exports = GrpcClient;
 
@@ -121,7 +125,8 @@ GrpcClient.prototype.constructSettings = function constructSettings(
       clientConfig,
       configOverrides,
       this.grpc.status,
-      {metadata: metadata});
+      {metadata: metadata},
+      this.promise);
 };
 
 /**
@@ -140,7 +145,8 @@ GrpcClient.prototype.createStub = function(
   options = options || {};
   var self = this;
   var serviceAddress = servicePath + ':' + port;
-  return new Promise(function(resolve, reject) {
+  var PromiseModule = this.promise;
+  return new PromiseModule(function(resolve, reject) {
     self.auth.getAuthClient(function(err, auth) {
       if (err) {
         reject(err);

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -48,9 +48,9 @@ var gax = require('./gax');
  * @param {Object=} options.grpc - When specified, this will be used
  *   for the 'grpc' module in this context. By default, it will load the grpc
  *   module in the standard way.
- * @param {Module=} options.promise - A module that implements the ES6
- * specification of promise which will be used to create promises. If not
- * provided, native promises will be used.
+ * @param {Function=} options.promise - A constructor for a promise that
+ * implements the ES6 specification of promise. If not provided, native promises
+ * will be used.
  * @constructor
  */
 function GrpcClient(options) {
@@ -145,8 +145,8 @@ GrpcClient.prototype.createStub = function(
   options = options || {};
   var self = this;
   var serviceAddress = servicePath + ':' + port;
-  var PromiseModule = this.promise;
-  return new PromiseModule(function(resolve, reject) {
+  var PromiseCtor = this.promise;
+  return new PromiseCtor(function(resolve, reject) {
     self.auth.getAuthClient(function(err, auth) {
       if (err) {
         reject(err);

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -226,13 +226,16 @@ Operation.prototype.getOperation = function(callback) {
 
   function promisifyResponse() {
     if (!callback) {
-      if (self.latestResponse.error) {
-        var error = new Error(self.latestReponse.error.message);
-        error.code = self.latestReponse.error.code;
-        return self._callOptions.promise.reject(error);
-      }
-      return self._callOptions.promise.resolve(
-        [self.result, self.metadata, self.latestResponse]);
+      var PromiseCtor = self._callOptions.promise;
+      return new PromiseCtor(function(resolve, reject) {
+        if (self.latestResponse.error) {
+          var error = new Error(self.latestReponse.error.message);
+          error.code = self.latestReponse.error.code;
+          reject(error);
+        } else {
+          resolve([self.result, self.metadata, self.latestResponse]);
+        }
+      });
     }
     return;
   }
@@ -360,8 +363,8 @@ Operation.prototype.startPolling_ = function() {
  */
 Operation.prototype.promise = function() {
   var self = this;
-  var PromiseModule = this._callOptions.promise;
-  return new PromiseModule(function(resolve, reject) {
+  var PromiseCtor = this._callOptions.promise;
+  return new PromiseCtor(function(resolve, reject) {
     self
       .on('error', reject)
       .on('complete', function(result, metadata, rawResponse) {

--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -113,7 +113,8 @@ LongrunningApiCaller.prototype._wrapOperation = function(
     var operation = new Operation(
       rawResponse,
       longrunningDescriptor,
-      backoffSettings
+      backoffSettings,
+      settings
     );
 
     callback(null, operation, rawResponse);
@@ -130,8 +131,11 @@ LongrunningApiCaller.prototype._wrapOperation = function(
  * operations service client and unpacking mechanisms for the operation.
  * @param {BackoffSettings} backoffSettings - The backoff settings used in
  * in polling the operation.
+ * @param {CallOptions=} callOptions - CallOptions used in making get operation
+ * requests.
  */
-function Operation(grpcOp, longrunningDescriptor, backoffSettings) {
+function Operation(
+  grpcOp, longrunningDescriptor, backoffSettings, callOptions) {
   events.EventEmitter.call(this);
   this.completeListeners = 0;
   this.hasActiveListeners = false;
@@ -141,8 +145,9 @@ function Operation(grpcOp, longrunningDescriptor, backoffSettings) {
   this.result = null;
   this.metadata = null;
   this.backoffSettings = backoffSettings;
-  this.unpackResponse_(grpcOp);
-  this.listenForEvents_();
+  this._unpackResponse(grpcOp);
+  this._listenForEvents();
+  this._callOptions = callOptions;
 }
 util.inherits(Operation, events.EventEmitter);
 
@@ -156,7 +161,7 @@ util.inherits(Operation, events.EventEmitter);
  *
  * @private
  */
-Operation.prototype.listenForEvents_ = function() {
+Operation.prototype._listenForEvents = function() {
   var self = this;
 
   this.on('newListener', function(event) {
@@ -224,25 +229,27 @@ Operation.prototype.getOperation = function(callback) {
       if (self.latestResponse.error) {
         var error = new Error(self.latestReponse.error.message);
         error.code = self.latestReponse.error.code;
-        return Promise.reject(error);
+        return self._callOptions.promise.reject(error);
       }
-      return Promise.resolve([self.result, self.metadata, self.latestResponse]);
+      return self._callOptions.promise.resolve(
+        [self.result, self.metadata, self.latestResponse]);
     }
     return;
   }
 
   if (this.latestResponse.done) {
-    this.unpackResponse_(this.latestResponse, callback);
+    this._unpackResponse(this.latestResponse, callback);
     return promisifyResponse();
   }
 
   this.currentCallPromise_ =
-      operationsClient.getOperation({name: this.latestResponse.name});
+      operationsClient.getOperation(
+        {name: this.latestResponse.name}, this._callOptions);
 
   var noCallbackPromise = this.currentCallPromise_
     .then(function(responses) {
       self.latestResponse = responses[0];
-      self.unpackResponse_(responses[0], callback);
+      self._unpackResponse(responses[0], callback);
       return promisifyResponse();
     });
 
@@ -251,7 +258,7 @@ Operation.prototype.getOperation = function(callback) {
   }
 };
 
-Operation.prototype.unpackResponse_ = function(op, callback) {
+Operation.prototype._unpackResponse = function(op, callback) {
   var responseDecoder = this.longrunningDescriptor.responseDecoder;
   var metadataDecoder = this.longrunningDescriptor.metadataDecoder;
   var response;
@@ -353,8 +360,8 @@ Operation.prototype.startPolling_ = function() {
  */
 Operation.prototype.promise = function() {
   var self = this;
-
-  return new Promise(function(resolve, reject) {
+  var PromiseModule = this._callOptions.promise;
+  return new PromiseModule(function(resolve, reject) {
     self
       .on('error', reject)
       .on('complete', function(result, metadata, rawResponse) {
@@ -363,7 +370,22 @@ Operation.prototype.promise = function() {
   });
 };
 
-exports.operation = function(op, longrunningDescriptor, backoffSettings) {
-  return new Operation(op, longrunningDescriptor, backoffSettings);
-};
+/**
+ * Method used to create Operation objects.
+ *
+ * @constructor
+ *
+ * @param {google.longrunning.Operation} op - The operation to be wrapped.
+ * @param {LongrunningDescriptor} longrunningDescriptor - This defines the
+ * operations service client and unpacking mechanisms for the operation.
+ * @param {BackoffSettings} backoffSettings - The backoff settings used in
+ * in polling the operation.
+ * @param {CallOptions=} callOptions - CallOptions used in making get operation
+ * requests.
+ */
+exports.operation =
+  function(op, longrunningDescriptor, backoffSettings, callOptions) {
+    return new Operation(
+      op, longrunningDescriptor, backoffSettings, callOptions);
+  };
 

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -158,6 +158,25 @@ describe('Promise', function() {
       done();
     })).to.be.undefined;
   });
+
+  it('uses a provided promise module.', function(done) {
+    var called = false;
+    function MockPromise(resolver) {
+      called = true;
+      return new Promise(resolver);
+    }
+
+    function func(argument, metadata, options, callback) {
+      callback(null, 42);
+    }
+    var apiCall = createApiCall(func);
+    apiCall(null, {promise: MockPromise}).then(function(response) {
+      expect(response).to.be.an('array');
+      expect(response[0]).to.eq(42);
+      expect(called).to.be.true;
+      done();
+    }).catch(done);
+  });
 });
 
 describe('retryable', function() {

--- a/test/longrunning.js
+++ b/test/longrunning.js
@@ -91,6 +91,12 @@ var ERROR_OP = {
 };
 var mockDecoder = function(val) { return val.toString(); };
 
+function MockPromise(executor) {
+  var promise = new Promise(executor);
+  promise.isMock = true;
+  return promise;
+}
+
 function createApiCall(func, client) {
   var descriptor = new longrunning.LongrunningDescriptor(
         client, mockDecoder, mockDecoder);
@@ -311,6 +317,24 @@ describe('longrunning', function() {
           done();
         });
       });
+
+      it('uses provided promiseModule when resolving.', function(done) {
+        var func = function(argument, metadata, options, callback) {
+          callback(null, PENDING_OP);
+        };
+
+        var client = mockOperationsClient();
+        var apiCall = createApiCall(func, client);
+        var resolveSpy = sinon.spy(Promise.resolve);
+        MockPromise.resolve = resolveSpy;
+        apiCall(null, {promise: MockPromise}).then(function(responses) {
+          var operation = responses[0];
+          return operation.getOperation();
+        }).then(function() {
+          expect(resolveSpy.called).to.be.true;
+          done();
+        });
+      });
     });
 
     describe('promise', function() {
@@ -361,6 +385,30 @@ describe('longrunning', function() {
           expect(err.message).to.deep.eq('operation error');
           done();
         });
+      });
+
+      it('uses provided promiseModule', function(done) {
+        var client = mockOperationsClient();
+        var desc = new longrunning.LongrunningDescriptor(
+          client, mockDecoder, mockDecoder);
+        var initialRetryDelayMillis = 1;
+        var retryDelayMultiplier = 2;
+        var maxRetryDelayMillis = 3;
+        var totalTimeoutMillis = 4;
+        var unusedRpcValue = 0;
+        var backoff = gax.createBackoffSettings(
+          initialRetryDelayMillis,
+          retryDelayMultiplier,
+          maxRetryDelayMillis,
+          unusedRpcValue,
+          unusedRpcValue,
+          unusedRpcValue,
+          totalTimeoutMillis);
+        var operation = longrunning.operation(
+          SUCCESSFUL_OP, desc, backoff, {promise: MockPromise});
+        var promise = operation.promise();
+        expect(promise.isMock).to.be.true;
+        done();
       });
     });
 


### PR DESCRIPTION
The PR allows for gapic-clients to be able to be passed a module that fulfills the ES6 specification of promises and use that module for creating promises.

Example: Specify promise at instantiation.
```js
var exampleV1 = require('@google-cloud/example').v1({
  promise: require('bluebird')
});

// Any client created from exampleV1 will be using bluebird now.
var client = exampleV1.libraryClient();
```

Example: Specify promise at method invokation.
```js
var exampleV1 = require('@google-cloud/example').v1({});

var client = exampleV1.libraryClient();

client.getBook(name, {
  promise: require('bluebird')
}).then(function(responses) {
  ...
});
```