### PR TITLE
deps: bump google-auto-auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "extend": "^3.0.0",
     "globby": "^6.1.0",
-    "google-auto-auth": "^0.5.2",
+    "google-auto-auth": "^0.7.2",
     "google-proto-files": "^0.13.1",
     "grpc": "^1.2",
     "is-stream-ended": "^0.1.0",


### PR DESCRIPTION
This change picks up fixes introduced in v0.7.1 of `google-auto-auth`, notably related to context loss.