### PR TITLE
feat: allow strings for enums, bytes, and Long in .d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ npm-debug.log
 .coverage
 .nyc_output
 docs/
-google/
+protos/google/
 out/
 system-test/secrets.js
 system-test/*key.json

--- a/test/fixtures/dts-update/google/dts.proto
+++ b/test/fixtures/dts-update/google/dts.proto
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google;
+
+service DtsUpdateTest {
+  rpc Test(TestMessage) returns (TestMessage) {
+  }
+}
+
+enum TestEnum {
+  TEST_ENUM_UNSPECIFIED = 0;
+  SOME_VALUE = 1;
+}
+
+message TestMessage {
+  int64 long_field = 1;
+  bytes bytes_field = 2; 
+  TestEnum enum_field = 3;
+}

--- a/test/fixtures/dts-update/test_proto_list.json
+++ b/test/fixtures/dts-update/test_proto_list.json
@@ -1,0 +1,1 @@
+["./google/dts.proto"]


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-typescript/issues/196, https://github.com/googleapis/nodejs-tasks/issues/334, https://github.com/googleapis/nodejs-iot/issues/250, https://github.com/googleapis/nodejs-scheduler/issues/181, https://github.com/googleapis/nodejs-tasks/issues/331 (and maybe more).

## TL;DR

We will accept enum string values in TypeScript request and response types, just like our JavaScript samples suggest to do.

## More details

In this PR I'm updating the `compileProtos` tool so that the request and response types accepted strings for enums, `bytes`, and `Long`. For enums, I'm using the magic [`keyof typeof`](https://www.typescriptlang.org/docs/handbook/enums.html#enums-at-compile-time) TypeScript feature to only allow _proper_ strings as values. For `bytes`, `protobuf.js` allows passing arbitrary string (it will base64-decode it). For `Long`, `string` is also accepted with our current set of [options](https://github.com/googleapis/gax-nodejs/blob/7c3b374d44064d2fd4ed0c9312e51e53eeb3e058/src/grpc.ts#L177-L182).

## Example

[This `.d.ts` file](https://github.com/googleapis/nodejs-speech/blob/master/protos/protos.d.ts) from Speech API will have the following changes. I verified that with these changes it's possible to pass a string (e.g. `"FLAC"`) as an encoding.

```diff
diff --git a/protos/protos.d.ts b/protos/protos.d.ts
index 74cac6f..45cc6c8 100644
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -312,7 +312,7 @@ export namespace google {
                     streamingConfig?: (google.cloud.speech.v1.IStreamingRecognitionConfig|null);
 
                     /** StreamingRecognizeRequest audioContent */
-                    audioContent?: (Uint8Array|null);
+                    audioContent?: (Uint8Array|string|null);
                 }
 
                 /** Represents a StreamingRecognizeRequest. */
