### PR TITLE
fix: routing header parameters must be urlencoded

### DIFF
--- a/src/routingHeader.ts
+++ b/src/routingHeader.ts
@@ -44,8 +44,11 @@
  * @param {Object} params - the request header parameters.
  * @return {string} the routing header value.
  */
-export function fromParams(params: {[index: string]: {}}): string {
-  return Object.keys(params)
-    .map(key => `${key}=${params[key]}`)
-    .join('&');
+
+import * as querystring from 'querystring';
+
+export function fromParams(params: {
+  [index: string]: string | number | boolean;
+}): string {
+  return querystring.stringify(params);
 }

--- a/src/routingHeader.ts
+++ b/src/routingHeader.ts
@@ -29,6 +29,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import * as querystring from 'querystring';
+
 /**
  * Helpers for constructing routing headers.
  *
@@ -44,8 +46,6 @@
  * @param {Object} params - the request header parameters.
  * @return {string} the routing header value.
  */
-
-import * as querystring from 'querystring';
 
 export function fromParams(params: {
   [index: string]: string | number | boolean;

--- a/test/routingHeader.ts
+++ b/test/routingHeader.ts
@@ -37,4 +37,11 @@ describe('fromParams', () => {
     const routingHeader = fromParams({name: 'foo', 'book.read': true});
     expect(routingHeader).to.equal('name=foo&book.read=true');
   });
+
+  it('encodes non-ASCII characters', () => {
+    const routingHeader = fromParams({screaming: '😱', cyrillic: 'тест'});
+    expect(routingHeader).to.equal(
+      'screaming=%F0%9F%98%B1&cyrillic=%D1%82%D0%B5%D1%81%D1%82'
+    );
+  });
 });


### PR DESCRIPTION
Fixes #520 (cc: @schmidt-sebastian)

Turns out we had our very own implementation of `querystring.stringify`. Not anymore.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
