### PR TITLE
fix: copy values from LRO to Operation wrapper

### DIFF
--- a/src/longRunningCalls/longrunning.ts
+++ b/src/longRunningCalls/longrunning.ts
@@ -94,6 +94,9 @@ export class Operation extends EventEmitter {
     this.completeListeners = 0;
     this.hasActiveListeners = false;
     this.latestResponse = grpcOp;
+    this.name = this.latestResponse.name;
+    this.done = this.latestResponse.done;
+    this.error = this.latestResponse.error;
     this.longrunningDescriptor = longrunningDescriptor;
     this.result = null;
     this.metadata = null;
@@ -218,6 +221,7 @@ export class Operation extends EventEmitter {
       if (op.result === 'error') {
         const error = new GoogleError(op.error!.message);
         error.code = op.error!.code;
+        this.error = error;
         if (callback) {
           callback(error);
         }
@@ -225,8 +229,10 @@ export class Operation extends EventEmitter {
       }
 
       if (responseDecoder && op.response) {
+        this.response = op.response;
         response = responseDecoder(op.response.value);
         this.result = response;
+        this.done = true;
       }
     }
 

--- a/test/longrunning.ts
+++ b/test/longrunning.ts
@@ -168,6 +168,9 @@ describe('longrunning', () => {
             defaultTotalTimeoutMillis
           );
           expect(operation).to.have.property('longrunningDescriptor');
+          expect(operation.name).to.deep.eq(OPERATION_NAME);
+          // tslint:disable-next-line no-unused-expression
+          expect(operation.done).to.be.false;
           expect(operation.latestResponse).to.deep.eq(PENDING_OP);
           // tslint:disable-next-line no-unused-expression
           expect(operation.result).to.be.null;
@@ -221,6 +224,10 @@ describe('longrunning', () => {
         totalTimeoutMillis
       );
       expect(operation).to.have.property('longrunningDescriptor');
+      expect(operation.name).to.deep.eq(OPERATION_NAME);
+      // tslint:disable-next-line no-unused-expression
+      expect(operation.done).to.be.true;
+      expect(operation.response).to.deep.eq(RESPONSE);
       expect(operation.result).to.deep.eq(RESPONSE_VAL);
       expect(operation.metadata).to.deep.eq(METADATA_VAL);
       expect(operation.latestResponse).to.deep.eq(SUCCESSFUL_OP);


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-speech/issues/397.

Seems like some properties of the `Operation` wrapper were never set. Fixing it.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
