### PR TITLE
fix: properly parse special field names in compileProtos

### DIFF
--- a/test/fixtures/dts-update/google/dts.proto
+++ b/test/fixtures/dts-update/google/dts.proto
@@ -30,4 +30,5 @@ message TestMessage {
   int64 long_field = 1;
   bytes bytes_field = 2; 
   TestEnum enum_field = 3;
+  TestEnum case = 4; // special name
 }

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -117,6 +117,13 @@ describe('compileProtos tool', () => {
           'enumField?: (google.TestEnum|keyof typeof google.TestEnum|null);'
         )
     );
+    assert(
+      ts
+        .toString()
+        .includes(
+          '"case"?: (google.TestEnum|keyof typeof google.TestEnum|null);'
+        )
+    );
     assert(ts.toString().includes('public longField: (number|Long|string);'));
     assert(ts.toString().includes('public bytesField: (Uint8Array|string);'));
     assert(
@@ -124,6 +131,13 @@ describe('compileProtos tool', () => {
         .toString()
         .includes(
           'public enumField: (google.TestEnum|keyof typeof google.TestEnum);'
+        )
+    );
+    assert(
+      ts
+        .toString()
+        .includes(
+          'public case: (google.TestEnum|keyof typeof google.TestEnum);'
         )
     );
   });

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -117,7 +117,7 @@ function updateDtsTypes(dts: string, enums: Set<string>): string {
     // Enums can be used in interfaces and in classes.
     // For simplicity, we'll check these two cases independently.
     // encoding?: (google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding|null);
-    const interfaceMatch = line.match(/\w+\?: \(([\w.]+)\|null\);/);
+    const interfaceMatch = line.match(/"?\w+"?\?: \(([\w.]+)\|null\);/);
     if (interfaceMatch) {
       typeName = interfaceMatch[1];
     }


### PR DESCRIPTION
The yesterday's fix #714 works perfectly with one exception: if a proto message has a field that is a reserved word in TypeScript, it does not detect it.

Example (real-life from Language API):

```proto
message PartOfSpeech {
  ...
  enum Case {
    ...
  }
  ...
  Case case = 3;
  ...
}
```

```ts
interface IPartOfSpeech {
  ...
  "case"?: (google.cloud.language.v1.PartOfSpeech.Case|null);
  ...
}

// note that in class it's totally fine because of the "public" keyword:
class PartOfSpeech implements IPartOfSpeech {
  ...
  public case: (google.cloud.language.v1.PartOfSpeech.Case|keyof typeof google.cloud.language.v1.PartOfSpeech.Case);
  ...
}
```

This fix allows for quotes around the field name in the `.d.ts` interface definitions. Checked that it fixes the above problem. Added a test for this scenario.