### PR TITLE
test: longer timeout for Pub/Sub system tests

### DIFF
--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -124,7 +124,9 @@ describe('Run system tests for some libraries', () => {
     before(async () => {
       await preparePackage('nodejs-pubsub');
     });
-    it('should pass system tests', async () => {
+    it('should pass system tests', async function() {
+      // Pub/Sub tests can be slow since they check packaging
+      this.timeout(300000);
       await runSystemTest('nodejs-pubsub');
     });
   });


### PR DESCRIPTION
Fixes random Pub/Sub test failures caused by extra testing added (packaging and stuff).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