@@ -328,7 +328,7 @@ export namespace google {
                     public streamingConfig?: (google.cloud.speech.v1.IStreamingRecognitionConfig|null);
 
                     /** StreamingRecognizeRequest audioContent. */
-                    public audioContent: Uint8Array;
+                    public audioContent: (Uint8Array|string);
 
                     /** StreamingRecognizeRequest streamingRequest. */
                     public streamingRequest?: ("streamingConfig"|"audioContent");
@@ -510,7 +510,7 @@ export namespace google {
                 interface IRecognitionConfig {
 
                     /** RecognitionConfig encoding */
-                    encoding?: (google.cloud.speech.v1.RecognitionConfig.AudioEncoding|null);
+                    encoding?: (google.cloud.speech.v1.RecognitionConfig.AudioEncoding|keyof typeof google.cloud.speech.v1.RecognitionConfig.AudioEncoding|null);
 
                     /** RecognitionConfig sampleRateHertz */
                     sampleRateHertz?: (number|null);
@@ -562,7 +562,7 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1.IRecognitionConfig);
 
                     /** RecognitionConfig encoding. */
-                    public encoding: google.cloud.speech.v1.RecognitionConfig.AudioEncoding;
+                    public encoding: (google.cloud.speech.v1.RecognitionConfig.AudioEncoding|keyof typeof google.cloud.speech.v1.RecognitionConfig.AudioEncoding);
 
                     /** RecognitionConfig sampleRateHertz. */
                     public sampleRateHertz: number;
@@ -801,19 +801,19 @@ export namespace google {
                 interface IRecognitionMetadata {
 
                     /** RecognitionMetadata interactionType */
-                    interactionType?: (google.cloud.speech.v1.RecognitionMetadata.InteractionType|null);
+                    interactionType?: (google.cloud.speech.v1.RecognitionMetadata.InteractionType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.InteractionType|null);
 
                     /** RecognitionMetadata industryNaicsCodeOfAudio */
                     industryNaicsCodeOfAudio?: (number|null);
 
                     /** RecognitionMetadata microphoneDistance */
-                    microphoneDistance?: (google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance|null);
+                    microphoneDistance?: (google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance|keyof typeof google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance|null);
 
                     /** RecognitionMetadata originalMediaType */
-                    originalMediaType?: (google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType|null);
+                    originalMediaType?: (google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType|null);
 
                     /** RecognitionMetadata recordingDeviceType */
-                    recordingDeviceType?: (google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType|null);
+                    recordingDeviceType?: (google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType|null);
 
                     /** RecognitionMetadata recordingDeviceName */
                     recordingDeviceName?: (string|null);
@@ -835,19 +835,19 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1.IRecognitionMetadata);
 
                     /** RecognitionMetadata interactionType. */
-                    public interactionType: google.cloud.speech.v1.RecognitionMetadata.InteractionType;
+                    public interactionType: (google.cloud.speech.v1.RecognitionMetadata.InteractionType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.InteractionType);
 
                     /** RecognitionMetadata industryNaicsCodeOfAudio. */
                     public industryNaicsCodeOfAudio: number;
 
                     /** RecognitionMetadata microphoneDistance. */
-                    public microphoneDistance: google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance;
+                    public microphoneDistance: (google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance|keyof typeof google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance);
 
                     /** RecognitionMetadata originalMediaType. */
-                    public originalMediaType: google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType;
+                    public originalMediaType: (google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType);
 
                     /** RecognitionMetadata recordingDeviceType. */
-                    public recordingDeviceType: google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType;
+                    public recordingDeviceType: (google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType|keyof typeof google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType);
 
                     /** RecognitionMetadata recordingDeviceName. */
                     public recordingDeviceName: string;
@@ -1065,7 +1065,7 @@ export namespace google {
                 interface IRecognitionAudio {
 
                     /** RecognitionAudio content */
-                    content?: (Uint8Array|null);
+                    content?: (Uint8Array|string|null);
 
                     /** RecognitionAudio uri */
                     uri?: (string|null);
@@ -1081,7 +1081,7 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1.IRecognitionAudio);
 
                     /** RecognitionAudio content. */
-                    public content: Uint8Array;
+                    public content: (Uint8Array|string);
 
                     /** RecognitionAudio uri. */
                     public uri: string;
@@ -1452,7 +1452,7 @@ export namespace google {
                     results?: (google.cloud.speech.v1.IStreamingRecognitionResult[]|null);
 
                     /** StreamingRecognizeResponse speechEventType */
-                    speechEventType?: (google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType|null);
+                    speechEventType?: (google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType|keyof typeof google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType|null);
                 }
 
                 /** Represents a StreamingRecognizeResponse. */
@@ -1471,7 +1471,7 @@ export namespace google {
                     public results: google.cloud.speech.v1.IStreamingRecognitionResult[];
 
                     /** StreamingRecognizeResponse speechEventType. */
-                    public speechEventType: google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType;
+                    public speechEventType: (google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType|keyof typeof google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType);
 
                     /**
                      * Creates a new StreamingRecognizeResponse instance using the specified properties.
@@ -2269,7 +2269,7 @@ export namespace google {
                     streamingConfig?: (google.cloud.speech.v1p1beta1.IStreamingRecognitionConfig|null);
 
                     /** StreamingRecognizeRequest audioContent */
-                    audioContent?: (Uint8Array|null);
+                    audioContent?: (Uint8Array|string|null);
                 }
 
                 /** Represents a StreamingRecognizeRequest. */
@@ -2285,7 +2285,7 @@ export namespace google {
                     public streamingConfig?: (google.cloud.speech.v1p1beta1.IStreamingRecognitionConfig|null);
 
                     /** StreamingRecognizeRequest audioContent. */
-                    public audioContent: Uint8Array;
+                    public audioContent: (Uint8Array|string);
 
                     /** StreamingRecognizeRequest streamingRequest. */
                     public streamingRequest?: ("streamingConfig"|"audioContent");
@@ -2467,7 +2467,7 @@ export namespace google {
                 interface IRecognitionConfig {
 
                     /** RecognitionConfig encoding */
-                    encoding?: (google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding|null);
+                    encoding?: (google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding|keyof typeof google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding|null);
 
                     /** RecognitionConfig sampleRateHertz */
                     sampleRateHertz?: (number|null);
@@ -2531,7 +2531,7 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1p1beta1.IRecognitionConfig);
 
                     /** RecognitionConfig encoding. */
-                    public encoding: google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding;
+                    public encoding: (google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding|keyof typeof google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding);
 
                     /** RecognitionConfig sampleRateHertz. */
                     public sampleRateHertz: number;
@@ -2777,19 +2777,19 @@ export namespace google {
                 interface IRecognitionMetadata {
 
                     /** RecognitionMetadata interactionType */
-                    interactionType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType|null);
+                    interactionType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType|null);
 
                     /** RecognitionMetadata industryNaicsCodeOfAudio */
                     industryNaicsCodeOfAudio?: (number|null);
 
                     /** RecognitionMetadata microphoneDistance */
-                    microphoneDistance?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance|null);
+                    microphoneDistance?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance|null);
 
                     /** RecognitionMetadata originalMediaType */
-                    originalMediaType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType|null);
+                    originalMediaType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType|null);
 
                     /** RecognitionMetadata recordingDeviceType */
-                    recordingDeviceType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType|null);
+                    recordingDeviceType?: (google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType|null);
 
                     /** RecognitionMetadata recordingDeviceName */
                     recordingDeviceName?: (string|null);
@@ -2798,7 +2798,7 @@ export namespace google {
                     originalMimeType?: (string|null);
 
                     /** RecognitionMetadata obfuscatedId */
-                    obfuscatedId?: (number|Long|null);
+                    obfuscatedId?: (number|Long|string|null);
 
                     /** RecognitionMetadata audioTopic */
                     audioTopic?: (string|null);
@@ -2814,19 +2814,19 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1p1beta1.IRecognitionMetadata);
 
                     /** RecognitionMetadata interactionType. */
-                    public interactionType: google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType;
+                    public interactionType: (google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType);
 
                     /** RecognitionMetadata industryNaicsCodeOfAudio. */
                     public industryNaicsCodeOfAudio: number;
 
                     /** RecognitionMetadata microphoneDistance. */
-                    public microphoneDistance: google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance;
+                    public microphoneDistance: (google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance);
 
                     /** RecognitionMetadata originalMediaType. */
-                    public originalMediaType: google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType;
+                    public originalMediaType: (google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType);
 
                     /** RecognitionMetadata recordingDeviceType. */
-                    public recordingDeviceType: google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType;
+                    public recordingDeviceType: (google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType|keyof typeof google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType);
 
                     /** RecognitionMetadata recordingDeviceName. */
                     public recordingDeviceName: string;
@@ -2835,7 +2835,7 @@ export namespace google {
                     public originalMimeType: string;
 
                     /** RecognitionMetadata obfuscatedId. */
-                    public obfuscatedId: (number|Long);
+                    public obfuscatedId: (number|Long|string);
 
                     /** RecognitionMetadata audioTopic. */
                     public audioTopic: string;
@@ -3053,7 +3053,7 @@ export namespace google {
                 interface IRecognitionAudio {
 
                     /** RecognitionAudio content */
-                    content?: (Uint8Array|null);
+                    content?: (Uint8Array|string|null);
 
                     /** RecognitionAudio uri */
                     uri?: (string|null);
@@ -3069,7 +3069,7 @@ export namespace google {
                     constructor(properties?: google.cloud.speech.v1p1beta1.IRecognitionAudio);
 
                     /** RecognitionAudio content. */
-                    public content: Uint8Array;
+                    public content: (Uint8Array|string);
 
                     /** RecognitionAudio uri. */
                     public uri: string;
@@ -3440,7 +3440,7 @@ export namespace google {
                     results?: (google.cloud.speech.v1p1beta1.IStreamingRecognitionResult[]|null);
 
                     /** StreamingRecognizeResponse speechEventType */
-                    speechEventType?: (google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType|null);
+                    speechEventType?: (google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType|keyof typeof google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType|null);
                 }
 
                 /** Represents a StreamingRecognizeResponse. */
@@ -3459,7 +3459,7 @@ export namespace google {
                     public results: google.cloud.speech.v1p1beta1.IStreamingRecognitionResult[];
 
                     /** StreamingRecognizeResponse speechEventType. */
-                    public speechEventType: google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType;
+                    public speechEventType: (google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType|keyof typeof google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType);
 
                     /**
                      * Creates a new StreamingRecognizeResponse instance using the specified properties.
@@ -5029,10 +5029,10 @@ export namespace google {
             number?: (number|null);
 
             /** FieldDescriptorProto label */
-            label?: (google.protobuf.FieldDescriptorProto.Label|null);
+            label?: (google.protobuf.FieldDescriptorProto.Label|keyof typeof google.protobuf.FieldDescriptorProto.Label|null);
 
             /** FieldDescriptorProto type */
-            type?: (google.protobuf.FieldDescriptorProto.Type|null);
+            type?: (google.protobuf.FieldDescriptorProto.Type|keyof typeof google.protobuf.FieldDescriptorProto.Type|null);
 
             /** FieldDescriptorProto typeName */
             typeName?: (string|null);
@@ -5069,10 +5069,10 @@ export namespace google {
             public number: number;
 
             /** FieldDescriptorProto label. */
-            public label: google.protobuf.FieldDescriptorProto.Label;
+            public label: (google.protobuf.FieldDescriptorProto.Label|keyof typeof google.protobuf.FieldDescriptorProto.Label);
 
             /** FieldDescriptorProto type. */
-            public type: google.protobuf.FieldDescriptorProto.Type;
+            public type: (google.protobuf.FieldDescriptorProto.Type|keyof typeof google.protobuf.FieldDescriptorProto.Type);
 
             /** FieldDescriptorProto typeName. */
             public typeName: string;
@@ -5847,7 +5847,7 @@ export namespace google {
             javaStringCheckUtf8?: (boolean|null);
 
             /** FileOptions optimizeFor */
-            optimizeFor?: (google.protobuf.FileOptions.OptimizeMode|null);
+            optimizeFor?: (google.protobuf.FileOptions.OptimizeMode|keyof typeof google.protobuf.FileOptions.OptimizeMode|null);
 
             /** FileOptions goPackage */
             goPackage?: (string|null);
@@ -5920,7 +5920,7 @@ export namespace google {
             public javaStringCheckUtf8: boolean;
 
             /** FileOptions optimizeFor. */
-            public optimizeFor: google.protobuf.FileOptions.OptimizeMode;
+            public optimizeFor: (google.protobuf.FileOptions.OptimizeMode|keyof typeof google.protobuf.FileOptions.OptimizeMode);
 
             /** FileOptions goPackage. */
             public goPackage: string;
@@ -6166,13 +6166,13 @@ export namespace google {
         interface IFieldOptions {
 
             /** FieldOptions ctype */
-            ctype?: (google.protobuf.FieldOptions.CType|null);
+            ctype?: (google.protobuf.FieldOptions.CType|keyof typeof google.protobuf.FieldOptions.CType|null);
 
             /** FieldOptions packed */
             packed?: (boolean|null);
 
             /** FieldOptions jstype */
-            jstype?: (google.protobuf.FieldOptions.JSType|null);
+            jstype?: (google.protobuf.FieldOptions.JSType|keyof typeof google.protobuf.FieldOptions.JSType|null);
 
             /** FieldOptions lazy */
             lazy?: (boolean|null);
@@ -6200,13 +6200,13 @@ export namespace google {
             constructor(properties?: google.protobuf.IFieldOptions);
 
             /** FieldOptions ctype. */
-            public ctype: google.protobuf.FieldOptions.CType;
+            public ctype: (google.protobuf.FieldOptions.CType|keyof typeof google.protobuf.FieldOptions.CType);
 
             /** FieldOptions packed. */
             public packed: boolean;
 
             /** FieldOptions jstype. */
-            public jstype: google.protobuf.FieldOptions.JSType;
+            public jstype: (google.protobuf.FieldOptions.JSType|keyof typeof google.protobuf.FieldOptions.JSType);
 
             /** FieldOptions lazy. */
             public lazy: boolean;
@@ -6705,7 +6705,7 @@ export namespace google {
             deprecated?: (boolean|null);
 
             /** MethodOptions idempotencyLevel */
-            idempotencyLevel?: (google.protobuf.MethodOptions.IdempotencyLevel|null);
+            idempotencyLevel?: (google.protobuf.MethodOptions.IdempotencyLevel|keyof typeof google.protobuf.MethodOptions.IdempotencyLevel|null);
 
             /** MethodOptions uninterpretedOption */
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
@@ -6733,7 +6733,7 @@ export namespace google {
             public deprecated: boolean;
 
             /** MethodOptions idempotencyLevel. */
-            public idempotencyLevel: google.protobuf.MethodOptions.IdempotencyLevel;
+            public idempotencyLevel: (google.protobuf.MethodOptions.IdempotencyLevel|keyof typeof google.protobuf.MethodOptions.IdempotencyLevel);
 
             /** MethodOptions uninterpretedOption. */
             public uninterpretedOption: google.protobuf.IUninterpretedOption[];
@@ -6829,16 +6829,16 @@ export namespace google {
             identifierValue?: (string|null);
 
             /** UninterpretedOption positiveIntValue */
-            positiveIntValue?: (number|Long|null);
+            positiveIntValue?: (number|Long|string|null);
 
             /** UninterpretedOption negativeIntValue */
-            negativeIntValue?: (number|Long|null);
+            negativeIntValue?: (number|Long|string|null);
 
             /** UninterpretedOption doubleValue */
             doubleValue?: (number|null);
 
             /** UninterpretedOption stringValue */
-            stringValue?: (Uint8Array|null);
+            stringValue?: (Uint8Array|string|null);
 
             /** UninterpretedOption aggregateValue */
             aggregateValue?: (string|null);
@@ -6860,16 +6860,16 @@ export namespace google {
             public identifierValue: string;
 
             /** UninterpretedOption positiveIntValue. */
-            public positiveIntValue: (number|Long);
+            public positiveIntValue: (number|Long|string);
 
             /** UninterpretedOption negativeIntValue. */
-            public negativeIntValue: (number|Long);
+            public negativeIntValue: (number|Long|string);
 
             /** UninterpretedOption doubleValue. */
             public doubleValue: number;
 
             /** UninterpretedOption stringValue. */
-            public stringValue: Uint8Array;
+            public stringValue: (Uint8Array|string);
 
             /** UninterpretedOption aggregateValue. */
             public aggregateValue: string;
@@ -7459,7 +7459,7 @@ export namespace google {
             type_url?: (string|null);
 
             /** Any value */
-            value?: (Uint8Array|null);
+            value?: (Uint8Array|string|null);
         }
 
         /** Represents an Any. */
@@ -7475,7 +7475,7 @@ export namespace google {
             public type_url: string;
 
             /** Any value. */
-            public value: Uint8Array;
+            public value: (Uint8Array|string);
 
             /**
              * Creates a new Any instance using the specified properties.
@@ -7552,7 +7552,7 @@ export namespace google {
         interface IDuration {
 
             /** Duration seconds */
-            seconds?: (number|Long|null);
+            seconds?: (number|Long|string|null);
 
             /** Duration nanos */
             nanos?: (number|null);
@@ -7568,7 +7568,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IDuration);
 
             /** Duration seconds. */
-            public seconds: (number|Long);
+            public seconds: (number|Long|string);
 
             /** Duration nanos. */
             public nanos: number;
@@ -7732,7 +7732,7 @@ export namespace google {
         interface ITimestamp {
 
             /** Timestamp seconds */
-            seconds?: (number|Long|null);
+            seconds?: (number|Long|string|null);
 
             /** Timestamp nanos */
             nanos?: (number|null);
@@ -7748,7 +7748,7 @@ export namespace google {
             constructor(properties?: google.protobuf.ITimestamp);
 
             /** Timestamp seconds. */
-            public seconds: (number|Long);
+            public seconds: (number|Long|string);
 
             /** Timestamp nanos. */
             public nanos: number;
```