### PR TITLE
Allow users to pass in headers at method call.

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -170,7 +170,7 @@ function addTimeoutArg(aFunc, timeout, otherArgs, abTests) {
       otherArgs.metadataBuilder ? otherArgs.metadataBuilder(abTests) : null;
     var headers = otherArgs.headers || {};
     for (var key in headers) {
-      if (headers.hasOwnProperty(key)) {
+      if (key !== 'x-goog-api-client' && headers.hasOwnProperty(key)) {
         metadata.set(key, headers[key]);
       }
     }

--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -168,6 +168,12 @@ function addTimeoutArg(aFunc, timeout, otherArgs, abTests) {
     options.deadline = new Date(now.getTime() + timeout);
     var metadata =
       otherArgs.metadataBuilder ? otherArgs.metadataBuilder(abTests) : null;
+    var headers = otherArgs.headers || {};
+    for (var key in headers) {
+      if (headers.hasOwnProperty(key)) {
+        metadata.set(key, headers[key]);
+      }
+    }
     return aFunc(argument, metadata, options, callback);
   };
 }

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -435,4 +435,31 @@ describe('retryable', function() {
       done();
     });
   });
+
+  it('does not override \'x-goog-api-client\' headers', function(done) {
+    function func(argument, metadata, options, callback) {
+      callback();
+    }
+
+    var setSpy = sinon.spy();
+    var metadata = {set: setSpy};
+    var mockBuilder = function() {
+      return metadata;
+    };
+    var settings = {settings: {
+      otherArgs: {metadataBuilder: mockBuilder}
+    }};
+    var apiCall = createApiCall(func, settings);
+    var headers = {
+      'x-goog-api-client': 'header',
+      'h1': 'val1',
+      'h2': 'val2'
+    };
+    apiCall(null, {otherArgs: {headers: headers}}).then(function() {
+      expect(setSpy.callCount).to.equal(2);
+      expect(setSpy.firstCall.args).to.deep.equal(['h1', 'val1']);
+      expect(setSpy.secondCall.args).to.deep.equal(['h2', 'val2']);
+      done();
+    });
+  });
 });

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -409,4 +409,30 @@ describe('retryable', function() {
       mockBuilder.verify();
     });
   });
+
+  it('uses sets metadata headers with users headers', function(done) {
+    function func(argument, metadata, options, callback) {
+      callback();
+    }
+
+    var setSpy = sinon.spy();
+    var metadata = {set: setSpy};
+    var mockBuilder = function() {
+      return metadata;
+    };
+    var settings = {settings: {
+      otherArgs: {metadataBuilder: mockBuilder}
+    }};
+    var apiCall = createApiCall(func, settings);
+    var headers = {
+      h1: 'val1',
+      h2: 'val2'
+    };
+    apiCall(null, {otherArgs: {headers: headers}}).then(function() {
+      expect(setSpy.callCount).to.equal(2);
+      expect(setSpy.firstCall.args).to.deep.equal(['h1', 'val1']);
+      expect(setSpy.secondCall.args).to.deep.equal(['h2', 'val2']);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
cc @stephenplusplus 

This should help users set other headers as needed [here](https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2195#discussion_r110702349)