### PR TITLE
test: fix browser tests

### DIFF
--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -230,7 +230,7 @@ describe('grpc-fallback', () => {
     assert.strictEqual(createdAbortControllers[0].abortCalled, true);
   });
 
-  it.only('should be able to add extra headers to the request', async () => {
+  it('should be able to add extra headers to the request', async () => {
     const client = new EchoClient(opts);
     const requestObject = {content: 'test-content'};
     // tslint:disable-next-line no-any

--- a/test/system-test/showcase-server.ts
+++ b/test/system-test/showcase-server.ts
@@ -47,7 +47,7 @@ export class ShowcaseServer {
     const testDir = path.join(process.cwd(), '.showcase-server-dir');
     const platform = process.platform;
     const arch = process.arch === 'x64' ? 'amd64' : process.arch;
-    const showcaseVersion = process.env['SHOWCASE_VERSION'] || '0.2.4';
+    const showcaseVersion = process.env['SHOWCASE_VERSION'] || '0.6.1';
     const tarballFilename = `gapic-showcase-${showcaseVersion}-${platform}-${arch}.tar.gz`;
     const fallbackServerUrl = `https://github.com/googleapis/gapic-showcase/releases/download/v${showcaseVersion}/${tarballFilename}`;
     const binaryName = './gapic-showcase';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,34 @@
+/**
+ * Copyright 2020 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 const path = require('path');
 
 module.exports = {
@@ -15,21 +46,24 @@ module.exports = {
       },
     },
     module: {
-        rules: [
-          {
-            test: /\.ts$/,
-            use: 'ts-loader',
-            exclude: /node_modules/,
-          },
-          {
-            test: /node_modules[\\\/]retry-request[\\\/]/,
-            use: 'null-loader',
-          },
-          {
-            test: /node_modules[\/]google-auth-library/,
-            use: 'null-loader',
-          }
-        ],
-      },
+      rules: [
+        {
+          test: /\.ts$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
+        },
+        {
+          test: /node_modules[\\\/]retry-request[\\\/]/,
+          use: 'null-loader',
+        },
+        {
+          test: /node_modules[\/]google-auth-library/,
+          use: 'null-loader',
+        }
+      ],
+    },
+    node: {
+      fs: 'empty',
+    },
     mode: 'production'
 }


### PR DESCRIPTION
#692 broke karma+mocha magic, here is the fix.

(also, no idea why we have `it.only` in browser tests, it's not supposed to be there, so removing it)