### PR TITLE
Version bump for 13.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This is to include #129, #130 to help with [google-cloud-node/pull/2195](https://github.com/GoogleCloudPlatform/google-cloud-node/pull/2195)