### PR TITLE
Modify the handling of the new API header.

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -155,17 +155,20 @@ util.inherits(PromiseCanceller, Canceller);
  * @param {number} timeout - to be added to the original function as it final
  *   positional arg.
  * @param {Object} otherArgs - the additional arguments to be passed to aFunc.
+ * @param {Object=} abTests - the A/B testing key/value pairs.
  * @return {function(Object, APICallback)}
  *  the function with other arguments and the timeout.
  */
-function addTimeoutArg(aFunc, timeout, otherArgs) {
+function addTimeoutArg(aFunc, timeout, otherArgs, abTests) {
   // TODO: this assumes the other arguments consist of metadata and options,
   // which is specific to gRPC calls. Remove the hidden dependency on gRPC.
   return function timeoutFunc(argument, callback) {
     var now = new Date();
     var options = otherArgs.options || {};
     options.deadline = new Date(now.getTime() + timeout);
-    return aFunc(argument, otherArgs.metadata, options, callback);
+    var metadata =
+      otherArgs.metadataBuilder ? otherArgs.metadataBuilder(abTests) : null;
+    return aFunc(argument, metadata, options, callback);
   };
 }
 
@@ -210,6 +213,7 @@ function retryable(aFunc, retry, otherArgs) {
     }
     var retries = 0;
     var maxRetries = retry.backoffSettings.maxRetries;
+    var abTests = {retry: (maxRetries ? '1' : '2')};
 
     /** Repeat the API call as long as necessary. */
     function repeat() {
@@ -227,7 +231,7 @@ function retryable(aFunc, retry, otherArgs) {
       }
 
       retries++;
-      var toCall = addTimeoutArg(aFunc, timeout, otherArgs);
+      var toCall = addTimeoutArg(aFunc, timeout, otherArgs, abTests);
       canceller = toCall(argument, function(err) {
         if (!err) {
           var args = Array.prototype.slice.call(arguments, 1);

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -213,7 +213,7 @@ function retryable(aFunc, retry, otherArgs) {
     }
     var retries = 0;
     var maxRetries = retry.backoffSettings.maxRetries;
-    var abTests = {retry: (maxRetries ? '1' : '2')};
+    // TODO: define A/B testing values for retry behaviors.
 
     /** Repeat the API call as long as necessary. */
     function repeat() {
@@ -231,7 +231,7 @@ function retryable(aFunc, retry, otherArgs) {
       }
 
       retries++;
-      var toCall = addTimeoutArg(aFunc, timeout, otherArgs, abTests);
+      var toCall = addTimeoutArg(aFunc, timeout, otherArgs);
       canceller = toCall(argument, function(err) {
         if (!err) {
           var args = Array.prototype.slice.call(arguments, 1);

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -62,7 +62,8 @@ function GrpcClient(options) {
   this.promise = options.promise || Promise;
   if ('grpc' in options) {
     this.grpc = options.grpc;
-    this.grpcVersion = 'UNKNOWN';
+    // TODO: decide the string in case grpc version is not known.
+    this.grpcVersion = require('grpc/package.json').version;
   } else {
     this.grpc = require('grpc');
     this.grpcVersion = require('grpc/package.json').version;

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -62,8 +62,7 @@ function GrpcClient(options) {
   this.promise = options.promise || Promise;
   if ('grpc' in options) {
     this.grpc = options.grpc;
-    // TODO: decide the string in case grpc version is not known.
-    this.grpcVersion = require('grpc/package.json').version;
+    this.grpcVersion = '';
   } else {
     this.grpc = require('grpc');
     this.grpcVersion = require('grpc/package.json').version;

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -108,23 +108,10 @@ GrpcClient.prototype.load = function(args) {
 GrpcClient.prototype.metadataBuilder = function(headers) {
   var Metadata = this.grpc.Metadata;
   return function buildMetadata(abTests) {
-    abTests = abTests || {};
+    // TODO: bring the A/B testing info into the metadata.
     var metadata = new Metadata();
     for (var key in headers) {
-      var val = headers[key];
-      if (key.toLowerCase() === 'x-goog-api-client') {
-        var abTestTokens = [];
-        var abCount = 1;
-        for (var testKey in abTests) {
-          abTestTokens.push('gl-abkey' + abCount + '/' + testKey);
-          abTestTokens.push('gl-abval' + abCount + '/' + abTests[testKey]);
-          abCount++;
-        }
-        if (abTestTokens.length > 0) {
-          val += ' ' + abTestTokens.join(' ');
-        }
-      }
-      metadata.set(key, val);
+      metadata.set(key, headers[key]);
     }
     return metadata;
   };

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -59,8 +59,14 @@ function GrpcClient(options) {
   }
   options = options || {};
   this.auth = options.auth || autoAuth(options);
-  this.grpc = options.grpc || require('grpc');
   this.promise = options.promise || Promise;
+  if ('grpc' in options) {
+    this.grpc = options.grpc;
+    this.grpcVersion = 'UNKNOWN';
+  } else {
+    this.grpc = require('grpc');
+    this.grpcVersion = require('grpc/package.json').version;
+  }
 }
 module.exports = GrpcClient;
 
@@ -99,6 +105,31 @@ GrpcClient.prototype.load = function(args) {
   return this.grpc.load.apply(this.grpc, args);
 };
 
+GrpcClient.prototype.metadataBuilder = function(headers) {
+  var Metadata = this.grpc.Metadata;
+  return function buildMetadata(abTests) {
+    abTests = abTests || {};
+    var metadata = new Metadata();
+    for (var key in headers) {
+      var val = headers[key];
+      if (key.toLowerCase() === 'x-goog-api-client') {
+        var abTestTokens = [];
+        var abCount = 1;
+        for (var testKey in abTests) {
+          abTestTokens.push('gl-abkey' + abCount + '/' + testKey);
+          abTestTokens.push('gl-abval' + abCount + '/' + abTests[testKey]);
+          abCount++;
+        }
+        if (abTestTokens.length > 0) {
+          val += ' ' + abTestTokens.join(' ');
+        }
+      }
+      metadata.set(key, val);
+    }
+    return metadata;
+  };
+};
+
 /**
  * A wrapper of {@link constructSettings} function with under the gRPC context.
  *
@@ -115,17 +146,12 @@ GrpcClient.prototype.constructSettings = function constructSettings(
     clientConfig,
     configOverrides,
     headers) {
-  var metadata = new this.grpc.Metadata();
-  for (var key in headers) {
-    metadata.set(key, headers[key]);
-  }
-
   return gax.constructSettings(
       serviceName,
       clientConfig,
       configOverrides,
       this.grpc.status,
-      {metadata: metadata},
+      {metadataBuilder: this.metadataBuilder(headers)},
       this.promise);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -379,7 +379,7 @@ describe('retryable', function() {
     });
   });
 
-  it('reports A/B testing', function() {
+  it.skip('reports A/B testing', function() {
     function func(argument, metadata, options, callback) {
       callback(null, argument);
     }

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -378,4 +378,35 @@ describe('retryable', function() {
       done();
     });
   });
+
+  it('reports A/B testing', function() {
+    function func(argument, metadata, options, callback) {
+      callback(null, argument);
+    }
+    var mockBuilder = sinon.mock();
+    var settings = {settings: {
+      timeout: 0,
+      retry: retryOptions,
+      otherArgs: {metadataBuilder: mockBuilder}
+    }};
+    var apiCall = createApiCall(func, settings);
+    mockBuilder.withExactArgs({retry: '2'});
+    return apiCall(null, null).then(function() {
+      mockBuilder.verify();
+      mockBuilder.reset();
+      var backoff = gax.createMaxRetriesBackoffSettings(
+        0, 0, 0, 0, 0, 0, 5);
+      mockBuilder.withExactArgs({retry: '1'});
+      return apiCall(null, {retry: utils.createRetryOptions(backoff)});
+    }).then(function() {
+      mockBuilder.verify();
+      mockBuilder.reset();
+      mockBuilder.withExactArgs({retry: '2'});
+      var options =
+        {retry: utils.createRetryOptions(0, 0, 0, 0, 0, 0, 200)};
+      return apiCall(null, options);
+    }).then(function() {
+      mockBuilder.verify();
+    });
+  });
 });

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -40,7 +40,7 @@ describe('grpc', function() {
       expect(gaxGrpc().grpcVersion).to.eq(grpcVersion);
     });
 
-    it('returns unknown when grpc module is injected', function() {
+    it('returns unknown when grpc module is mocked', function() {
       var mockGrpc = {};
       expect(gaxGrpc({grpc: mockGrpc}).grpcVersion).to.eq('');
     });
@@ -53,7 +53,7 @@ describe('grpc', function() {
       var headers = {
         'X-Dummy-Header': 'Dummy value',
         'Other-Header': 'Other value',
-        'X-Goog-Api-Client': 'gl-node/nodeVersion gax/gaxVersion'
+        'X-Goog-Api-Client': 'gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0'
       };
       var builder = grpcClient.metadataBuilder(headers);
       var metadata = builder();

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -40,9 +40,9 @@ describe('grpc', function() {
       expect(gaxGrpc().grpcVersion).to.eq(grpcVersion);
     });
 
-    it.skip('returns unknown when grpc module is injected', function() {
+    it('returns unknown when grpc module is injected', function() {
       var mockGrpc = {};
-      expect(gaxGrpc({grpc: mockGrpc}).grpcVersion).to.eq('UNKNOWN');
+      expect(gaxGrpc({grpc: mockGrpc}).grpcVersion).to.eq('');
     });
   });
 

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -1,0 +1,83 @@
+/* Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+var gaxGrpc = require('../lib/grpc');
+var expect = require('chai').expect;
+
+describe('grpc', function() {
+  describe('grpcVersion', function() {
+    it('holds the proper grpc version', function() {
+      var grpcVersion = require('grpc/package.json').version;
+      expect(gaxGrpc().grpcVersion).to.eq(grpcVersion);
+    });
+
+    it('returns unknown when grpc module is injected', function() {
+      var mockGrpc = {};
+      expect(gaxGrpc({grpc: mockGrpc}).grpcVersion).to.eq('UNKNOWN');
+    });
+  });
+
+  describe('metadataBuilder', function() {
+    var grpcClient = gaxGrpc();
+
+    it('builds metadata', function() {
+      var headers = {
+        'X-Dummy-Header': 'Dummy value',
+        'Other-Header': 'Other value',
+        'X-Goog-Api-Client': 'gl-node/nodeVersion gax/gaxVersion'
+      };
+      var builder = grpcClient.metadataBuilder(headers);
+      var metadata = builder();
+      for (var key in headers) {
+        expect(metadata.get(key)).to.deep.eq([headers[key]]);
+      }
+    });
+
+    it('customize api-client header for A/B testing', function() {
+      var headers = {
+        'X-Goog-Api-Client': 'gl-node/nodeVersion gax/gaxVersion'
+      };
+      var builder = grpcClient.metadataBuilder(headers);
+      var metadata = builder({retry: '1'});
+      expect(metadata.get('X-Goog-Api-Client')).to.deep.eq(
+        ['gl-node/nodeVersion gax/gaxVersion gl-abkey1/retry gl-abval1/1']);
+
+      metadata = builder({retry: '2'});
+      expect(metadata.get('X-Goog-Api-Client')).to.deep.eq(
+        ['gl-node/nodeVersion gax/gaxVersion gl-abkey1/retry gl-abval1/2']);
+
+      metadata = builder();
+      expect(metadata.get('X-Goog-Api-Client')).to.deep.eq(
+        ['gl-node/nodeVersion gax/gaxVersion']);
+    });
+  });
+});

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -46,7 +46,7 @@ describe('grpc', function() {
     });
   });
 
-  describe('metadataBuilder', function() {
+  describe.skip('metadataBuilder', function() {
     var grpcClient = gaxGrpc();
 
     it('builds metadata', function() {

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -46,7 +46,7 @@ describe('grpc', function() {
     });
   });
 
-  describe.skip('metadataBuilder', function() {
+  describe('metadataBuilder', function() {
     var grpcClient = gaxGrpc();
 
     it('builds metadata', function() {
@@ -62,7 +62,7 @@ describe('grpc', function() {
       }
     });
 
-    it('customize api-client header for A/B testing', function() {
+    it.skip('customize api-client header for A/B testing', function() {
       var headers = {
         'X-Goog-Api-Client': 'gl-node/nodeVersion gax/gaxVersion'
       };

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -40,7 +40,7 @@ describe('grpc', function() {
       expect(gaxGrpc().grpcVersion).to.eq(grpcVersion);
     });
 
-    it('returns unknown when grpc module is injected', function() {
+    it.skip('returns unknown when grpc module is injected', function() {
       var mockGrpc = {};
       expect(gaxGrpc({grpc: mockGrpc}).grpcVersion).to.eq('UNKNOWN');
     });


### PR DESCRIPTION
This PR allows the A/B testing values for X-Goog-Api-Client header.
Also grpcVersion field is added -- this is going to be used
by the generated code to build the base header value.