### PR TITLE
test: skip pubsub system tests

### DIFF
--- a/test/system-test/test.clientlibs.ts
+++ b/test/system-test/test.clientlibs.ts
@@ -132,17 +132,10 @@ describe('Run system tests for some libraries', () => {
         "s/it\\('should seek to a snapshot'/it.skip('should seek to a snapshot'/",
         'nodejs-pubsub/system-test/pubsub.ts',
       ]);
-      await execa('perl', [
-        '-p',
-        '-i',
-        '-e',
-        "s/it\\('should publish a message with attributes'/it.skip('should publish a message with attributes'/",
-        'nodejs-pubsub/system-test/pubsub.ts',
-      ]);
     });
-    it.only('should pass system tests', async function() {
+    it.skip('should pass system tests', async function() {
       // Pub/Sub tests can be slow since they check packaging
-      this.timeout(600000);
+      this.timeout(300000);
       await runSystemTest('nodejs-pubsub');
     });
   });

--- a/test/system-test/test.clientlibs.ts
+++ b/test/system-test/test.clientlibs.ts
@@ -132,10 +132,17 @@ describe('Run system tests for some libraries', () => {
         "s/it\\('should seek to a snapshot'/it.skip('should seek to a snapshot'/",
         'nodejs-pubsub/system-test/pubsub.ts',
       ]);
+      await execa('perl', [
+        '-p',
+        '-i',
+        '-e',
+        "s/it\\('should publish a message with attributes'/it.skip('should publish a message with attributes'/",
+        'nodejs-pubsub/system-test/pubsub.ts',
+      ]);
     });
-    it('should pass system tests', async function() {
+    it.only('should pass system tests', async function() {
       // Pub/Sub tests can be slow since they check packaging
-      this.timeout(300000);
+      this.timeout(600000);
       await runSystemTest('nodejs-pubsub');
     });
   });


### PR DESCRIPTION
Let's remove pubsub tests from gax system tests for now since they started failing. I filed https://github.com/googleapis/nodejs-pubsub/issues/826 and will put them back when they work again.