### PR TITLE
test: better return type for typescript 3.4.0

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,6 +49,10 @@ export function createApiCall(func, opts?) {
         if (opts.returnCancelFunc) {
           return {
             cancel: func(argument, metadata, options, callback),
+            completed: true,
+            call: () => {
+              throw new Error('should not be run');
+            }
           };
         }
         func(argument, metadata, options, callback);
@@ -56,6 +60,10 @@ export function createApiCall(func, opts?) {
           cancel: opts.cancel || (() => {
                     callback(new Error('canceled'));
                   }),
+          completed: true,
+          call: () => {
+            throw new Error('should not be run');
+          }
         };
       }),
       settings, descriptor);


### PR DESCRIPTION
Fixes the failing build that fails after #461.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
