### PR TITLE
fix(deps): use typescript ~3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "stream-events": "^1.0.4",
     "through2": "^3.0.0",
     "ts-loader": "^6.0.3",
-    "typescript": "~3.7.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.34.0",
     "webpack-cli": "^3.3.4"
   },


### PR DESCRIPTION
Fixes #642 by reverting TypeScript dependency back to `~3.6.0`.