### PR TITLE
fix: reverting to use grpc.loadObject for now

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -212,7 +212,10 @@ export class GrpcClient {
       oneofs: true,
       includeDirs
     };
-    return this.loadFromProto(filename, options);
+    const retval = this.loadFromProto(filename, options);
+    console.log('loadProto', protoPath, filename);
+    console.log(JSON.stringify(retval, null, '  '));
+    return retval;
   }
 
   metadataBuilder(headers: OutgoingHttpHeaders) {

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -188,7 +188,6 @@ export class GrpcClient {
    */
   loadFromProto(filename: string, options: grpcProtoLoaderTypes.Options) {
     const packageDef = grpcProtoLoaderTypes.loadSync(filename, options);
-    console.log('loaded packageDef:', JSON.stringify(packageDef, null, '  '));
     return this.grpc.loadPackageDefinition(packageDef);
   }
 
@@ -205,8 +204,6 @@ export class GrpcClient {
     const resolvedPath = GrpcClient._resolveFile(protoPath, filename);
     const retval = this.grpc.loadObject(
         protobuf.loadSync(resolvedPath, new GoogleProtoFilesRoot()));
-    console.log('loadProto', protoPath, filename);
-    console.log(JSON.stringify(retval, null, '  '));
     return retval;
   }
 

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -188,6 +188,7 @@ export class GrpcClient {
    */
   loadFromProto(filename: string, options: grpcProtoLoaderTypes.Options) {
     const packageDef = grpcProtoLoaderTypes.loadSync(filename, options);
+    console.log('loaded packageDef:', JSON.stringify(packageDef, null, '  '));
     return this.grpc.loadPackageDefinition(packageDef);
   }
 
@@ -212,6 +213,7 @@ export class GrpcClient {
       oneofs: true,
       includeDirs
     };
+    console.log(options);
     const retval = this.loadFromProto(filename, options);
     console.log('loadProto', protoPath, filename);
     console.log(JSON.stringify(retval, null, '  '));

--- a/src/operations_client.ts
+++ b/src/operations_client.ts
@@ -441,9 +441,6 @@ export class OperationsClientBuilder {
     const protoFilesRoot = require('google-proto-files')('..');
     const operationsClient = gaxGrpc.loadProto(
         protoFilesRoot, 'google/longrunning/operations.proto');
-    console.log(
-        'loaded operationsClient:',
-        JSON.stringify(operationsClient, null, '  '));
     extend(this, operationsClient.google.longrunning);
 
     /**

--- a/src/operations_client.ts
+++ b/src/operations_client.ts
@@ -441,6 +441,7 @@ export class OperationsClientBuilder {
     const protoFilesRoot = require('google-proto-files')('..');
     const operationsClient = gaxGrpc.loadProto(
         protoFilesRoot, 'google/longrunning/operations.proto');
+    console.log('loaded operationsClient:', JSON.stringify(operationsClient, null, '  '));
     extend(this, operationsClient.google.longrunning);
 
     /**

--- a/src/operations_client.ts
+++ b/src/operations_client.ts
@@ -441,7 +441,9 @@ export class OperationsClientBuilder {
     const protoFilesRoot = require('google-proto-files')('..');
     const operationsClient = gaxGrpc.loadProto(
         protoFilesRoot, 'google/longrunning/operations.proto');
-    console.log('loaded operationsClient:', JSON.stringify(operationsClient, null, '  '));
+    console.log(
+        'loaded operationsClient:',
+        JSON.stringify(operationsClient, null, '  '));
     extend(this, operationsClient.google.longrunning);
 
     /**


### PR DESCRIPTION
Fixes #286 (again).

We don't use `grpc.load` but still need to use `grpc.loadObject`. I'm not sure yet how we need to redesign it, but since `loadObject` is not deprecated, let's just try that.

I'll release a new version after this one is merged, and we'll see if it works :)  (I checked manually on some libraries though)