### PR TITLE
chore(dep): unpin grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@grpc/proto-loader": "^0.5.0",
     "duplexify": "^3.6.0",
     "google-auth-library": "^3.0.0",
-    "grpc": "1.20.0",
+    "grpc": "^1.20.2",
     "grpc-gcp": "^0.1.1",
     "is-stream-ended": "^0.1.4",
     "lodash.at": "^4.6.0",

--- a/system-test/fixtures/google-gax-packaging-test-app/package.json
+++ b/system-test/fixtures/google-gax-packaging-test-app/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^0.3.6",
     "google-gax": "file:./google-gax.tgz",
-    "grpc": "1.20.0",
+    "grpc": "^1.20.2",
     "lodash.merge": "^4.6.1",
     "protobufjs": "^6.8.8"
   },


### PR DESCRIPTION
gRPC v1.20.2 is out fixing the typing problems in v1.20.1, so unpinning it back.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
