### PR TITLE
Limits being called "exceeded" when being hit exactly #149

### DIFF
--- a/lib/bundling.js
+++ b/lib/bundling.js
@@ -353,11 +353,11 @@ BundleExecutor.prototype.schedule = function(apiCall, request, callback) {
   var byteLimit = this._options.requestByteLimit || 0;
 
   if (
-    (countLimit > 0 && elementCount >= countLimit) ||
+    (countLimit > 0 && elementCount > countLimit) ||
     (byteLimit > 0 && requestBytes >= byteLimit)
   ) {
     var message;
-    if (countLimit > 0 && elementCount >= countLimit) {
+    if (countLimit > 0 && elementCount > countLimit) {
       message =
         'The number of elements ' +
         elementCount +
@@ -380,7 +380,7 @@ BundleExecutor.prototype.schedule = function(apiCall, request, callback) {
   var existingBytes = task.getRequestByteSize();
 
   if (
-    (countLimit > 0 && elementCount + existingCount >= countLimit) ||
+    (countLimit > 0 && elementCount + existingCount > countLimit) ||
     (byteLimit > 0 && requestBytes + existingBytes >= byteLimit)
   ) {
     this._runNow(bundleId);


### PR DESCRIPTION
Should fix

```
Unhandled rejection Error: The number of elements 1000 exceeds the limit 1000
```