### PR TITLE
feat: support sending `x-goog-request-params` (and other extra) headers for fallback requests 

### DIFF
--- a/browser-test/test.grpc-fallback.ts
+++ b/browser-test/test.grpc-fallback.ts
@@ -31,10 +31,12 @@
 
 import * as assert from 'assert';
 import * as protobuf from 'protobufjs';
+import * as gax from '../src/browser';
 import * as sinon from 'sinon';
 import {echoProtoJson} from './echoProtoJson';
 import {expect} from 'chai';
 import {GrpcClient} from '../src/browser';
+import * as EchoClient from '../system-test/fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client';
 
 const authStub = {
   getRequestHeaders() {
@@ -194,6 +196,7 @@ describe('grpc-fallback', () => {
       {},
       (err, result) => {}
     );
+    console.log('real result,', result);
   });
 
   it('should be able to cancel an API call using AbortController', async () => {
@@ -208,5 +211,50 @@ describe('grpc-fallback', () => {
 
     // @ts-ignore
     assert.strictEqual(createdAbortControllers[0].abortCalled, true);
+  });
+
+  it('should be able to add extra headers to the request', async () => {
+    const authStub = {
+      getRequestHeaders() {
+        return {Authorization: 'Bearer SOME_TOKEN'};
+      },
+    };
+
+    const opts = {
+      auth: authStub,
+      protocol: 'http',
+      port: 1337,
+    };
+
+    const client = new EchoClient(opts);
+    const requestObject = {content: 'test-content'};
+    // tslint:disable-next-line no-any
+    const options: any = {};
+    options.otherArgs = {};
+    options.otherArgs.headers = {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      abc: 'def',
+    });
+    const responseType = protos.lookupType('EchoResponse');
+    const response = responseType.create(requestObject);
+    console.log('response:', responseType.encode(response).finish());
+    const savedFetch = window.fetch;
+    // @ts-ignore
+    window.fetch = (url, options) => {
+      // @ts-ignore
+      assert.strictEqual(options.headers['x-goog-request-params'], 'abc=def');
+
+      return Promise.resolve({
+        arrayBuffer: () => {
+          Promise.resolve(responseType.encode(response).finish());
+        },
+      });
+    };
+    const [result] = await client.echo(requestObject, options);
+    //TODO: assert that result is what we want
+
+    window.fetch = savedFetch;
   });
 });

