### PR TITLE
chore(deps): update dependency @grpc/grpc-js to ^0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "protos"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^0.4.0",
+    "@grpc/grpc-js": "^0.5.2",
     "@grpc/proto-loader": "^0.5.1",
     "duplexify": "^3.6.0",
     "google-auth-library": "^4.0.0",


### PR DESCRIPTION
This fix includes https://github.com/grpc/grpc-node/pull/962 which is a work around for a bad metadata keys problem that many customer see across several libraries (https://github.com/googleapis/nodejs-datastore/issues/415, https://github.com/googleapis/nodejs-logging/issues/527, https://github.com/googleapis/nodejs-pubsub/issues/667 are just a few).

Fixes https://github.com/googleapis/nodejs-datastore/issues/415
Fixes https://github.com/googleapis/nodejs-logging/issues/527

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
