### PR TITLE
feat: use @grpc/proto-loader instead of deprecated grpc load

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -202,13 +202,15 @@ export class GrpcClient {
   loadProto(protoPath: string, filename: string) {
     // This set of @grpc/proto-loader options
     // 'closely approximates the existing behavior of grpc.load'
+    const includeDirs = INCLUDE_DIRS.slice();
+    includeDirs.unshift(protoPath);
     const options = {
       keepCase: true,
       longs: String,
       enums: String,
       defaults: true,
       oneofs: true,
-      includeDirs: INCLUDE_DIRS
+      includeDirs
     };
     return this.loadFromProto(filename, options);
   }

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -42,39 +42,17 @@ import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as gax from './gax';
 import {OutgoingHttpHeaders} from 'http';
 import {AnyDecoder} from './longrunning';
-let googleProtoFilesDir = require('google-proto-files')('..');
 
+let googleProtoFilesDir = require('google-proto-files')('..');
 googleProtoFilesDir = path.normalize(googleProtoFilesDir);
 
-/**
- * Options accepted by grpc.load, which was formerly called by GrpcClient#load.
- */
-export interface GrpcLoadOldOptions {
-  convertFieldsToCamelCase?: boolean;
-  binaryAsBase64?: boolean;
-  longsAsStrings?: boolean;
-  enumsAsStrings?: boolean;
-}
 
-/**
- * Acceptable types for values of `filename` in GrpcClient#load.
- */
-export type GrpcLoadFileArg = string|{
-  root?: string;
-  file: string;
-};
+// INCLUDE_DIRS is passed to @grpc/proto-loader
+const INCLUDE_DIRS: string[] = [];
+INCLUDE_DIRS.push(googleProtoFilesDir);
 
-/**
- * Options accepted by GrpcClient#load.
- */
-export type GrpcLoadOptions = GrpcLoadOldOptions&grpcProtoLoaderTypes.Options;
-
-/**
- * GrpcClient#load accepts its arguments in either load(args) or load(...args)
- * format. This is the type of `args` in the former of the two.
- */
-export type GrpcLoadArgs = [GrpcLoadFileArg, null, GrpcLoadOptions];
-
+// COMMON_PROTO_FILES logic is here for protobufjs loads (see
+// GoogleProtoFilesRoot below)
 const COMMON_PROTO_DIRS = [
   // This list of directories is defined here:
   // https://github.com/googleapis/googleapis/blob/master/gapic/packaging/common_protos.yaml
@@ -99,7 +77,6 @@ const COMMON_PROTO_FILES =
         .map(filename => {
           return filename.substring(googleProtoFilesDir.length + 1);
         });
-
 
 export interface GrpcClientOptions extends GoogleAuthOptions {
   auth: GoogleAuth;
@@ -202,50 +179,33 @@ export class GrpcClient {
    * @param options Options for loading the proto file.
    */
   loadFromProto(filename: string, options: grpcProtoLoaderTypes.Options) {
+    console.log('load:', filename);
     const packageDef = grpcProtoLoaderTypes.loadSync(filename, options);
+    console.log('def:', packageDef);
     return this.grpc.loadPackageDefinition(packageDef);
-  }
-
-  /**
-   * Load grpc proto services with the specific arguments.
-   * Pending deprecation: use GrpcClient#loadFromProto.
-   * @param {Array=} args - The argument list to be passed to grpc.load().
-   * @return {Object} The gRPC loaded result (the toplevel namespace object).
-   */
-  load(args: Array<{}>) {
-    if (!args) {
-      args = [];
-    } else if (!Array.isArray(args)) {
-      args = [args];
-    }
-    if (args.length === 1) {
-      args.push('proto', {convertFieldsToCamelCase: true});
-    }
-    return this.grpc.load.apply(this.grpc, args);
   }
 
   /**
    * Load grpc proto service from a filename hooking in googleapis common protos
    * when necessary.
-   * Pending deprecation: use GrpcClient#loadFromProto.
    * @param {String} protoPath - The directory to search for the protofile.
    * @param {String} filename - The filename of the proto to be loaded.
    * @return {Object<string, *>} The gRPC loaded result (the toplevel namespace
    *   object).
    */
   loadProto(protoPath: string, filename: string) {
-    const resolvedPath = GrpcClient._resolveFile(protoPath, filename);
-    return this.grpc.loadObject(
-        protobuf.loadSync(resolvedPath, new GoogleProtoFilesRoot()));
-  }
-
-  static _resolveFile(protoPath: string, filename: string) {
-    if (fs.existsSync(path.join(protoPath, filename))) {
-      return path.join(protoPath, filename);
-    } else if (COMMON_PROTO_FILES.indexOf(filename) > -1) {
-      return path.join(googleProtoFilesDir, filename);
-    }
-    throw new Error(filename + ' could not be found in ' + protoPath);
+    // This set of @grpc/proto-loader options
+    // 'closely approximates the existing behavior of grpc.load'
+    const options = {
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true,
+      includeDirs: INCLUDE_DIRS
+    };
+    console.log(INCLUDE_DIRS);
+    return this.loadFromProto(filename, options);
   }
 
   metadataBuilder(headers: OutgoingHttpHeaders) {

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -187,9 +187,7 @@ export class GrpcClient {
    * @param options Options for loading the proto file.
    */
   loadFromProto(filename: string, options: grpcProtoLoaderTypes.Options) {
-    console.log('load:', filename);
     const packageDef = grpcProtoLoaderTypes.loadSync(filename, options);
-    console.log('def:', packageDef);
     return this.grpc.loadPackageDefinition(packageDef);
   }
 
@@ -212,7 +210,6 @@ export class GrpcClient {
       oneofs: true,
       includeDirs: INCLUDE_DIRS
     };
-    console.log(INCLUDE_DIRS);
     return this.loadFromProto(filename, options);
   }
 

--- a/src/operations_client.ts
+++ b/src/operations_client.ts
@@ -27,6 +27,7 @@
 /* jscs: disable maximumLineLength */
 'use strict';
 
+import * as path from 'path';
 import * as extend from 'extend';
 import * as apiCallable from './api_callable';
 import * as gax from './gax';
@@ -437,12 +438,9 @@ export class OperationsClient {
 }
 export class OperationsClientBuilder {
   constructor(gaxGrpc) {
-    const operationsClient = gaxGrpc.load([
-      {
-        root: require('google-proto-files')('..'),
-        file: 'google/longrunning/operations.proto',
-      },
-    ]);
+    const protoFilesRoot = require('google-proto-files')('..');
+    const operationsClient = gaxGrpc.loadProto(
+        path.join(protoFilesRoot, 'google/longrunning/operations.proto'));
     extend(this, operationsClient.google.longrunning);
 
     /**

--- a/src/operations_client.ts
+++ b/src/operations_client.ts
@@ -440,7 +440,7 @@ export class OperationsClientBuilder {
   constructor(gaxGrpc) {
     const protoFilesRoot = require('google-proto-files')('..');
     const operationsClient = gaxGrpc.loadProto(
-        path.join(protoFilesRoot, 'google/longrunning/operations.proto'));
+        protoFilesRoot, 'google/longrunning/operations.proto');
     extend(this, operationsClient.google.longrunning);
 
     /**

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -225,7 +225,6 @@ describe('grpc', () => {
       // test will fail anyway.
       // tslint:disable-next-line:no-any
       const protos = grpcClient.loadProto(TEST_PATH, TEST_FILE) as any;
-      console.log(protos);
       expect(protos.google.example.library.v1.LibraryService)
           .to.be.a('Function');
     });

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -208,20 +208,19 @@ describe('grpc', () => {
   });
 
   describe('loadProto', () => {
-    const TEST_FILE = path.join(
-        'fixtures', 'google', 'example', 'library', 'v1', 'library.proto');
-    // const RESOLVED_TEST_FILE = path.resolve(`../`)
-    const TEST_PATH = path.resolve(__dirname, '../../test');
     const grpcClient = gaxGrpc();
+    const TEST_FILE =
+        path.join('google', 'example', 'library', 'v1', 'library.proto');
+    const TEST_PATH = path.resolve(__dirname, '../../test/fixtures');
 
     it('should load the test file', () => {
       // no-any disabled because if the accessed fields are non-existent, this
       // test will fail anyway.
       // tslint:disable-next-line:no-any
       const protos = grpcClient.loadProto(TEST_PATH, TEST_FILE) as any;
+      console.log(protos);
       expect(protos.google.example.library.v1.LibraryService)
           .to.be.a('Function');
-      expect(protos.test.TestMessage).to.be.an('object');
     });
 
     it('should load a common proto', () => {


### PR DESCRIPTION
BREAKING CHANGE: removing `GrpcClient.load()` which was a wrapper for `grpc.load`. In `GrpcClient.loadProto()` replacing `grpc.loadObject` with a (hopefully compatible) call to `@grpc/proto-loader`.

I'm going to test this in several client libraries and see if anything breaks (which is highly possible).

Fixes #286.