### PR TITLE
refactor: use duplexify within StreamProxy

### DIFF
--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -68,6 +68,7 @@ function StreamProxy(type, callback) {
   });
   this.type = type;
   this._callback = callback;
+  this._isCancelCalled = false;
 }
 
 util.inherits(StreamProxy, Duplexify);

--- a/lib/streaming.js
+++ b/lib/streaming.js
@@ -33,7 +33,7 @@
 /* This file describes the gRPC-streaming. */
 
 var util = require('util');
-var DuplexStream = require('readable-stream').Duplex;
+var Duplexify = require('duplexify');
 
 /**
  * The type of gRPC streaming.
@@ -61,50 +61,16 @@ exports.StreamType = StreamType;
  * @param {ApiCallback} callback - the callback for further API call.
  */
 function StreamProxy(type, callback) {
-  DuplexStream.call(this, {
+  Duplexify.call(this, null, null, {
     objectMode: true,
     readable: type !== StreamType.CLIENT_STREAMING,
     writable: type !== StreamType.SERVER_STREAMING,
   });
   this.type = type;
   this._callback = callback;
-  this._writeQueue = [];
-  this._isEndCalled = false;
-  this._isCancelCalled = false;
-  var self = this;
-  this.on('finish', function() {
-    self._onFinish();
-  });
 }
 
-util.inherits(StreamProxy, DuplexStream);
-
-StreamProxy.prototype._read = function() {
-  if (this.type === StreamType.CLIENT_STREAMING) {
-    this.emit('error', new Error('stream is not readable'));
-  }
-};
-
-StreamProxy.prototype._write = function(chunk, encoding, callback) {
-  if (this.type === StreamType.SERVER_STREAMING) {
-    this.emit('error', new Error('stream is not writable'));
-    return;
-  }
-  if (this.stream) {
-    this.stream.write(chunk);
-  } else {
-    this._writeQueue.push(chunk);
-  }
-  callback();
-};
-
-StreamProxy.prototype._onFinish = function() {
-  if (this.stream) {
-    this.stream.end();
-  } else {
-    this._isEndCalled = true;
-  }
-};
+util.inherits(StreamProxy, Duplexify);
 
 StreamProxy.prototype.cancel = function() {
   if (this.stream) {
@@ -123,7 +89,7 @@ StreamProxy.prototype.setStream = function(apiCall, argument) {
   var stream = apiCall(argument, this._callback);
   this.stream = stream;
   var self = this;
-  ['error', 'metadata', 'status'].forEach(function(event) {
+  ['metadata', 'status'].forEach(function(event) {
     stream.on(event, function() {
       var args = Array.prototype.slice.call(arguments, 0);
       args.unshift(event);
@@ -146,29 +112,13 @@ StreamProxy.prototype.setStream = function(apiCall, argument) {
     });
   });
   if (this.type !== StreamType.CLIENT_STREAMING) {
-    stream.on('data', function() {
-      var args = Array.prototype.slice.call(arguments, 0);
-      args.unshift('data');
-      self.emit.apply(self, args);
-    });
-    // Pushing null causes an ending process of the readable stream.
-    stream.on('end', function() {
-      self.push(null);
-    });
-    // This is required in case no 'data' handler exists.
-    this.resume();
+    this.setReadable(stream);
   }
   if (this.type !== StreamType.SERVER_STREAMING) {
-    this._writeQueue.forEach(function(data) {
-      stream.write(data);
-    });
-    this._writeQueue = [];
-    if (this._isEndCalled) {
-      stream.end();
-    }
-    if (this._isCancelCalled) {
-      stream.cancel();
-    }
+    this.setWritable(stream);
+  }
+  if (this._isCancelCalled) {
+    stream.cancel();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "dependencies": {
+    "duplexify": "^3.5.4",
     "extend": "^3.0.0",
     "globby": "^8.0.0",
     "google-auto-auth": "^0.9.0",
@@ -15,7 +16,6 @@
     "is-stream-ended": "^0.1.0",
     "lodash": "^4.17.2",
     "protobufjs": "^6.8.0",
-    "readable-stream": "^2.2.2",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/test/streaming.js
+++ b/test/streaming.js
@@ -146,7 +146,7 @@ describe('streaming', function() {
       setTimeout(function() {
         s.emit('metadata', responseMetadata);
       }, 10);
-      s.on('end', function() {
+      s.on('finish', function() {
         s.emit('status', status);
       });
       return s;
@@ -165,7 +165,7 @@ describe('streaming', function() {
     s.on('response', function(data) {
       receivedResponse = data;
     });
-    s.on('end', function() {
+    s.on('finish', function() {
       expect(receivedMetadata).to.deep.eq(responseMetadata);
       expect(receivedStatus).to.deep.eq(status);
       expect(receivedResponse).to.deep.eq(expectedResponse);


### PR DESCRIPTION
I ran into an issue where I wasn't able to apply flow control to a stream because the StreamProxy class wouldn't wait for the underlying stream to finish writing data.

Once I looked closer at the StreamProxy class I noticed we could simplify it by leveraging Duplexify.