### PR TITLE
Use 'timeout' for non-idempotent API calls.

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -353,7 +353,8 @@ exports.createApiCall = function createApiCall(
     var status = apiCaller.init(thisSettings, callback);
     funcWithAuth.then(function(func) {
       func = apiCaller.wrap(func);
-      if (thisSettings.retry && thisSettings.retry.retryCodes) {
+      var retry = thisSettings.retry;
+      if (retry && retry.retryCodes && retry.retryCodes.length > 0) {
         return retryable(func, thisSettings.retry, thisSettings.otherArgs);
       }
       return addTimeoutArg(func, thisSettings.timeout, thisSettings.otherArgs);


### PR DESCRIPTION
Fixes #136

I've double-checked the behavior of gax-python, and it has
the check like
`if this_settings.retry and this_settings.retry.retry_codes`

Similar code exists here, but JavaScript empty array [] is
truthy, so it passes to the retryable code path. It should check
if the code length explicitly to be consistent with other
languages.