### PR TITLE
refactor: swap out duplexify library

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^0.3.0",
     "@grpc/proto-loader": "^0.4.0",
-    "duplexify": "^3.6.0",
+    "@justinbeckwith/duplexify": "^3.7.1",
     "google-auth-library": "^3.0.0",
     "google-proto-files": "^0.18.0",
     "grpc": "^1.16.0",
@@ -25,8 +25,7 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
-    "@types/chai": "^4.1.3",
-    "@types/duplexify": "^3.5.0",
+    "@types/chai": "^4.1.7",
     "@types/lodash.at": "^4.6.4",
     "@types/lodash.has": "^4.5.4",
     "@types/mocha": "^5.2.1",
@@ -38,7 +37,7 @@
     "@types/sinon": "^7.0.0",
     "@types/source-map-support": "^0.4.1",
     "@types/through2": "^2.0.33",
-    "chai": "*",
+    "chai": "^4.2.0",
     "codecov": "^3.1.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.9.0",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -31,9 +31,8 @@
 
 /* This file describes the gRPC-streaming. */
 
-import * as Duplexify from 'duplexify';
+import {Duplexify} from '@justinbeckwith/duplexify';
 import {Duplex, DuplexOptions, Stream} from 'stream';
-
 import {APICall, APICallback} from './api_callable';
 
 const retryRequest = require('retry-request');


### PR DESCRIPTION
We're starting to see a variety of problems with duplexify, and I want to swap it out for our own implementation.  We may choose to move this from my github over to googleapis if it makes sense.  Solves these issues:
1. We have users running into issues with the `allowSyntheticImports` setting in TypeScript with `@types/duplexify` https://github.com/googleapis/nodejs-logging-bunyan/issues/241
1. `duplexify` takes a dependency on a user space `ReadableStream` module that we don't need https://npmtrace.appspot.com/packages/google-gax/0.25.0
1. There's  PR on a few repos where tests start failing after a 4.0 release, and they basically have 0 release notes. https://github.com/googleapis/gax-nodejs/pull/408

I think we're seeing enough evidence to make a change here.