### PR TITLE
Update grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "globby": "^6.1.0",
     "google-auto-auth": "^0.7.2",
     "google-proto-files": "^0.13.1",
-    "grpc": "^1.2",
+    "grpc": "^1.7.1",
     "is-stream-ended": "^0.1.0",
     "lodash": "^4.17.2",
     "process-nextick-args": "^1.0.7",


### PR DESCRIPTION
Disallow cached versions of gRPC.

Related: https://github.com/GoogleCloudPlatform/google-cloud-node/issues/2699