### PR TITLE
test: don't run Pub/Sub system tests

### DIFF
--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -121,16 +121,16 @@ describe('Run system tests for some libraries', () => {
     });
   });
   // Pub/Sub has streaming methods and pagination
-/*  TODO(alexander.fenster): uncomment after Pub/Sub release >0.21.1
- *  describe('pubsub', () => {
- *   before(async () => {
- *     await preparePackage('nodejs-pubsub');
- *   });
- *   it('should pass system tests', async () => {
- *     await runSystemTest('nodejs-pubsub');
- *   });
- * });
- */
+  /*  TODO(alexander.fenster): uncomment after Pub/Sub release >0.21.1
+   *  describe('pubsub', () => {
+   *   before(async () => {
+   *     await preparePackage('nodejs-pubsub');
+   *   });
+   *   it('should pass system tests', async () => {
+   *     await runSystemTest('nodejs-pubsub');
+   *   });
+   * });
+   */
   // Speech only has smoke tests, but still...
   describe('speech', () => {
     before(async () => {

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -121,14 +121,16 @@ describe('Run system tests for some libraries', () => {
     });
   });
   // Pub/Sub has streaming methods and pagination
-  describe('pubsub', () => {
-    before(async () => {
-      await preparePackage('nodejs-pubsub');
-    });
-    it('should pass system tests', async () => {
-      await runSystemTest('nodejs-pubsub');
-    });
-  });
+/*  TODO(alexander.fenster): uncomment after Pub/Sub release >0.21.1
+ *  describe('pubsub', () => {
+ *   before(async () => {
+ *     await preparePackage('nodejs-pubsub');
+ *   });
+ *   it('should pass system tests', async () => {
+ *     await runSystemTest('nodejs-pubsub');
+ *   });
+ * });
+ */
   // Speech only has smoke tests, but still...
   describe('speech', () => {
     before(async () => {


### PR DESCRIPTION
Pub/Sub compilation is broken and will be fixed in the next release (> v0.21.1). Disabling until then.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
