### PR TITLE
fix: correct array comparison

### DIFF
--- a/src/longRunningCalls/longrunning.ts
+++ b/src/longRunningCalls/longrunning.ts
@@ -285,12 +285,12 @@ export class Operation extends EventEmitter {
       self.emit(event, ...args);
     }
 
-    //Helper function to replace nodejs buffer's equals()
-    function arrayEquals(a, b) {
+    // Helper function to replace nodejs buffer's equals()
+    function arrayEquals(a: Uint8Array, b: Uint8Array): boolean {
       if (a.byteLength !== b.byteLength) {
         return false;
       }
-      for (let i = a.length; -1 < i; i -= 1) {
+      for (let i = 0; i < a.byteLength; ++i) {
         if (a[i] !== b[i]) return false;
       }
       return true;


### PR DESCRIPTION
This code was added during an internship project, was reviewed by several folks and got into master but it's a little bit wrong (accesss an element at `a.length`).

Fixing the comparison to remove the off by one error. We still cannot use `Buffer` because this code is supposed to work in browser as well.

@noahdietz just FYI, we missed an off by one :) 