### PR TITLE
refactor: do not use Status from grpc-js

### DIFF
--- a/src/bundlingCalls/bundleExecutor.ts
+++ b/src/bundlingCalls/bundleExecutor.ts
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {status} from '@grpc/grpc-js';
+import {Status} from '../status';
 
 import {SimpleCallbackFunction} from '../apitypes';
 import {GoogleError} from '../googleError';
@@ -163,7 +163,7 @@ export class BundleExecutor {
           this._options.requestByteLimit;
       }
       const error = new GoogleError(message);
-      error.code = status.INVALID_ARGUMENT;
+      error.code = Status.INVALID_ARGUMENT;
       callback(error);
       return {
         cancel: noop,

--- a/src/bundlingCalls/bundleExecutor.ts
+++ b/src/bundlingCalls/bundleExecutor.ts
@@ -113,9 +113,7 @@ export class BundleExecutor {
     if (request[this._descriptor.bundledField] === undefined) {
       warn(
         'bundling_no_bundled_field',
-        `Request does not contain field ${
-          this._descriptor.bundledField
-        } that must present for bundling. ` +
+        `Request does not contain field ${this._descriptor.bundledField} that must present for bundling. ` +
           `Invoking immediately. Request: ${JSON.stringify(request)}`
       );
       return apiCall(request, callback);

--- a/src/bundlingCalls/task.ts
+++ b/src/bundlingCalls/task.ts
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {status} from '@grpc/grpc-js';
+import {Status} from '../status';
 
 import {APICallback, GRPCCallResult, SimpleCallbackFunction} from '../apitypes';
 import {GoogleError} from '../googleError';
@@ -220,7 +220,7 @@ export class Task {
         for (let i = 0; i < self._data.length; ++i) {
           if (self._data[i].cancelled) {
             const error = new GoogleError('cancelled');
-            error.code = status.CANCELLED;
+            error.code = Status.CANCELLED;
             self._data[i].callback(error);
           } else {
             self._data[i].callback(err, responses[i]);
@@ -267,7 +267,7 @@ export class Task {
     for (let i = 0; i < this._data.length; ++i) {
       if (this._data[i].callback.id === id) {
         const error = new GoogleError('cancelled');
-        error.code = status.CANCELLED;
+        error.code = Status.CANCELLED;
         this._data[i].callback(error);
         this._data.splice(i, 1);
         break;

--- a/src/call.ts
+++ b/src/call.ts
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {status} from '@grpc/grpc-js';
+import {Status} from './status';
 
 import {
   APICallback,
@@ -75,7 +75,7 @@ export class OngoingCall {
       this.cancelFunc();
     } else {
       const error = new GoogleError('cancelled');
-      error.code = status.CANCELLED;
+      error.code = Status.CANCELLED;
       this.callback!(error);
     }
   }

--- a/src/longRunningCalls/longrunning.ts
+++ b/src/longRunningCalls/longrunning.ts
@@ -30,7 +30,7 @@
  */
 
 import {EventEmitter} from 'events';
-import {status} from '@grpc/grpc-js';
+import {Status} from '../status';
 
 import {GaxCallPromise, ResultTuple} from '../apitypes';
 import {CancellablePromise} from '../call';
@@ -278,7 +278,7 @@ export class Operation extends EventEmitter {
         const error = new GoogleError(
           'Total timeout exceeded before any response was received'
         );
-        error.code = status.DEADLINE_EXCEEDED;
+        error.code = Status.DEADLINE_EXCEEDED;
         setImmediate(emit, 'error', error);
         return;
       }
@@ -305,7 +305,7 @@ export class Operation extends EventEmitter {
             const error = new GoogleError(
               'Long running operation has finished but there was no result'
             );
-            error.code = status.UNKNOWN;
+            error.code = Status.UNKNOWN;
             setImmediate(emit, 'error', error);
             return;
           }

--- a/src/normalCalls/retries.ts
+++ b/src/normalCalls/retries.ts
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {status} from '@grpc/grpc-js';
+import {Status} from '../status';
 
 import {
   APICallback,
@@ -98,7 +98,7 @@ export function retryable(
         const error = new GoogleError(
           'Retry total timeout exceeded before any response was received'
         );
-        error.code = status.DEADLINE_EXCEEDED;
+        error.code = Status.DEADLINE_EXCEEDED;
         callback(error);
         return;
       }
@@ -108,7 +108,7 @@ export function retryable(
           'Exceeded maximum number of retries before any ' +
             'response was received'
         );
-        error.code = status.DEADLINE_EXCEEDED;
+        error.code = Status.DEADLINE_EXCEEDED;
         callback(error);
         return;
       }
@@ -147,7 +147,7 @@ export function retryable(
         'Cannot set both totalTimeoutMillis and maxRetries ' +
           'in backoffSettings.'
       );
-      error.code = status.INVALID_ARGUMENT;
+      error.code = Status.INVALID_ARGUMENT;
       callback(error);
     } else {
       repeat();
@@ -162,7 +162,7 @@ export function retryable(
           canceller.cancel();
         } else {
           const error = new GoogleError('cancelled');
-          error.code = status.CANCELLED;
+          error.code = Status.CANCELLED;
           callback(error);
         }
       },

--- a/src/status.ts
+++ b/src/status.ts
@@ -29,9 +29,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {Status} from './status';
+// The following is a copy of the Status enum defined in @grpc/grpc-js,
+// src/constants.ts. We need to use some of these statuses here and there,
+// but we don't want to include the whole @grpc/grpc-js into the browser
+// bundle just to have this small enum.
 
-export class GoogleError extends Error {
-  code?: Status;
-  note?: string;
+export enum Status {
+  OK = 0,
+  CANCELLED,
+  UNKNOWN,
+  INVALID_ARGUMENT,
+  DEADLINE_EXCEEDED,
+  NOT_FOUND,
+  ALREADY_EXISTS,
+  PERMISSION_DENIED,
+  RESOURCE_EXHAUSTED,
+  FAILED_PRECONDITION,
+  ABORTED,
+  OUT_OF_RANGE,
+  UNIMPLEMENTED,
+  INTERNAL,
+  UNAVAILABLE,
+  DATA_LOSS,
+  UNAUTHENTICATED,
 }


### PR DESCRIPTION
We use this `Status` enum here and there, and when we create a webpack bundle, it tries to bundle all the `@grpc/grpc-js` even if all it needs it just this tiny enum.

Let's just make a copy of it - maybe not the cleanest, but the easiest solution.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
