### PR TITLE
fix: bundling is optional in MethodConfig

### DIFF
--- a/src/gax.ts
+++ b/src/gax.ts
@@ -549,7 +549,7 @@ export interface RetryParamsConfig {
 export interface MethodConfig {
   retry_codes_name: string;
   retry_params_name: string;
-  bundling: BundlingConfig;
+  bundling?: BundlingConfig;
   timeout_millis?: number;
 }
 


### PR DESCRIPTION
Adapding gax for TypeScript micro-generator (which is coming like really soon).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
