### PR TITLE
feat: export ServiceError from @grpc/grpc-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,3 +159,5 @@ export interface PaginationResponse<
   nextPageRequest?: RequestObject;
   rawResponse?: ResponseObject;
 }
+
+export {ServiceError} from '@grpc/grpc-js';


### PR DESCRIPTION
This is coming up during the TypeScript transition in Bigtable.  This type appears to be used everywhere.  