### PR TITLE
fix: set element_count_limit param as optional for bundling config

### DIFF
--- a/src/gax.ts
+++ b/src/gax.ts
@@ -531,7 +531,7 @@ export interface MethodConfig {
 
 export interface BundlingConfig {
   element_count_threshold: number;
-  element_count_limit: number;
+  element_count_limit?: number;
   request_byte_threshold?: number;
   request_byte_limit?: number;
   delay_threshold_millis?: number;


### PR DESCRIPTION
Fix type compile error: https://github.com/googleapis/gapic-generator-typescript/pull/330

This field is required in `BundlingConfig` from gax, but not set in service_client_config.json from API.