### PR TITLE
fix: allow passing numbers as path template parameters

### DIFF
--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -34,7 +34,7 @@ export interface Segment {
 }
 
 export interface Bindings {
-  [index: string]: string;
+  [index: string]: string | number;
 }
 
 export class PathTemplate {
@@ -129,7 +129,7 @@ export class PathTemplate {
           );
           throw new TypeError(msg);
         }
-        const tmp = new PathTemplate(bindings[segment.literal]);
+        const tmp = new PathTemplate(bindings[segment.literal].toString());
         Array.prototype.push.apply(out, tmp.segments);
         inABinding = true;
       } else if (segment.kind === extras.END_BINDING) {

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -139,6 +139,18 @@ describe('PathTemplate', () => {
       const want = 'bar/1/2/foo/3';
       expect(template.render(params)).to.eql(want);
     });
+
+    it('should accept both strings and numbers as values', () => {
+      const template = new PathTemplate(
+        'projects/{project}/sessions/{session}'
+      );
+      const params = {
+        project: 'testProject',
+        session: 123,
+      };
+      const want = 'projects/testProject/sessions/123';
+      expect(template.render(params)).to.eql(want);
+    });
   });
 
   describe('method `inspect`', () => {


### PR DESCRIPTION
Fixes the problem shown in https://github.com/googleapis/nodejs-dialogflow/pull/568 - it makes no harm if we just allow passing numbers as path template parameters, and silently convert them to strings under the hood.