### PR TITLE
chore: don't run system tests with grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fix": "gts fix && eslint --fix samples/*.js samples/**/*.js",
     "prepare": "npm run compile",
     "posttest": "npm run lint",
-    "system-test": "cross-env GOOGLE_CLOUD_USE_GRPC_JS=1 nyc mocha --timeout 1200000 build/system-test && mocha build/system-test --timeout 120000",
+    "system-test": "mocha build/system-test --timeout 120000",
     "samples-test": "echo no sample tests 😱"
   },
   "repository": "googleapis/gax-nodejs",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fix": "gts fix && eslint --fix samples/*.js samples/**/*.js",
     "prepare": "npm run compile",
     "posttest": "npm run lint",
-    "system-test": "mocha build/system-test --timeout 120000",
+    "system-test": "nyc mocha build/system-test --timeout 120000",
     "samples-test": "echo no sample tests 😱"
   },
   "repository": "googleapis/gax-nodejs",


### PR DESCRIPTION
@kinwa91 will enable system tests with grpc-js as a separate Kokoro task.
It's a little bit flaky now so will likely bring more harm than good.

But good news is that it works (#400)!

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