--- a/browser-test/test.grpc-fallback.ts
+++ b/browser-test/test.grpc-fallback.ts
@@ -188,7 +188,12 @@ describe('grpc-fallback', () => {
     sinon.replace(window, 'fetch', fakeFetch);
 
     const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
-    const result = await echoStub.echo(requestObject);
+    const result = await echoStub.echo(
+      requestObject,
+      {},
+      {},
+      (err, result) => {}
+    );
   });
 
   it('should be able to cancel an API call using AbortController', async () => {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -32,6 +32,7 @@
 import * as protobuf from 'protobufjs';
 import * as gax from './gax';
 import * as nodeFetch from 'node-fetch';
+import * as routingHeader from './routingHeader';
 import {Status} from './status';
 import {OutgoingHttpHeaders} from 'http';
 import {
@@ -50,6 +51,7 @@ import {createApiCall as _createApiCall} from './createApiCall';
 import {isBrowser} from './isbrowser';
 
 export {PathTemplate} from './pathTemplate';
+export {routingHeader};
 export {CallSettings, constructSettings, RetryOptions} from './gax';
 
 export {
@@ -138,11 +140,37 @@ export class GrpcClient {
     configOverrides: gax.ClientConfig,
     headers: OutgoingHttpHeaders
   ) {
+    function buildMetadata(abTests, moreHeaders) {
+      const metadata = {};
+      if (moreHeaders) {
+        for (const key in moreHeaders) {
+          if (
+            key.toLowerCase() !== 'x-goog-api-client' &&
+            moreHeaders.hasOwnProperty(key)
+          ) {
+            const value = moreHeaders[key];
+            if (Array.isArray(value)) {
+              if (metadata[key] === undefined) {
+                metadata[key] = value;
+              } else {
+                value.forEach(v => {
+                  metadata[key].push(v);
+                });
+              }
+            } else {
+              metadata[key] = value;
+            }
+          }
+        }
+      }
+      return metadata;
+    }
     return gax.constructSettings(
       serviceName,
       clientConfig,
       configOverrides,
       Status,
+      {metadataBuilder: buildMetadata},
       this.promise
     );
   }
@@ -171,81 +199,83 @@ export class GrpcClient {
     }
     const authHeader = await this.authClient.getRequestHeaders();
     function serviceClientImpl(method, requestData, callback) {
-      let cancelController, cancelSignal;
-      if (typeof AbortController !== 'undefined') {
-        cancelController = new AbortController();
-        cancelSignal = cancelController.signal;
-      }
-      const cancelHandler: CancelHandler = {
-        canceller: cancelController,
-        cancelRequested: false,
-      };
-      const headers = Object.assign({}, authHeader);
-      headers['Content-Type'] = 'application/x-protobuf';
-
-      const grpcFallbackProtocol = opts.protocol || 'https';
-      let servicePath = opts.servicePath;
-      if (!servicePath) {
-        if (service.options && service.options['(google.api.default_host)']) {
-          servicePath = service.options['(google.api.default_host)'];
-        } else {
-          callback(new Error('Service path is undefined'));
-          return;
-        }
-      }
-      let servicePort;
-      const match = servicePath.match(/^(.*):(\d+)$/);
-      if (match) {
-        servicePath = match[1];
-        servicePort = match[2];
-      }
-      if (opts.port) {
-        servicePort = opts.port;
-      } else if (!servicePort) {
-        servicePort = 443;
-      }
-      const protoNamespaces: string[] = [];
-      let currNamespace = method.parent;
-      while (currNamespace.name !== '') {
-        protoNamespaces.unshift(currNamespace.name);
-        currNamespace = currNamespace.parent;
-      }
-      const protoServiceName = protoNamespaces.join('.');
-      const rpcName = method.name;
-
-      const url = `${grpcFallbackProtocol}://${servicePath}:${servicePort}/$rpc/${protoServiceName}/${rpcName}`;
-
-      const fetch = isBrowser() ? window.fetch : nodeFetch;
-      fetch(url, {
-        headers,
-        method: 'post',
-        body: requestData,
-        signal: cancelSignal,
-      })
-        .then(response => {
-          return response.arrayBuffer();
-        })
-        .then(buffer => {
-          callback(null, new Uint8Array(buffer));
-        })
-        .catch(err => {
-          if (!cancelHandler.cancelRequested || err.name !== 'AbortError') {
-            callback(err);
-          }
-        });
-      return cancelHandler;
+      return [method, requestData, callback];
     }
-
     const serviceStub = service.create(serviceClientImpl, false, false);
     const methods = this.getServiceMethods(service);
 
     const newServiceStub = service.create(serviceClientImpl, false, false);
     for (const methodName of methods) {
       newServiceStub[methodName] = (req, options, metadata, callback) => {
-        const cancelHandler = serviceStub[methodName].apply(serviceStub, [
-          req,
-          callback,
-        ]) as CancelHandler;
+        const [method, requestData, serviceCallback] = serviceStub[
+          methodName
+        ].apply(serviceStub, [req, callback]);
+
+        let cancelController, cancelSignal;
+        if (typeof AbortController !== 'undefined') {
+          cancelController = new AbortController();
+          cancelSignal = cancelController.signal;
+        }
+        const cancelHandler: CancelHandler = {
+          canceller: cancelController,
+          cancelRequested: false,
+        };
+        const headers = Object.assign({}, authHeader);
+        headers['Content-Type'] = 'application/x-protobuf';
+        for (const key of Object.keys(options)) {
+          headers[key] = options[key];
+        }
+        const grpcFallbackProtocol = opts.protocol || 'https';
+        let servicePath = opts.servicePath;
+        if (!servicePath) {
+          if (service.options && service.options['(google.api.default_host)']) {
+            servicePath = service.options['(google.api.default_host)'];
+          } else {
+            serviceCallback(new Error('Service path is undefined'));
+            return;
+          }
+        }
+        let servicePort;
+        const match = servicePath.match(/^(.*):(\d+)$/);
+        if (match) {
+          servicePath = match[1];
+          servicePort = match[2];
+        }
+        if (opts.port) {
+          servicePort = opts.port;
+        } else if (!servicePort) {
+          servicePort = 443;
+        }
+        const protoNamespaces: string[] = [];
+        let currNamespace = method.parent;
+        while (currNamespace.name !== '') {
+          protoNamespaces.unshift(currNamespace.name);
+          currNamespace = currNamespace.parent;
+        }
+        const protoServiceName = protoNamespaces.join('.');
+        const rpcName = method.name;
+
+        const url = `${grpcFallbackProtocol}://${servicePath}:${servicePort}/$rpc/${protoServiceName}/${rpcName}`;
+
+        const fetch = isBrowser() ? window.fetch : nodeFetch;
+        fetch(url, {
+          headers,
+          method: 'post',
+          body: requestData,
+          signal: cancelSignal,
+        })
+          .then(response => {
+            return response.arrayBuffer();
+          })
+          .then(buffer => {
+            serviceCallback(null, new Uint8Array(buffer));
+          })
+          .catch(err => {
+            if (!cancelHandler.cancelRequested || err.name !== 'AbortError') {
+              serviceCallback(err);
+            }
+          });
+
         return {
           cancel: () => {
             if (!cancelHandler.canceller) {


### PR DESCRIPTION
Changed constructSettings() and createStub() to support sending extra headers (set in options) through fallback requests. 