### PR TITLE
fix: depend on @types/long

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@grpc/grpc-js": "0.6.9",
     "@grpc/proto-loader": "^0.5.1",
+    "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^3.6.0",
     "google-auth-library": "^5.0.0",


### PR DESCRIPTION
As suggested in https://github.com/googleapis/gapic-generator-typescript/pull/118, let's just have this dependency here and not in every client library. 