### PR TITLE
fix(deps): use protobuf.js v6.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash.at": "^4.6.0",
     "lodash.has": "^4.5.2",
     "node-fetch": "^2.6.0",
-    "protobufjs": "^6.8.8",
+    "protobufjs": "^6.8.9",
     "retry-request": "^4.0.0",
     "semver": "^6.0.0",
     "walkdir": "^0.4.0"


### PR DESCRIPTION
The new `protobufjs` v6.8.9 has some old dependencies updated.