### PR TITLE
Add grpc-gcp support in gax

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "google-auth-library": "^3.0.0",
     "google-proto-files": "^0.18.0",
     "grpc": "^1.16.0",
+    "grpc-gcp": "^0.1.1",
     "is-stream-ended": "^0.1.4",
     "lodash.at": "^4.6.0",
     "lodash.has": "^4.5.2",

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -35,6 +35,7 @@ import * as fs from 'fs';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import {getProtoPath} from 'google-proto-files';
 import * as grpcTypes from 'grpc';  // for types only
+import * as grpcGcp from 'grpc-gcp';
 import {OutgoingHttpHeaders} from 'http';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
@@ -286,13 +287,19 @@ export class GrpcClient {
       Object.keys(options).forEach(key => {
         if (key.indexOf('grpc.') === 0) {
           grpcOptions[key] = options[key];
-        } else if (key.indexOf('grpc_gcp.') === 0) {
-          // This prefix is used to pass additional arguments that aren't
-          // options for grpc. Strip the prefix before passing.
-          const prefixLength = 'grpc_gcp.'.length;
-          grpcOptions[key.substr(prefixLength)] = options[key];
         }
       });
+      const apiConfigPath = options['grpc_gcp.apiConfigPath'];
+      console.log(apiConfigPath);
+      if (apiConfigPath && fs.existsSync(apiConfigPath)) {
+        const apiConfig = grpcGcp.createGcpApiConfig(
+            JSON.parse(fs.readFileSync(apiConfigPath).toString()));
+        grpcOptions['channelFactoryOverride'] =
+            grpcGcp.gcpChannelFactoryOverride;
+        grpcOptions['callInvocationTransformer'] =
+            grpcGcp.gcpCallInvocationTransformer;
+        grpcOptions['gcpApiConfig'] = apiConfig;
+      }
       return new CreateStub(serviceAddress, credentials, grpcOptions);
     });
   }

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -289,11 +289,9 @@ export class GrpcClient {
           grpcOptions[key] = options[key];
         }
       });
-      const apiConfigPath = options['grpc_gcp.apiConfigPath'];
-      console.log(apiConfigPath);
-      if (apiConfigPath && fs.existsSync(apiConfigPath)) {
-        const apiConfig = grpcGcp.createGcpApiConfig(
-            JSON.parse(fs.readFileSync(apiConfigPath).toString()));
+      const apiConfigDefition = options['grpc_gcp.apiConfig'];
+      if (apiConfigDefition) {
+        const apiConfig = grpcGcp.createGcpApiConfig(apiConfigDefition);
         grpcOptions['channelFactoryOverride'] =
             grpcGcp.gcpChannelFactoryOverride;
         grpcOptions['callInvocationTransformer'] =

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -196,11 +196,12 @@ describe('grpc', () => {
     });
 
     it('supports grpc-gcp options', () => {
-      const configPath = path.resolve(TEST_PATH, 'test_grpc_config.json');
+      const apiConfigDefinition =
+          require(path.resolve(TEST_PATH, 'test_grpc_config.json'));
       const opts = {
         servicePath: 'foo.example.com',
         port: 443,
-        'grpc_gcp.apiConfigPath': configPath,
+        'grpc_gcp.apiConfig': apiConfigDefinition,
       };
       return grpcClient.createStub(DummyStub, opts).then(stub => {
         expect(stub).to.be.an.instanceOf(DummyStub);
@@ -212,7 +213,7 @@ describe('grpc', () => {
         ]);
         // tslint:disable-next-line no-any
         (expect(stub.options).to.not.have as any).key([
-          'servicePath', 'port', 'grpc_gcp.apiConfigPath'
+          'servicePath', 'port', 'grpc_gcp.apiConfig'
         ]);
         // tslint:disable-next-line no-any
         (expect(stub.options['gcpApiConfig']).has as any).key([

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -128,6 +128,7 @@ describe('grpc', () => {
   });
 
   describe('createStub', () => {
+    const TEST_PATH = path.resolve(__dirname, '../../test');
     class DummyStub {
       constructor(public address, public creds, public options) {}
     }
@@ -177,7 +178,6 @@ describe('grpc', () => {
         port: 443,
         'grpc.max_send_message_length': 10 * 1024 * 1024,
         'grpc.initial_reconnect_backoff_ms': 10000,
-        'grpc_gcp.non_grpc_option': 1,
         other_dummy_options: 'test',
       };
       return grpcClient.createStub(DummyStub, opts).then(stub => {
@@ -186,12 +186,37 @@ describe('grpc', () => {
         expect(stub.creds).to.deep.eq(dummyChannelCreds);
         // tslint:disable-next-line no-any
         (expect(stub.options).has as any).key([
-          'grpc.max_send_message_length', 'grpc.initial_reconnect_backoff_ms',
-          'non_grpc_option'
+          'grpc.max_send_message_length', 'grpc.initial_reconnect_backoff_ms'
         ]);
         // tslint:disable-next-line no-any
         (expect(stub.options).to.not.have as any).key([
           'servicePath', 'port', 'other_dummy_options'
+        ]);
+      });
+    });
+
+    it('supports grpc-gcp options', () => {
+      const configPath = path.resolve(TEST_PATH, 'test_grpc_config.json');
+      const opts = {
+        servicePath: 'foo.example.com',
+        port: 443,
+        'grpc_gcp.apiConfigPath': configPath,
+      };
+      return grpcClient.createStub(DummyStub, opts).then(stub => {
+        expect(stub).to.be.an.instanceOf(DummyStub);
+        expect(stub.address).to.eq('foo.example.com:443');
+        expect(stub.creds).to.deep.eq(dummyChannelCreds);
+        // tslint:disable-next-line no-any
+        (expect(stub.options).has as any).key([
+          'channelFactoryOverride', 'callInvocationTransformer', 'gcpApiConfig'
+        ]);
+        // tslint:disable-next-line no-any
+        (expect(stub.options).to.not.have as any).key([
+          'servicePath', 'port', 'grpc_gcp.apiConfigPath'
+        ]);
+        // tslint:disable-next-line no-any
+        (expect(stub.options['gcpApiConfig']).has as any).key([
+          'channelPool', 'method'
         ]);
       });
     });

--- a/test/test_grpc_config.json
+++ b/test/test_grpc_config.json
@@ -1,0 +1,15 @@
+{
+	"channelPool": {
+		"maxSize": 1,
+		"maxConcurrentStreamsLowWatermark": 1
+    },
+    "method": [
+        {
+            "name": ["method1"],
+            "affinity": {
+                "command": "BIND",
+                "affinityKey": "key1"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As discussed in https://github.com/googleapis/nodejs-spanner/pull/436 , we decided to put the grpc-gcp related logic into gax,  while in client library, we only need  to add a new entry with key named `grpc_gcp.apiConfig` into the client options, so that the gax will enable the grpc-gcp support only when the entry exists.