### PR TITLE
fix: do not use console.warn or console.error

### DIFF
--- a/src/bundling.ts
+++ b/src/bundling.ts
@@ -38,6 +38,7 @@ import {status} from 'grpc';
 import {NormalApiCaller, APICall, PromiseCanceller, APICallback} from './apiCallable';
 import {GoogleError} from './GoogleError';
 import {CallSettings} from './gax';
+import {warn} from './warnings';
 
 /**
  * A function which does nothing. Used for an empty cancellation funciton.
@@ -361,11 +362,12 @@ export class BundleExecutor {
         computeBundleId(request, this._descriptor.requestDiscriminatorFields);
     callback = (callback || noop) as TaskCallback;
     if (bundleId === undefined) {
-      console.warn(
+      warn(
+          'bundling_schedule_bundleid_undefined',
           'The request does not have enough information for request bundling. ' +
-          'Invoking immediately. Request: ' + JSON.stringify(request) +
-          ' discriminator fields: ' +
-          this._descriptor.requestDiscriminatorFields);
+              `Invoking immediately. Request: ${JSON.stringify(request)} ` +
+              `discriminator fields: ${
+                  this._descriptor.requestDiscriminatorFields}`);
       return apiCall(request, callback);
     }
 
@@ -490,7 +492,7 @@ export class BundleExecutor {
    */
   _runNow(bundleId: string) {
     if (!(bundleId in this._tasks)) {
-      console.warn('no such bundleid: ' + bundleId);
+      warn('bundle_runnow_bundleid_unknown', `No such bundleid: ${bundleId}`);
       return;
     }
     this._maybeClearTimeout(bundleId);

--- a/src/isbrowser.ts
+++ b/src/isbrowser.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isBrowser(): boolean {
+  return typeof (window) !== 'undefined';
+}

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -34,6 +34,7 @@
 import * as Duplexify from 'duplexify';
 import {Duplex, DuplexOptions, Stream} from 'stream';
 import {APICall, APICallback} from './apiCallable';
+import {warn} from './warnings';
 
 const retryRequest = require('retry-request');
 
@@ -190,7 +191,9 @@ export class GrpcStreamable {
           return func(metadata, options);
         };
       default:
-        console.error('Unknown stream type', this.descriptor.type);
+        warn(
+            'streaming_wrap_unknown_stream_type',
+            `Unknown stream type: ${this.descriptor.type}`);
     }
     return func;
   }

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as semver from 'semver';
+import {isBrowser} from './isbrowser';
+
+const emittedWarnings = new Set<string>();
+
+export function warn(code: string, message: string) {
+  // Only show a given warning once
+  if (emittedWarnings.has(code)) {
+    return;
+  }
+  emittedWarnings.add(code);
+
+  if (isBrowser()) {
+    console.warn(message);
+  } else {
+    process.emitWarning(message);
+  }
+}

--- a/test/warning.ts
+++ b/test/warning.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assert} from 'chai';
+import * as sinon from 'sinon';
+
+import {warn} from '../src/warnings';
+
+describe('warnings', () => {
+  it('should warn the given code once with the first message', (done) => {
+    const stub = sinon.stub(process, 'emitWarning');
+    warn('code1', 'message1-1');
+    warn('code1', 'message1-2');
+    warn('code1', 'message1-3');
+    assert(stub.calledOnceWith('message1-1'));
+    stub.restore();
+    done();
+  });
+  it('should warn each code once', (done) => {
+    const stub = sinon.stub(process, 'emitWarning');
+    warn('codeA', 'messageA-1');
+    warn('codeB', 'messageB-1');
+    warn('codeA', 'messageA-2');
+    warn('codeB', 'messageB-2');
+    warn('codeC', 'messageC-1');
+    warn('codeA', 'messageA-3');
+    assert.strictEqual(stub.callCount, 3);
+    stub.restore();
+    done();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
+    "lib": ["es2015", "dom"],
     "rootDir": ".",
     "outDir": "build",
     "noImplicitAny": false


### PR DESCRIPTION
Make it easy to warn. Inspired by https://github.com/googleapis/google-auth-library-nodejs/blob/master/src/messages.ts but since we don't warn much in this library, decided to make it easier (YAGNI).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
