### PR TITLE
docs: fix the url for codecov.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ For detailed documentation of the modules in gax-nodejs, please check out the [d
 ## License
 BSD - See [LICENSE][license] for more information.
 
-[codecovimg]: https://codecov.io/github/googleapis/gax-nodejs/coverage.svg?branch=master
-[codecov]: https://codecov.io/github/googleapis/gax-nodejs?branch=master
+[codecovimg]: https://codecov.io/gh/googleapis/gax-nodejs/coverage.svg?branch=master
+[codecov]: https://codecov.io/gh/googleapis/gax-nodejs?branch=master
 [contributing]: https://github.com/googleapis/gax-nodejs/blob/master/CONTRIBUTING.md
 [docs]: http://googleapis.github.io/gax-nodejs/
 [license]: https://github.com/googleapis/gax-nodejs/blob/master/LICENSE


### PR DESCRIPTION
To make `linkinator` work better (that is, ignore the codecov.io URLs in its checks).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
