### PR TITLE
feat: allow loading multiple proto files at once

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -175,6 +175,9 @@ export class GrpcClient {
    *   object).
    */
   loadProto(protoPath: string, filename: string | string[]) {
+    if (typeof filename === 'object' && filename.length === 0) {
+      return {};
+    }
     // This set of @grpc/proto-loader options
     // 'closely approximates the existing behavior of grpc.load'
     const includeDirs = INCLUDE_DIRS.slice();

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -153,13 +153,16 @@ export class GrpcClient {
   }
 
   /**
-   * Loads the gRPC service from the proto file at the given path and with the
+   * Loads the gRPC service from the proto file(s) at the given path and with the
    * given options.
-   * @param filename The path to the proto file.
+   * @param filename The path to the proto file(s).
    * @param options Options for loading the proto file.
    */
-  loadFromProto(filename: string, options: grpcProtoLoader.Options) {
-    const packageDef = grpcProtoLoader.loadSync(filename, options);
+  loadFromProto(filename: string | string[], options: grpcProtoLoader.Options) {
+    // TODO: @grpc/proto-loader actually supports loading multiple files
+    // but the .d.ts does not reflect this. Remove no-any when this is fixed.
+    // tslint:disable-next-line no-any
+    const packageDef = grpcProtoLoader.loadSync(filename as any, options);
     return this.grpc.loadPackageDefinition(packageDef);
   }
 
@@ -167,11 +170,11 @@ export class GrpcClient {
    * Load grpc proto service from a filename hooking in googleapis common protos
    * when necessary.
    * @param {String} protoPath - The directory to search for the protofile.
-   * @param {String} filename - The filename of the proto to be loaded.
+   * @param {String|String[]} filename - The filename(s) of the proto(s) to be loaded.
    * @return {Object<string, *>} The gRPC loaded result (the toplevel namespace
    *   object).
    */
-  loadProto(protoPath: string, filename: string) {
+  loadProto(protoPath: string, filename: string | string[]) {
     // This set of @grpc/proto-loader options
     // 'closely approximates the existing behavior of grpc.load'
     const includeDirs = INCLUDE_DIRS.slice();

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -175,7 +175,7 @@ export class GrpcClient {
    *   object).
    */
   loadProto(protoPath: string, filename: string | string[]) {
-    if (typeof filename === 'object' && filename.length === 0) {
+    if (Array.isArray(filename) && filename.length === 0) {
       return {};
     }
     // This set of @grpc/proto-loader options

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -245,6 +245,21 @@ describe('grpc', () => {
       expect(protos.google.iam.v1.IAMPolicy).to.be.a('Function');
     });
 
+    it('should load multiple files', () => {
+      const iamService = path.join('google', 'iam', 'v1', 'iam_policy.proto');
+      // no-any disabled because if the accessed fields are non-existent, this
+      // test will fail anyway.
+      const protos = grpcClient.loadProto(TEST_PATH, [
+        TEST_FILE,
+        iamService,
+        // tslint:disable-next-line:no-any
+      ]) as any;
+      expect(protos.google.example.library.v1.LibraryService).to.be.a(
+        'Function'
+      );
+      expect(protos.google.iam.v1.IAMPolicy).to.be.a('Function');
+    });
+
     it('should emit an error for not found proto', () => {
       const nonExistentDir = path.join(__dirname, 'nonexistent', 'dir');
       const nonExistentFile = 'nonexistent.proto';

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -245,6 +245,11 @@ describe('grpc', () => {
       expect(protos.google.iam.v1.IAMPolicy).to.be.a('Function');
     });
 
+    it('should be able to load no files', () => {
+      const protos = grpcClient.loadProto('.', []);
+      expect(protos).to.deep.equal({});
+    });
+
     it('should load multiple files', () => {
       const iamService = path.join('google', 'iam', 'v1', 'iam_policy.proto');
       // no-any disabled because if the accessed fields are non-existent, this


### PR DESCRIPTION
This will allow us to stop using `lodash.merge` in cases like [this one](https://github.com/googleapis/nodejs-pubsub/blob/c72491f9c3e68fff5d05f13ae73ea7e75b90c18b/src/v1/subscriber_client.js#L93-L103). It [turns out](https://github.com/grpc/grpc-node/issues/805) merging protos is supported by Protobuf.js and (unofficially, [proposal pending](https://github.com/grpc/proposal/pull/143)) supported by `@grpc/proto-loader`, so let's just use it and then remove `lodash.merge` from the client libraries.

This is a compatible, non-breaking, change. GAX v1.1.0 is coming!

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
