### PR TITLE
docs: update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 * **deps:** unpin @grpc/grpc-js, set it to ^0.6.12 ([#665](https://www.github.com/googleapis/gax-nodejs/issues/665)) ([265461e](https://www.github.com/googleapis/gax-nodejs/commit/265461e7573c9bbd650eb0558313c05330691717))
 
+* fix: servicePath and port may be undefined ([#668](https://github.com/googleapis/gax-nodejs/pull/668))
+([54fa7b9](https://www.github.com/googleapis/gax-nodejs/commit/54fa7b96915852255f511bddc575177c3cabb3ac))
+
 ### [1.11.1](https://www.github.com/googleapis/gax-nodejs/compare/v1.11.0...v1.11.1) (2019-11-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * **deps:** unpin @grpc/grpc-js, set it to ^0.6.12 ([#665](https://www.github.com/googleapis/gax-nodejs/issues/665)) ([265461e](https://www.github.com/googleapis/gax-nodejs/commit/265461e7573c9bbd650eb0558313c05330691717))
 
-* fix: servicePath and port may be undefined ([#668](https://github.com/googleapis/gax-nodejs/pull/668))
+* servicePath and port may be undefined ([#668](https://github.com/googleapis/gax-nodejs/pull/668))
 ([54fa7b9](https://www.github.com/googleapis/gax-nodejs/commit/54fa7b96915852255f511bddc575177c3cabb3ac))
 
 ### [1.11.1](https://www.github.com/googleapis/gax-nodejs/compare/v1.11.0...v1.11.1) (2019-11-15)


### PR DESCRIPTION
The merged auto-release PR #666 will be only processed on Monday, so the latest merged fix #667 will be actually included in the upcoming release 1.11.2. Changing the change log accordingly to have it shown in the release notes.

(if the auto release fires before this PR is merged, I'll update the release notes on GitHub manually)