### PR TITLE
feat: allow to pass just one file path to loadProto

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -168,10 +168,16 @@ export class GrpcClient {
    * when necessary.
    * @param {String} protoPath - The directory to search for the protofile.
    * @param {String|String[]} filename - The filename(s) of the proto(s) to be loaded.
+   *   If omitted, protoPath will be treated as a file path to load.
    * @return {Object<string, *>} The gRPC loaded result (the toplevel namespace
    *   object).
    */
-  loadProto(protoPath: string, filename: string | string[]) {
+  loadProto(protoPath: string, filename?: string | string[]) {
+    if (!filename) {
+      filename = path.basename(protoPath);
+      protoPath = path.dirname(protoPath);
+    }
+
     if (Array.isArray(filename) && filename.length === 0) {
       return {};
     }

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -235,6 +235,17 @@ describe('grpc', () => {
       );
     });
 
+    it('should load the test file using single parameter syntax', () => {
+      const fullPath = path.join(TEST_PATH, TEST_FILE);
+      // no-any disabled because if the accessed fields are non-existent, this
+      // test will fail anyway.
+      // tslint:disable-next-line:no-any
+      const protos = grpcClient.loadProto(fullPath) as any;
+      expect(protos.google.example.library.v1.LibraryService).to.be.a(
+        'Function'
+      );
+    });
+
     it('should load a common proto', () => {
       const nonExistentDir = path.join(__dirname, 'nonexistent', 'dir');
       const iamService = path.join('google', 'iam', 'v1', 'iam_policy.proto');


### PR DESCRIPTION
This fix allows to call `gaxGrpc.loadProto(file)` passing just one file as a parameter. The current API only allows two parameters (folder and filename). This change is compatible and allows for simpler `loadProto` usage for the use case when just one proto file must be loaded.

(and it will be used in client libraries soon!)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
