### PR TITLE
chore: run browser testing on node 12

### DIFF
--- a/.kokoro/continuous/node12/browser-test.cfg
+++ b/.kokoro/continuous/node12/browser-test.cfg
@@ -4,7 +4,7 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-puppeteer"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-puppeteer"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/presubmit/node12/browser-test.cfg
+++ b/.kokoro/presubmit/node12/browser-test.cfg
@@ -4,7 +4,7 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/node:8-puppeteer"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:12-puppeteer"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"


### PR DESCRIPTION
Run browser tests on Node 12 since 8 got broken too quick.

Browser tests in this PR might still fail until some other settings are in place and Docker image is ready.