### PR TITLE
test: do not use grpc-js in regular system test

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "fix": "gts fix && eslint --fix samples/*.js samples/**/*.js",
     "prepare": "npm run compile",
     "posttest": "npm run lint",
-    "system-test": "cross-env GOOGLE_CLOUD_USE_GRPC_JS=1 nyc mocha --timeout 1200000 build/system-test && mocha build/system-test --timeout 120000",
+    "system-test": "nyc mocha build/system-test --timeout 120000",
     "samples-test": "echo no sample tests 😱",
     "docs-test": "blcl docs -r --exclude www.googleapis.com",
     "predocs-test": "npm run docs"


### PR DESCRIPTION
This was originally merged in #417 but looks like it got lost in merges. We still need to remove this since we now have a separate Kokoro task for grpc-js.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
