### PR TITLE
fix(deps): use @grpc/grpc-js v0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.6.3",
+    "@grpc/grpc-js": "^0.6.4",
     "@grpc/proto-loader": "^0.5.1",
     "abort-controller": "^3.0.0",
     "duplexify": "^3.6.0",


### PR DESCRIPTION
There was a [performance issue](https://github.com/grpc/grpc-node/issues/1061) in `@grpc/grpc-js` v0.6.3 which is fixed in v0.6.4. Let's force everyone use the latest version.