### PR TITLE
fix(deps): unpin @grpc/grpc-js, set it to ^0.6.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "0.6.9",
+    "@grpc/grpc-js": "^0.6.12",
     "@grpc/proto-loader": "^0.5.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
Unpinning `@grpc/grpc-js`. Will be released as 1.11.2.