### PR TITLE
fix: servicePath and port may be undefined

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -262,17 +262,20 @@ export class GrpcClient {
 
         const grpcFallbackProtocol = opts.protocol || 'https';
         let servicePath = opts.servicePath;
+        if (
+          !servicePath &&
+          service.options &&
+          service.options['(google.api.default_host)']
+        ) {
+          servicePath = service.options['(google.api.default_host)'];
+        }
         if (!servicePath) {
-          if (service.options && service.options['(google.api.default_host)']) {
-            servicePath = service.options['(google.api.default_host)'];
-          } else {
-            serviceCallback(new Error('Service path is undefined'));
-            return;
-          }
+          serviceCallback(new Error('Service path is undefined'));
+          return;
         }
 
         let servicePort;
-        const match = servicePath.match(/^(.*):(\d+)$/);
+        const match = servicePath!.match(/^(.*):(\d+)$/);
         if (match) {
           servicePath = match[1];
           servicePort = match[2];

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -77,8 +77,8 @@ export type GrpcModule = typeof grpc;
 
 export interface ClientStubOptions {
   protocol?: string;
-  servicePath: string;
-  port: number;
+  servicePath?: string;
+  port?: number;
   // TODO: use sslCreds?: grpc.ChannelCredentials;
   // tslint:disable-next-line no-any
   sslCreds?: any;


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-text-to-speech/issues/298. I'm not sure why `servicePath` and `port` were set as required, because they are not.