### PR TITLE
getAuthClient is an instance method

### DIFF
--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -84,7 +84,7 @@ GrpcClient.prototype._getCredentials = function _getCredentials(opts) {
     return PromiseCtor.resolve(opts.sslCreds);
   }
   var grpc = this.grpc;
-  var getAuthClient = this.auth.getAuthClient;
+  var getAuthClient = this.auth.getAuthClient.bind(this.auth);
   var sslCreds = grpc.credentials.createSsl();
   return new PromiseCtor(function(resolve, reject) {
     getAuthClient(function(err, auth) {


### PR DESCRIPTION
Without this fix, I am getting unhandled rejections with the `@google-cloud/logging`.

```
❯ node --trace-warnings index.js
[ 0, 4282461 ]
undefined
(node:44617) TypeError: Cannot read property 'config' of undefined
    at Auth.getAuthClient (/Users/ofrobots/tmp/log-t/node_modules/google-gax/node_modules/google-auto-auth/index.js:38:20)
    at /Users/ofrobots/tmp/log-t/node_modules/google-gax/lib/grpc.js:90:5
    at GrpcClient._getCredentials (/Users/ofrobots/tmp/log-t/node_modules/google-gax/lib/grpc.js:89:10)
    at GrpcClient.createStub (/Users/ofrobots/tmp/log-t/node_modules/google-gax/lib/grpc.js:172:15)
    at new LoggingServiceV2Client (/Users/ofrobots/tmp/log-t/node_modules/@google-cloud/logging/src/v2/logging_service_v2_client.js:122:38)
    at Object.LoggingServiceV2ClientBuilder.loggingServiceV2Client (/Users/ofrobots/tmp/log-t/node_modules/@google-cloud/logging/src/v2/logging_service_v2_client.js:832:12)
    at /Users/ofrobots/tmp/log-t/node_modules/@google-cloud/logging/src/index.js:603:52
    at Immediate.<anonymous> (/Users/ofrobots/tmp/log-t/node_modules/google-auto-auth/index.js:146:7)
    at runCallback (timers.js:672:20)
    at tryOnImmediate (timers.js:645:5)
```

<details>

```js
'use strict'

var gcl = require('@google-cloud/logging')();

var gclog = gcl.log('syslog-benchmark');


var t = process.hrtime();
var max = 2;
for (var i = 0; i < max; ++i) {
  gclog.info('hello world');
}

t = process.hrtime(t);
console.log(t);
```
</details>