### PR TITLE
feat: export OperationsClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ lro.SERVICE_ADDRESS = operationsClient.SERVICE_ADDRESS;
 lro.ALL_SCOPES = operationsClient.ALL_SCOPES;
 
 export {lro};
+export {OperationsClient} from './operationsClient';
 export const createByteLengthFunction = GrpcClient.createByteLengthFunction;
 export const version = require('../../package.json').version;
 


### PR DESCRIPTION
Seems like we need to properly export `OperationsClient` from TypeScript libraries to give users access to low level LRO stuff. https://github.com/googleapis/nodejs-speech/issues/483

Let's first export it from gax, then I'll update the generator.