### PR TITLE
fix: make fallback version unique

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -55,7 +55,7 @@ import {FallbackErrorDecoder} from './fallbackError';
 export {PathTemplate} from './pathTemplate';
 export {routingHeader};
 export {CallSettings, constructSettings, RetryOptions} from './gax';
-export const version = require('../../package.json').version;
+export const version = require('../../package.json').version + '-fallback';
 
 export {
   BundleDescriptor,

--- a/test/unit/exports.ts
+++ b/test/unit/exports.ts
@@ -98,7 +98,7 @@ describe('exports', () => {
     });
     it('exports version', () => {
       assert(typeof fallback.version === 'string');
-      assert.strictEqual(fallback.version, version);
+      assert.strictEqual(fallback.version, version + '-fallback');
     });
   });
 });


### PR DESCRIPTION
This PR make the exported `version` (that goes to the `gax/` field of `x-goog-api-client`) say if it's a fallback or regular version of gax. This makes sense, since even though they share versions, the fallback one uses totally different code.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
