### PR TITLE
feat!: throw for versions of Node.js older than v10.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 13]
+        node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -100,7 +100,7 @@ export class GrpcClient {
     const minimumVersion = '10.0.0';
     if (semver.lt(process.version, minimumVersion)) {
       const errorMessage =
-        `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit:` +
+        `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit: ` +
         'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
       throw new Error(errorMessage);
     }

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -97,20 +97,20 @@ export class GrpcClient {
     this.auth = options.auth || new GoogleAuth(options);
     this.fallback = false;
 
+    const minimumVersion = '10.0.0';
+    if (semver.lt(process.version, minimumVersion)) {
+      const errorMessage =
+        `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit:` +
+        'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
+      throw new Error(errorMessage);
+    }
+
     if ('grpc' in options) {
       this.grpc = options.grpc!;
       this.grpcVersion = '';
     } else {
-      const minimumVersion = '10.0.0'
-      if (semver.gte(process.version, minimumVersion)) {
-        this.grpc = grpc;
-        this.grpcVersion = require('@grpc/grpc-js/package.json').version;
-      } else {
-        const errorMessage =
-          `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit:` +
-          'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
-        throw new Error(errorMessage);
-      }
+      this.grpc = grpc;
+      this.grpcVersion = require('@grpc/grpc-js/package.json').version;
     }
   }
 

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -101,13 +101,14 @@ export class GrpcClient {
       this.grpc = options.grpc!;
       this.grpcVersion = '';
     } else {
-      if (semver.gte(process.version, '8.13.0')) {
+      const minimumVersion = '10.0.0'
+      if (semver.gte(process.version, minimumVersion)) {
         this.grpc = grpc;
         this.grpcVersion = require('@grpc/grpc-js/package.json').version;
       } else {
         const errorMessage =
-          'To use @grpc/grpc-js you must run your code on Node.js v8.13.0 or newer. Please see README if you need to use an older version. ' +
-          'https://github.com/googleapis/gax-nodejs/blob/master/README.md';
+          `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit:` +
+          'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
         throw new Error(errorMessage);
       }
     }


### PR DESCRIPTION
This is waiting on landing: https://github.com/googleapis/google-cloud-node/pull/2980

_Note: we should test this in cloud functions once we get the first library using this version._