### PR TITLE
chore(deps): pin @grpc/grpc-js to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.6.4",
+    "@grpc/grpc-js": "0.6.6",
     "@grpc/proto-loader": "^0.5.1",
     "abort-controller": "^3.0.0",
     "duplexify": "^3.6.0",


### PR DESCRIPTION
From now on, `google-gax` will pin the exact version of `@grpc/grpc-js` to make updates more safe and predictable for users.