### PR TITLE
feat: export GRPC error code enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export {
 } from './grpc';
 export {Operation, operation} from './longRunningCalls/longrunning';
 export {PathTemplate} from './pathTemplate';
+export {Status} from './status';
 export {StreamType} from './streamingCalls/streaming';
 export {routingHeader};
 

--- a/test/system-test/test.clientlibs.ts
+++ b/test/system-test/test.clientlibs.ts
@@ -120,25 +120,6 @@ describe('Run system tests for some libraries', () => {
       await runSystemTest('nodejs-video-intelligence');
     });
   });
-  // Pub/Sub has streaming methods and pagination
-  describe('pubsub', () => {
-    before(async () => {
-      await preparePackage('nodejs-pubsub');
-      // TODO: remove the next line when pubsub system test works again
-      await execa('perl', [
-        '-p',
-        '-i',
-        '-e',
-        "s/it\\('should seek to a snapshot'/it.skip('should seek to a snapshot'/",
-        'nodejs-pubsub/system-test/pubsub.ts',
-      ]);
-    });
-    it.skip('should pass system tests', async function() {
-      // Pub/Sub tests can be slow since they check packaging
-      this.timeout(300000);
-      await runSystemTest('nodejs-pubsub');
-    });
-  });
   // Speech only has smoke tests, but still...
   describe('speech', () => {
     before(async () => {


### PR DESCRIPTION
This should allow me to use the same status codes in Firestore. Right now, we have our own copy (https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/watch.ts#L62). FWIW, this enum is used in the exported GoogleError.