### PR TITLE
fix: monitoring could be a common proto

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -58,6 +58,7 @@ const COMMON_PROTO_DIRS = [
   'api',
   path.join('iam', 'v1'),
   path.join('logging', 'type'),
+  path.join('monitoring', 'v3'),
   'longrunning',
   'protobuf',  // This is an additional path that the common protos depend on.
   'rpc',


### PR DESCRIPTION
Makes https://github.com/googleapis/nodejs-irm/pull/8 work since this nodejs-irm library depends on monitoring protos which were never listed as common protos.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
