### PR TITLE
Update grpc dependency version to ~1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [
@@ -10,7 +10,7 @@
     "extend": "^3.0.0",
     "google-auto-auth": "^0.5.2",
     "google-proto-files": "^0.8.3",
-    "grpc": "~1.0",
+    "grpc": "~1.1",
     "lodash": "^4.17.2",
     "process-nextick-args": "^1.0.7",
     "readable-stream": "^2.2.2"


### PR DESCRIPTION
Due to the grpc releases of 1.1.x.
See also:
https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1946