### PR TITLE
chore: release 0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Google API Extensions",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
Releasing v0.20.0. 

[Release notes](https://github.com/googleapis/gax-nodejs/releases/edit/untagged-282ea5b0635180648e71)

I expect Renovate to attempt updating all libraries to use this version, which will effectively test if it works now :)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
