### PR TITLE
fix: properly handle gRPC-fallback errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "lint": "gts check && eslint samples/*.js samples/**/*.js",
     "clean": "gts clean",
     "compile": "tsc -p . && cp src/*.json build/src && cp src/*.js build/src && cp -r test/fixtures build/test/",
-    "compile-protos": "pbjs -t json ./protos/google/longrunning/operations.proto -p ./protos > protos/operations.json",
+    "compile-protos": "pbjs -t json google/longrunning/operations.proto -p ./protos > protos/operations.json && pbjs -t json google/rpc/status.proto google/rpc/error_details.proto google/protobuf/any.proto -p ./protos > protos/status.json",
     "fix": "gts fix && eslint --fix samples/*.js samples/**/*.js",
     "prepare": "npm run compile && node ./build/tools/prepublish.js",
     "posttest": "npm run lint",

--- a/protos/status.json
+++ b/protos/status.json
@@ -1,0 +1,225 @@
+{
+  "nested": {
+    "google": {
+      "nested": {
+        "protobuf": {
+          "nested": {
+            "Any": {
+              "fields": {
+                "type_url": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            },
+            "Duration": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            }
+          }
+        },
+        "rpc": {
+          "options": {
+            "go_package": "google.golang.org/genproto/googleapis/rpc/errdetails;errdetails",
+            "java_multiple_files": true,
+            "java_outer_classname": "ErrorDetailsProto",
+            "java_package": "com.google.rpc",
+            "objc_class_prefix": "RPC"
+          },
+          "nested": {
+            "Status": {
+              "fields": {
+                "code": {
+                  "type": "int32",
+                  "id": 1
+                },
+                "message": {
+                  "type": "string",
+                  "id": 2
+                },
+                "details": {
+                  "rule": "repeated",
+                  "type": "google.protobuf.Any",
+                  "id": 3
+                }
+              }
+            },
+            "RetryInfo": {
+              "fields": {
+                "retryDelay": {
+                  "type": "google.protobuf.Duration",
+                  "id": 1
+                }
+              }
+            },
+            "DebugInfo": {
+              "fields": {
+                "stackEntries": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 1
+                },
+                "detail": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "QuotaFailure": {
+              "fields": {
+                "violations": {
+                  "rule": "repeated",
+                  "type": "Violation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Violation": {
+                  "fields": {
+                    "subject": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "PreconditionFailure": {
+              "fields": {
+                "violations": {
+                  "rule": "repeated",
+                  "type": "Violation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Violation": {
+                  "fields": {
+                    "type": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "subject": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                }
+              }
+            },
+            "BadRequest": {
+              "fields": {
+                "fieldViolations": {
+                  "rule": "repeated",
+                  "type": "FieldViolation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "FieldViolation": {
+                  "fields": {
+                    "field": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "RequestInfo": {
+              "fields": {
+                "requestId": {
+                  "type": "string",
+                  "id": 1
+                },
+                "servingData": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "ResourceInfo": {
+              "fields": {
+                "resourceType": {
+                  "type": "string",
+                  "id": 1
+                },
+                "resourceName": {
+                  "type": "string",
+                  "id": 2
+                },
+                "owner": {
+                  "type": "string",
+                  "id": 3
+                },
+                "description": {
+                  "type": "string",
+                  "id": 4
+                }
+              }
+            },
+            "Help": {
+              "fields": {
+                "links": {
+                  "rule": "repeated",
+                  "type": "Link",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Link": {
+                  "fields": {
+                    "description": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "url": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "LocalizedMessage": {
+              "fields": {
+                "locale": {
+                  "type": "string",
+                  "id": 1
+                },
+                "message": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/fallbackError.ts
+++ b/src/fallbackError.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import * as protobuf from 'protobufjs';
+
+interface ProtobufAny {
+  type_url: string;
+  value: Uint8Array;
+}
+
+interface RpcStatus {
+  code: number;
+  message: string;
+  details: ProtobufAny[];
+}
+
+interface DecodedRpcStatus {
+  code: number;
+  message: string;
+  details: Array<{}>;
+}
+
+export class FallbackErrorDecoder {
+  root: protobuf.Root;
+  anyType: protobuf.Type;
+  statusType: protobuf.Type;
+
+  constructor() {
+    const errorProtoJson = require('../../protos/status.json');
+    this.root = protobuf.Root.fromJSON(errorProtoJson);
+    this.anyType = this.root.lookupType('google.protobuf.Any');
+    this.statusType = this.root.lookupType('google.rpc.Status');
+  }
+
+  decodeProtobufAny(anyValue: ProtobufAny): protobuf.Message<{}> {
+    const match = anyValue.type_url.match(/^type.googleapis.com\/(.*)/);
+    if (!match) {
+      throw new Error(
+        `Unknown type encoded in google.protobuf.any: ${anyValue.type_url}`
+      );
+    }
+    const typeName = match[1];
+    const type = this.root.lookupType(typeName);
+    if (!type) {
+      throw new Error(`Cannot lookup type ${typeName}`);
+    }
+    return type.decode(anyValue.value);
+  }
+
+  // Decodes gRPC-fallback error which is an instance of google.rpc.Status.
+  decodeRpcStatus(buffer: Buffer | ArrayBuffer): DecodedRpcStatus {
+    const uint8array = new Uint8Array(buffer);
+    const status = (this.statusType.decode(uint8array) as unknown) as RpcStatus;
+
+    // google.rpc.Status contains an array of google.protobuf.Any
+    // which need a special treatment
+    const result = {
+      code: status.code,
+      message: status.message,
+      details: status.details.map(detail => this.decodeProtobufAny(detail)),
+    };
+    return result;
+  }
+}

--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -279,5 +279,4 @@ describe('grpc-fallback', () => {
       });
     });
   });
-
 });

--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -37,6 +37,8 @@ import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {expect} from 'chai';
 import * as EchoClient from '../fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client';
 
+const statusJsonProto = require('../../protos/status.json');
+
 const authStub = {
   getRequestHeaders() {
     return {Authorization: 'Bearer SOME_TOKEN'};
@@ -195,6 +197,7 @@ describe('grpc-fallback', () => {
     const responseType = protos.lookupType('EchoResponse');
     const response = responseType.create(requestObject); // request === response for EchoService
     const fakeFetch = sinon.fake.resolves({
+      ok: true,
       arrayBuffer: () => {
         return Promise.resolve(responseType.encode(response).finish());
       },
@@ -238,6 +241,7 @@ describe('grpc-fallback', () => {
       // @ts-ignore
       assert.strictEqual(options.headers['x-goog-request-params'], 'abc=def');
       return Promise.resolve({
+        ok: true,
         arrayBuffer: () => {
           return Promise.resolve(responseType.encode(response).finish());
         },
@@ -247,4 +251,33 @@ describe('grpc-fallback', () => {
     assert.strictEqual(requestObject.content, result.content);
     window.fetch = savedFetch;
   });
+
+  it('should handle an error', done => {
+    const requestObject = {content: 'test-content'};
+    // example of an actual google.rpc.Status error message returned by Language API
+    const expectedError = {
+      code: 3,
+      message: 'Error message',
+      details: [],
+    };
+
+    const fakeFetch = sinon.fake.resolves({
+      ok: false,
+      arrayBuffer: () => {
+        const root = protobuf.Root.fromJSON(statusJsonProto);
+        const statusType = root.lookupType('google.rpc.Status');
+        const statusMessage = statusType.fromObject(expectedError);
+        return Promise.resolve(statusType.encode(statusMessage).finish());
+      },
+    });
+    sinon.replace(window, 'fetch', fakeFetch);
+
+    gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+      echoStub.echo(requestObject, {}, {}, (err, result) => {
+        assert.strictEqual(err.message, JSON.stringify(expectedError));
+        done();
+      });
+    });
+  });
+
 });

--- a/test/fixtures/error.bin
+++ b/test/fixtures/error.bin
@@ -1,0 +1,4 @@
+/One of content, or gcs_content_uri must be set.k
+)type.googleapis.com/google.rpc.BadRequest>
+<
+document.content(Must have some text content to annotate.

--- a/test/unit/fallbackError.ts
+++ b/test/unit/fallbackError.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {FallbackErrorDecoder} from '../../src/fallbackError';
+
+describe('gRPC-fallback error decoding', () => {
+  it('decodes error', () => {
+    // example of an actual google.rpc.Status error message returned by Language API
+    const fixtureName = path.resolve(__dirname, '..', 'fixtures', 'error.bin');
+    const errorBin = fs.readFileSync(fixtureName);
+    const expectedError = {
+      code: 3,
+      message: 'One of content, or gcs_content_uri must be set.',
+      details: [
+        {
+          fieldViolations: [
+            {
+              field: 'document.content',
+              description: 'Must have some text content to annotate.',
+            },
+          ],
+        },
+      ],
+    };
+    const decoder = new FallbackErrorDecoder();
+    const decodedError = decoder.decodeRpcStatus(errorBin);
+
+    // nested error messages have different types so we can't use deepStrictEqual here
+    assert.strictEqual(
+      JSON.stringify(decodedError),
+      JSON.stringify(expectedError)
+    );
+  });
+});

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -202,8 +202,6 @@ describe('grpc-fallback', () => {
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err, result) => {
-        console.log(err);
-        console.log(result);
         assert.strictEqual(err, null);
         assert.strictEqual(requestObject.content, result.content);
         done();

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -30,6 +30,8 @@
  */
 
 import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
 import * as nodeFetch from 'node-fetch';
 import * as abortController from 'abort-controller';
 import * as protobuf from 'protobufjs';
@@ -191,6 +193,7 @@ describe('grpc-fallback', () => {
 
     sinon.stub(nodeFetch, 'Promise').returns(
       Promise.resolve({
+        ok: true,
         arrayBuffer: () => {
           return Promise.resolve(responseType.encode(response).finish());
         },
@@ -199,7 +202,47 @@ describe('grpc-fallback', () => {
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err, result) => {
+        console.log(err);
+        console.log(result);
+        assert.strictEqual(err, null);
         assert.strictEqual(requestObject.content, result.content);
+        done();
+      });
+    });
+  });
+
+  it('should handle an error', done => {
+    const requestObject = {content: 'test-content'};
+    // example of an actual google.rpc.Status error message returned by Language API
+    const fixtureName = path.resolve(__dirname, '..', 'fixtures', 'error.bin');
+    const errorBin = fs.readFileSync(fixtureName);
+    const expectedError = {
+      code: 3,
+      message: 'One of content, or gcs_content_uri must be set.',
+      details: [
+        {
+          fieldViolations: [
+            {
+              field: 'document.content',
+              description: 'Must have some text content to annotate.',
+            },
+          ],
+        },
+      ],
+    };
+
+    sinon.stub(nodeFetch, 'Promise').returns(
+      Promise.resolve({
+        ok: false,
+        arrayBuffer: () => {
+          return Promise.resolve(errorBin);
+        },
+      })
+    );
+
+    gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+      echoStub.echo(requestObject, {}, {}, (err, result) => {
+        assert.strictEqual(err.message, JSON.stringify(expectedError));
         done();
       });
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
       alias: {
         '../../package.json': path.resolve(__dirname, 'package.json'),
         '../../protos/operations.json': path.resolve(__dirname, 'protos/operations.json'),
+        '../../protos/status.json': path.resolve(__dirname, 'protos/status.json'),
       },
     },
     module: {


### PR DESCRIPTION
We did not handle errors (4xx HTTP codes) in gRPC-fallback code properly.

According to the [document](https://googleapis.github.io/HowToRPC#grpc-fallback-experimental), in case of an error, the HTTP response payload is a serialized instance of `google.rpc.Status`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
