### PR TITLE
Export GoogleAuth for consumption

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -41,7 +41,6 @@ import * as semver from 'semver';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as gax from './gax';
 import {OutgoingHttpHeaders} from 'http';
-import {AnyDecoder} from './longrunning';
 
 let googleProtoFilesDir = require('google-proto-files')('..');
 googleProtoFilesDir = path.normalize(googleProtoFilesDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import * as extend from 'extend';
 
 import * as operationsClient from './operations_client';
 import * as routingHeader from './routing_header';
-import {GrpcClient, GrpcClientOptions } from './grpc';
+import {GrpcClient, GrpcClientOptions} from './grpc';
 
 export {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 export {routingHeader};

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,9 @@ import * as extend from 'extend';
 
 import * as operationsClient from './operations_client';
 import * as routingHeader from './routing_header';
-import {GrpcClient, GrpcClientOptions, GoogleProtoFilesRoot} from './grpc';
+import {GrpcClient, GrpcClientOptions } from './grpc';
 
+export {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 export {routingHeader};
 export {constructSettings} from './gax';
 export {StreamType, StreamDescriptor} from './streaming';


### PR DESCRIPTION
We have a situation in some npm modules where we are importing multiple versions of google-auth-libraries.  This can cause all sorts of weird problems, and I'd like high level modules to get their auth from here or common.  