### PR TITLE
fix: use `walkdir` instead of `globby`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@grpc/proto-loader": "^0.3.0",
     "duplexify": "^3.6.0",
     "extend": "^3.0.1",
-    "globby": "^8.0.1",
     "google-auth-library": "^2.0.0",
     "google-proto-files": "^0.17.0",
     "grpc": "^1.15.1",
@@ -22,13 +21,13 @@
     "lodash.has": "^4.5.2",
     "protobufjs": "^6.8.8",
     "retry-request": "^4.0.0",
-    "semver": "^5.5.1"
+    "semver": "^5.5.1",
+    "walkdir": "0.0.12"
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "@types/duplexify": "^3.5.0",
     "@types/extend": "^3.0.0",
-    "@types/globby": "^8.0.0",
     "@types/lodash.at": "^4.6.4",
     "@types/lodash.flatten": "^4.4.4",
     "@types/lodash.has": "^4.5.4",


### PR DESCRIPTION
This should trim ~120ms from our module load time.  Please take a close look at this one, because it could break a lot 😆 