### PR TITLE
Add the code path to skip auth.

### DIFF
--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -58,7 +58,8 @@ function GrpcClient(options) {
     return new GrpcClient(options);
   }
   options = options || {};
-  this.auth = options.auth || autoAuth(options);
+  this.auth =
+    (options.auth || options.auth === false) ? options.auth : autoAuth(options);
   this.promise = options.promise || Promise;
   if ('grpc' in options) {
     this.grpc = options.grpc;
@@ -81,6 +82,9 @@ module.exports = GrpcClient;
  */
 GrpcClient.prototype._getCredentials = function _getCredentials(opts, auth) {
   var sslCreds = opts.sslCreds || this.grpc.credentials.createSsl();
+  if (!this.auth) {
+    return sslCreds;
+  }
   var credentials = this.grpc.credentials.combineChannelCredentials(
       sslCreds,
       this.grpc.credentials.createFromGoogleCredential(auth)
@@ -159,6 +163,10 @@ GrpcClient.prototype.createStub = function(CreateStub, options) {
   var serviceAddress = options.servicePath + ':' + options.port;
   var PromiseCtor = this.promise;
   return new PromiseCtor(function(resolve, reject) {
+    if (!self.auth) {
+      resolve(null);
+      return;
+    }
     self.auth.getAuthClient(function(err, auth) {
       if (err) {
         reject(err);

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -89,17 +89,18 @@ describe('grpc', function() {
       this.options = options;
     }
     var grpcClient;
+    var stubGrpc;
     var dummyChannelCreds = {channelCreds: 'dummyChannelCreds'};
+    var dummySslCreds = {sslCreds: 'dummySslCreds'};
 
     beforeEach(function() {
       var stubAuth = {getAuthClient: sinon.stub()};
-      var stubGrpc = {credentials: {
+      stubGrpc = {credentials: {
         createSsl: sinon.stub(),
         combineChannelCredentials: sinon.stub(),
         createFromGoogleCredential: sinon.stub()
       }};
       var dummyAuth = {authData: 'dummyAuth'};
-      var dummySslCreds = {sslCreds: 'dummySslCreds'};
       var dummyGrpcAuth = {grpcAuth: 'dummyGrpcAuth'};
       stubAuth.getAuthClient.callsArgWith(0, null, dummyAuth);
       stubGrpc.credentials.createSsl.returns(dummySslCreds);
@@ -135,6 +136,19 @@ describe('grpc', function() {
         expect(stub.options).has.key([
           'grpc.max_send_message_length',
           'grpc.initial_reconnect_backoff_ms']);
+      });
+    });
+
+    it('disables auth', function() {
+      var opts = {servicePath: 'foo.example.com', port: 443};
+      grpcClient = gaxGrpc({auth: false, grpc: stubGrpc});
+      return grpcClient.createStub(DummyStub, opts).then(function(stub) {
+        expect(stub).to.be.an.instanceOf(DummyStub);
+        expect(stub.address).to.eq('foo.example.com:443');
+        expect(stub.creds).to.deep.eq(dummySslCreds);
+        expect(stubGrpc.credentials.createSsl.callCount).to.eq(1);
+        expect(stubGrpc.credentials.createFromGoogleCredential.callCount).to.eq(0);
+        expect(stubGrpc.credentials.combineChannelCredentials.callCount).to.eq(0);
       });
     });
   });


### PR DESCRIPTION
It skips the auth code path (getAuthClient() and
combineChannelCredentials) when auth: false is exactly specified.

This will be helpful for API developers, allow clients connect
to a testing server which has no auth.

Fixes #119