### PR TITLE
fix: add long to protos.d.ts

### DIFF
--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -83,6 +83,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
+    assert(ts.toString().includes('import * as Long'));
   });
 
   it('writes an empty object if no protos are given', async () => {

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -144,6 +144,15 @@ async function compileProtos(protos: string[]): Promise<void> {
   const tsOutput = path.join('protos', 'protos.d.ts');
   const pbjsArgs4ts = [jsOutput, '-o', tsOutput];
   await pbtsMain(pbjsArgs4ts);
+
+  // fix for pbts output: the corresponding protobufjs PR
+  // https://github.com/protobufjs/protobuf.js/pull/1166
+  // is merged but not yet released.
+  const tsResult = (await readFile(tsOutput)).toString();
+  if (!tsResult.match(/import \* as Long/)) {
+    const fixedTsResult = 'import * as Long from "long";\n' + tsResult;
+    await writeFile(tsOutput, fixedTsResult);
+  }
 }
 
 /**


### PR DESCRIPTION
The protobuf.js PR https://github.com/protobufjs/protobuf.js/pull/1166 was merged ages ago but still not released. I suspect it might take some more time to release it, so - since this script is the one place to generate proto TS file - let's do it from here for now.

It will only add a missing import if it's not there already, so when the the protobuf.js PR is finally released, it won't break and we'll just remove it from here.