### PR TITLE
test: use tar directly in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "sinon": "^7.0.0",
     "source-map-support": "^0.5.6",
     "stream-events": "^1.0.4",
-    "tar": "^4.4.10",
     "through2": "^3.0.0",
     "ts-loader": "^6.0.3",
     "typescript": "~3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "google-gax",
+  "_zzzzz": "test",
   "version": "1.6.1",
   "description": "Google API Extensions",
   "main": "build/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "google-gax",
-  "_zzzzz": "test",
   "version": "1.6.1",
   "description": "Google API Extensions",
   "main": "build/src/index.js",

--- a/test/system-test/showcase-server.ts
+++ b/test/system-test/showcase-server.ts
@@ -57,11 +57,24 @@ export class ShowcaseServer {
     process.chdir(testDir);
     console.log(`Server will be run from ${testDir}.`);
 
+    console.log(`About to download ${fallbackServerUrl} into ${testDir}`);
     await download(fallbackServerUrl, testDir);
+    console.log(`Downloaded:`);
+    {
+      const {stdout} = await execa('ls', ['-l', testDir]);
+      console.log(stdout);
+    }
+    console.log(`About to extract ${tarballFilename}`);
     await tar.extract({
       file: tarballFilename,
     });
+    console.log('Extracted');
 
+    {
+      const {stdout} = await execa('ls', ['-l', testDir]);
+      console.log(stdout);
+    }
+    console.log(`About to run ${binaryName}`);
     const childProcess = execa(binaryName, ['run'], {
       cwd: testDir,
       stdio: 'inherit',

--- a/test/system-test/showcase-server.ts
+++ b/test/system-test/showcase-server.ts
@@ -65,9 +65,13 @@ export class ShowcaseServer {
       console.log(stdout);
     }
     console.log(`About to extract ${tarballFilename}`);
-    await tar.extract({
-      file: tarballFilename,
-    });
+    await tar
+      .extract({
+        file: tarballFilename,
+      })
+      .catch(err => {
+        console.log('Error extracting!', err);
+      });
     console.log('Extracted');
 
     {

--- a/test/system-test/showcase-server.ts
+++ b/test/system-test/showcase-server.ts
@@ -34,7 +34,6 @@ import * as download from 'download';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
-import * as tar from 'tar';
 import * as util from 'util';
 
 const mkdir = util.promisify(fs.mkdir);
@@ -65,13 +64,7 @@ export class ShowcaseServer {
       console.log(stdout);
     }
     console.log(`About to extract ${tarballFilename}`);
-    await tar
-      .extract({
-        file: tarballFilename,
-      })
-      .catch(err => {
-        console.log('Error extracting!', err);
-      });
+    await execa('tar', ['xzf', tarballFilename]);
     console.log('Extracted');
 
     {

--- a/test/system-test/showcase-server.ts
+++ b/test/system-test/showcase-server.ts
@@ -56,22 +56,8 @@ export class ShowcaseServer {
     process.chdir(testDir);
     console.log(`Server will be run from ${testDir}.`);
 
-    console.log(`About to download ${fallbackServerUrl} into ${testDir}`);
     await download(fallbackServerUrl, testDir);
-    console.log(`Downloaded:`);
-    {
-      const {stdout} = await execa('ls', ['-l', testDir]);
-      console.log(stdout);
-    }
-    console.log(`About to extract ${tarballFilename}`);
     await execa('tar', ['xzf', tarballFilename]);
-    console.log('Extracted');
-
-    {
-      const {stdout} = await execa('ls', ['-l', testDir]);
-      console.log(stdout);
-    }
-    console.log(`About to run ${binaryName}`);
     const childProcess = execa(binaryName, ['run'], {
       cwd: testDir,
       stdio: 'inherit',


### PR DESCRIPTION
`tar` npm package suddenly stopped working in Kokoro (it still works locally though). I don't think we need to investigate it, let's just use `tar` binary directly. It's only in the test code, to unpack the Showcase server.