### PR TITLE
fix: compileProtos should not fail if no protos are given

### DIFF
--- a/test/compileProtos.ts
+++ b/test/compileProtos.ts
@@ -67,12 +67,30 @@ describe('compileProtos tool', () => {
     ]);
     const expectedResultFile = path.join(resultDir, 'protos.json');
     assert(fs.existsSync(expectedResultFile));
-    console.log(expectedResultFile);
 
     const json = await readFile(expectedResultFile);
     const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
 
     assert(root.lookup('TestMessage'));
     assert(root.lookup('LibraryService'));
+  });
+
+  it('writes an empty object if no protos are given', async () => {
+    await compileProtos.main([
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        'test',
+        'fixtures',
+        'protoLists',
+        'empty'
+      ),
+    ]);
+    const expectedResultFile = path.join(resultDir, 'protos.json');
+    assert(fs.existsSync(expectedResultFile));
+
+    const json = await readFile(expectedResultFile);
+    assert.strictEqual(json.toString(), '{}');
   });
 });

--- a/test/fixtures/protoLists/empty/README.txt
+++ b/test/fixtures/protoLists/empty/README.txt
@@ -1,0 +1,1 @@
+This folder is intentionally left empty.

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -42,7 +42,7 @@ const writeFile = util.promisify(fs.writeFile);
 const stat = util.promisify(fs.stat);
 const pbjsMain = util.promisify(pbjs.main);
 
-const PROTO_LIST_REGEX = /_proto_list.json$/;
+const PROTO_LIST_REGEX = /_proto_list\.json$/;
 
 /**
  * Recursively scans directories starting from `directory` and finds all files

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -114,7 +114,7 @@ async function compileProtos(protos: string[]): Promise<void> {
     '--target',
     'json',
     '-p',
-    path.join('node_modules', 'google-gax', 'protos'),
+    path.join(__dirname, '..', '..', 'protos'),
     '-p',
     'protos',
     '-o',

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -38,6 +38,7 @@ import * as pbjs from 'protobufjs/cli/pbjs';
 
 const readdir = util.promisify(fs.readdir);
 const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
 const stat = util.promisify(fs.stat);
 const pbjsMain = util.promisify(pbjs.main);
 
@@ -97,11 +98,18 @@ async function buildListOfProtos(protoJsonFiles: string[]): Promise<string[]> {
 
 /**
  * Runs `pbjs` to compile the given proto files, placing the result into
- * `./protos/protos.json`.
+ * `./protos/protos.json`. No support for changing output filename for now
+ * (but it's a TODO!)
  *
  * @param {string[]} protos List of proto files to compile.
  */
 async function compileProtos(protos: string[]): Promise<void> {
+  const output = path.join('protos', 'protos.json');
+  if (protos.length === 0) {
+    // no input file, just emit an empty object
+    await writeFile(output, '{}');
+    return;
+  }
   const pbjsArgs = [
     '--target',
     'json',
@@ -110,7 +118,7 @@ async function compileProtos(protos: string[]): Promise<void> {
     '-p',
     'protos',
     '-o',
-    path.join('protos', 'protos.json'),
+    output,
   ];
   pbjsArgs.push(...protos);
   await pbjsMain(pbjsArgs);


### PR DESCRIPTION
OK so I wrote this `compileProtos` script and it works, now let's fix some corner cases :)

This one makes it not fail if no protos are there yet (which will simplify our transition it a lot). Basically, no protos => no JSON (empty object).

Also, `compileProtos` needs to have use common protos (that are a part of `google-gax` distribution). To make it easier to run the script from a library folder without doing an extra `npm install`, let's use `__dirname` as a starting point for looking up those common protos.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
