### PR TITLE
test: enable pub/sub system tests

### DIFF
--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -121,16 +121,14 @@ describe('Run system tests for some libraries', () => {
     });
   });
   // Pub/Sub has streaming methods and pagination
-  /*  TODO(alexander.fenster): uncomment after Pub/Sub release >0.21.1
-   *  describe('pubsub', () => {
-   *   before(async () => {
-   *     await preparePackage('nodejs-pubsub');
-   *   });
-   *   it('should pass system tests', async () => {
-   *     await runSystemTest('nodejs-pubsub');
-   *   });
-   * });
-   */
+  describe('pubsub', () => {
+    before(async () => {
+      await preparePackage('nodejs-pubsub');
+    });
+    it('should pass system tests', async () => {
+      await runSystemTest('nodejs-pubsub');
+    });
+  });
   // Speech only has smoke tests, but still...
   describe('speech', () => {
     before(async () => {


### PR DESCRIPTION
Now that the Pub/Sub problem is fixed in v0.22.0, let's re-enable it in system tests.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
