### PR TITLE
deps: update grpc-js minimum version to 0.6.18 to catch the recent retry fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.6.12",
+    "@grpc/grpc-js": "^0.6.18",
     "@grpc/proto-loader": "^0.5.1",
     "@types/fs-extra": "^8.0.1",
     "@types/long": "^4.0.0",


### PR DESCRIPTION
PR for https://github.com/googleapis/gax-nodejs/issues/727
