### PR TITLE
Kill LRO total timeout.

### DIFF
--- a/lib/longrunning.js
+++ b/lib/longrunning.js
@@ -100,7 +100,7 @@ LongrunningApiCaller.prototype._wrapOperation = function(
   var backoffSettings = settings.longrunning;
   if (!backoffSettings) {
     backoffSettings =
-        createBackoffSettings(100, 1.3, 60000, null, null, null, 600000);
+        createBackoffSettings(100, 1.3, 60000, null, null, null, null);
   }
 
   var longrunningDescriptor = this.longrunningDescriptor;
@@ -308,7 +308,10 @@ Operation.prototype.startPolling_ = function() {
   var delayMult = this.backoffSettings.retryDelayMultiplier;
   var maxDelay = this.backoffSettings.maxRetryDelayMillis;
   var delay = this.backoffSettings.initialRetryDelayMillis;
-  var deadline = now.getTime() + this.backoffSettings.totalTimeoutMillis;
+  var deadline = Infinity;
+  if (this.backoffSettings.totalTimeoutMillis) {
+    deadline = now.getTime() + this.backoffSettings.totalTimeoutMillis;
+  }
   var previousMetadataBytes;
   if (this.latestResponse.metadata) {
     previousMetadataBytes = this.latestResponse.metadata.value;
@@ -391,4 +394,3 @@ exports.operation =
     return new Operation(
       op, longrunningDescriptor, backoffSettings, callOptions);
   };
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Google API Extensions",
   "main": "index.js",
   "files": [

--- a/test/longrunning.js
+++ b/test/longrunning.js
@@ -135,7 +135,7 @@ describe('longrunning', function() {
       var defaultInitialRetryDelayMillis = 100;
       var defaultRetryDelayMultiplier = 1.3;
       var defaultMaxRetryDelayMillis = 60000;
-      var defaultTotalTimeoutMillis = 600000;
+      var defaultTotalTimeoutMillis = null;
       var apiCall = createApiCall(func);
       apiCall().then(function(responses) {
         var operation = responses[0];


### PR DESCRIPTION
Florence reported a bug in Node where the LRO times out with a sufficiently large video.

After investigating, it turns out that this is because we have a hard-coded 10 minute total timeout. This is reasonable for most languages where this is a poll in the background that you can easily restart, but in Node, the operation provides `op.promise()` which is a one-and-done. Once the Promise is rejected, that is it. This makes even a very long timeout problematic.

While eventually we need to approach these settings differently as a whole, for the moment, this PR simply makes the timeout be `null` so that we can unblock video intelligence.

Assigned to @geigerj or @swcloud for review. Once either of you has approved, please feel free to merge and push to npm.