### PR TITLE
feat: export call types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,3 +83,12 @@ export {protobuf};
 
 import * as fallback from './fallback';
 export {fallback};
+
+export {
+  GRPCCallResult,
+  ServerStreamingCall,
+  ClientStreamingCall,
+  BiDiStreamingCall,
+  UnaryCall,
+  GRPCCall,
+} from './apitypes';


### PR DESCRIPTION
We need to have these types exported to properly define return types in the TypeScript code. Technically a 'feature' but no actual code is changed. Will be released as v1.5.0.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
