### PR TITLE
make metadata faster

### DIFF
--- a/lib/api_callable.js
+++ b/lib/api_callable.js
@@ -167,13 +167,7 @@ function addTimeoutArg(aFunc, timeout, otherArgs, abTests) {
     var options = otherArgs.options || {};
     options.deadline = new Date(now.getTime() + timeout);
     var metadata =
-      otherArgs.metadataBuilder ? otherArgs.metadataBuilder(abTests) : null;
-    var headers = otherArgs.headers || {};
-    for (var key in headers) {
-      if (key !== 'x-goog-api-client' && headers.hasOwnProperty(key)) {
-        metadata.set(key, headers[key]);
-      }
-    }
+      otherArgs.metadataBuilder ? otherArgs.metadataBuilder(abTests, otherArgs.headers || {}) : null;
     return aFunc(argument, metadata, options, callback);
   };
 }

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -120,11 +120,22 @@ GrpcClient.prototype.load = function(args) {
 
 GrpcClient.prototype.metadataBuilder = function(headers) {
   var Metadata = this.grpc.Metadata;
-  return function buildMetadata(abTests) {
+  var baseMetadata = new Metadata();
+  for (var key in headers) {
+    baseMetadata.set(key, headers[key]);
+  }
+  return function buildMetadata(abTests, moreHeaders) {
     // TODO: bring the A/B testing info into the metadata.
-    var metadata = new Metadata();
-    for (var key in headers) {
-      metadata.set(key, headers[key]);
+    var copied = false;
+    var metadata = baseMetadata;
+    for (var key in moreHeaders) {
+      if (key.toLowerCase() !== 'x-goog-api-client' && moreHeaders.hasOwnProperty(key)) {
+        if (!copied) {
+          copied = true;
+          metadata = metadata.clone();
+        }
+        metadata.set(key, moreHeaders[key]);
+      }
     }
     return metadata;
   };

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -456,8 +456,8 @@ describe('retryable', function() {
       h2: 'val2'
     };
     apiCall(null, {otherArgs: {headers: headers}}).then(function() {
-      expect(gotHeaders['h1']).to.deep.equal('val1');
-      expect(gotHeaders['h2']).to.deep.equal('val2');
+      expect(gotHeaders.h1).to.deep.equal('val1');
+      expect(gotHeaders.h2).to.deep.equal('val2');
       done();
     });
   });

--- a/test/api_callable.js
+++ b/test/api_callable.js
@@ -437,15 +437,15 @@ describe('retryable', function() {
     });
   });
 
-  it('uses sets metadata headers with users headers', function(done) {
+  it('forwards metadata to builder', function(done) {
     function func(argument, metadata, options, callback) {
       callback();
     }
 
-    var setSpy = sinon.spy();
-    var metadata = {set: setSpy};
-    var mockBuilder = function() {
-      return metadata;
+    var gotHeaders;
+    var mockBuilder = function(abTest, headers) {
+      console.log(headers);
+      gotHeaders = headers;
     };
     var settings = {settings: {
       otherArgs: {metadataBuilder: mockBuilder}
@@ -456,36 +456,8 @@ describe('retryable', function() {
       h2: 'val2'
     };
     apiCall(null, {otherArgs: {headers: headers}}).then(function() {
-      expect(setSpy.callCount).to.equal(2);
-      expect(setSpy.firstCall.args).to.deep.equal(['h1', 'val1']);
-      expect(setSpy.secondCall.args).to.deep.equal(['h2', 'val2']);
-      done();
-    });
-  });
-
-  it('does not override \'x-goog-api-client\' headers', function(done) {
-    function func(argument, metadata, options, callback) {
-      callback();
-    }
-
-    var setSpy = sinon.spy();
-    var metadata = {set: setSpy};
-    var mockBuilder = function() {
-      return metadata;
-    };
-    var settings = {settings: {
-      otherArgs: {metadataBuilder: mockBuilder}
-    }};
-    var apiCall = createApiCall(func, settings);
-    var headers = {
-      'x-goog-api-client': 'header',
-      'h1': 'val1',
-      'h2': 'val2'
-    };
-    apiCall(null, {otherArgs: {headers: headers}}).then(function() {
-      expect(setSpy.callCount).to.equal(2);
-      expect(setSpy.firstCall.args).to.deep.equal(['h1', 'val1']);
-      expect(setSpy.secondCall.args).to.deep.equal(['h2', 'val2']);
+      expect(gotHeaders['h1']).to.deep.equal('val1');
+      expect(gotHeaders['h2']).to.deep.equal('val2');
       done();
     });
   });

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -71,9 +71,9 @@ describe('grpc', function() {
       };
       var builder = grpcClient.metadataBuilder(headers);
       var abTesting = null;
-      var moreHeaders = {'foo': 'bar'};
+      var moreHeaders = {foo: 'bar'};
       var metadata = builder(abTesting, moreHeaders);
-      expect(metadata.get('foo')).to.deep.eq(['bar'])
+      expect(metadata.get('foo')).to.deep.eq(['bar']);
     });
 
     it('does not override x-goog-api-client', function() {
@@ -86,7 +86,8 @@ describe('grpc', function() {
       var abTesting = null;
       var moreHeaders = {'x-GOOG-api-CLIENT': 'something else'};
       var metadata = builder(abTesting, moreHeaders);
-      expect(metadata.get('x-goog-api-client')).to.deep.eq(['gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0'])
+      expect(metadata.get('x-goog-api-client'))
+        .to.deep.eq(['gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0']);
     });
 
     it.skip('customize api-client header for A/B testing', function() {

--- a/test/grpc.js
+++ b/test/grpc.js
@@ -63,6 +63,32 @@ describe('grpc', function() {
       }
     });
 
+    it('adds user metadata', function() {
+      var headers = {
+        'X-Dummy-Header': 'Dummy value',
+        'Other-Header': 'Other value',
+        'X-Goog-Api-Client': 'gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0'
+      };
+      var builder = grpcClient.metadataBuilder(headers);
+      var abTesting = null;
+      var moreHeaders = {'foo': 'bar'};
+      var metadata = builder(abTesting, moreHeaders);
+      expect(metadata.get('foo')).to.deep.eq(['bar'])
+    });
+
+    it('does not override x-goog-api-client', function() {
+      var headers = {
+        'X-Dummy-Header': 'Dummy value',
+        'Other-Header': 'Other value',
+        'X-Goog-Api-Client': 'gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0'
+      };
+      var builder = grpcClient.metadataBuilder(headers);
+      var abTesting = null;
+      var moreHeaders = {'x-GOOG-api-CLIENT': 'something else'};
+      var metadata = builder(abTesting, moreHeaders);
+      expect(metadata.get('x-goog-api-client')).to.deep.eq(['gl-node/6.6.0 gccl/0.7.0 gax/0.11.0 grpc/1.1.0'])
+    });
+
     it.skip('customize api-client header for A/B testing', function() {
       var headers = {
         'X-Goog-Api-Client': 'gl-node/nodeVersion gax/gaxVersion'


### PR DESCRIPTION
Instead of creating fresh metadata every time,
we keep a copy-on-write instance.
In the hopefully-common case that the users don't need
to insert any metadata, we don't need to create new ones.

This commit also fixes a bug related to x-goog-api-client header.
Previously we checked the key string against "x-goog-api-client"
and refuse to insert the value if the key matches.
This is incorrect because header key is case-insensitive;
by making any character upper case, the key-value pair can be overwritten.
This commit correctly compares ignoring case.