### PR TITLE
chore: update grpc to ^1.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "globby": "^8.0.1",
     "google-auth-library": "^2.0.0",
     "google-proto-files": "^0.16.0",
-    "grpc": "^1.12.2",
+    "grpc": "^1.15.1",
     "is-stream-ended": "^0.1.4",
     "lodash": "^4.17.10",
     "protobufjs": "^6.8.8",


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#450 (probably). Technically, I'm not changing anything since the most recent gRPC is still within range, but let's point to the recent version just in case.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
