### PR TITLE
fix: do not fail if bundledField is missing

### DIFF
--- a/src/bundling.ts
+++ b/src/bundling.ts
@@ -371,10 +371,11 @@ export class BundleExecutor {
       return apiCall(request, callback);
     }
     if (request[this._descriptor.bundledField] === undefined) {
-      console.warn(
+      warn(
+          'bundling_no_bundled_field',
           `Request does not contain field ${
               this._descriptor.bundledField} that must present for bundling. ` +
-          `Invoking immediately. Request: ${JSON.stringify(request)}`);
+              `Invoking immediately. Request: ${JSON.stringify(request)}`);
       return apiCall(request, callback);
     }
 

--- a/src/bundling.ts
+++ b/src/bundling.ts
@@ -368,6 +368,13 @@ export class BundleExecutor {
           this._descriptor.requestDiscriminatorFields);
       return apiCall(request, callback);
     }
+    if (request[this._descriptor.bundledField] === undefined) {
+      console.warn(
+          `Request does not contain field ${
+              this._descriptor.bundledField} that must present for bundling. ` +
+          `Invoking immediately. Request: ${JSON.stringify(request)}`);
+      return apiCall(request, callback);
+    }
 
     if (!(bundleId in this._tasks)) {
       this._tasks[bundleId] = new Task(

--- a/test/bundling.ts
+++ b/test/bundling.ts
@@ -846,6 +846,29 @@ describe('bundleable', () => {
     apiCall({field1: [1, 2, 3], field2: 'id'}, null).then(callback).catch(done);
   });
 
+  it('does not fail if bundle field is not set', (done) => {
+    const spy = sinon.spy(func);
+    const warnStub = sinon.stub(process, 'emitWarning');
+    const callback = sinon.spy(obj => {
+      expect(obj).to.be.an('array');
+      expect(obj[0].field1).to.be.an('undefined');
+      if (callback.callCount === 2) {
+        expect(spy.callCount).to.eq(2);
+        expect(warnStub.callCount).to.eq(1);
+        warnStub.restore();
+        done();
+      }
+    });
+    const apiCall = createApiCall(spy, settings);
+
+    function error(err: Error) {
+      warnStub.restore();
+      done(err);
+    }
+    apiCall({field2: 'id1'}, null).then(callback, error);
+    apiCall({field2: 'id2'}, null).then(callback, error);
+  });
+
   it('suppresses bundling behavior by call options', (done) => {
     const spy = sinon.spy(func);
     let callbackCount = 0;


### PR DESCRIPTION
Workaround for https://github.com/googleapis/nodejs-logging/issues/381. In some weird cases we can get `undefined` where we expect an array of values to be bundled in one call. It should not happen, but if it does, let's not fail there.

Fail happens here:

https://github.com/googleapis/gax-nodejs/blob/218232f8fc2ef5d1200e5c8cbc4d1709bd7c6f85/src/bundling.ts#L381-L382

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
