### PR TITLE
fix: use latest proto-loader with fixed types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@grpc/grpc-js": "^0.4.0",
-    "@grpc/proto-loader": "^0.5.0",
+    "@grpc/proto-loader": "^0.5.1",
     "duplexify": "^3.6.0",
     "google-auth-library": "^4.0.0",
     "is-stream-ended": "^0.1.4",

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -159,10 +159,7 @@ export class GrpcClient {
    * @param options Options for loading the proto file.
    */
   loadFromProto(filename: string | string[], options: grpcProtoLoader.Options) {
-    // TODO: @grpc/proto-loader actually supports loading multiple files
-    // but the .d.ts does not reflect this. Remove no-any when this is fixed.
-    // tslint:disable-next-line no-any
-    const packageDef = grpcProtoLoader.loadSync(filename as any, options);
+    const packageDef = grpcProtoLoader.loadSync(filename, options);
     return this.grpc.loadPackageDefinition(packageDef);
   }
 


### PR DESCRIPTION
The new patch release of `@grpc/proto-loader` updates types for `load` and `loadSync` so we don't need that `any` anymore.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
