### PR TITLE
feat: reexport protobufjs from gax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,6 @@ lro.ALL_SCOPES = operationsClient.ALL_SCOPES;
 export {lro};
 export const createByteLengthFunction = GrpcClient.createByteLengthFunction;
 export const version = require('../../package.json').version;
+
+import * as protobuf from 'protobufjs';
+export {protobuf};

--- a/test/grpc.ts
+++ b/test/grpc.ts
@@ -30,11 +30,11 @@
 
 import {expect} from 'chai';
 import * as path from 'path';
-import * as protobuf from 'protobufjs';
 import * as proxyquire from 'proxyquire';
 import * as semver from 'semver';
 import * as sinon from 'sinon';
 
+import {protobuf} from '../src/index';
 import {GoogleProtoFilesRoot, GrpcClient} from '../src/grpc';
 
 function gaxGrpc(options?) {


### PR DESCRIPTION
We sometimes need `protobufjs` in client libraries (e.g. for LRO proto loading). gapic-generator does not do a great job detecting if `protobufjs` is needed or not for the given client library, which sometimes causes lint errors about unused dependency.

Since `protobufjs` is an important part of gax, it will always be installed within gax. Let's just reexport it from gax, so that the client library used `gax.protobuf.loadSync`, `gax.protobuf.Root`, etc. whenever needed. By doing this, we'll remove `protobufjs` dependency from the client libraries, and also will make sure there will be no compatibility problems between two `protobufjs` dependencies.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
