### PR TITLE
fix: make async iteration work for gRPC-fallback; refactor the code

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "repository": "googleapis/gax-nodejs",
   "private": true,

--- a/samples/pagination.js
+++ b/samples/pagination.js
@@ -67,6 +67,16 @@ async function main() {
   // Call it!
   const [resources] = await wrappedFunction({request: 'empty'});
   console.log(resources);
+
+  // Alternatively, call it using async iterators!
+  const iterable = pageDescriptor.asyncIterate(wrappedFunction, {
+    request: 'empty',
+  });
+  const asyncResources = [];
+  for await (const resource of iterable) {
+    asyncResources.push(resource);
+  }
+  console.log(asyncResources);
 }
 
 main().catch(console.error);

--- a/src/apitypes.ts
+++ b/src/apitypes.ts
@@ -42,7 +42,7 @@ export type NextPageRequestType = {
 } | null;
 export type RawResponseType = Operation | {} | null;
 export type ResultTuple = [
-  ResponseType,
+  ResponseType | [ResponseType],
   NextPageRequestType | undefined,
   RawResponseType | undefined
 ];

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -82,6 +82,7 @@ async function testShowcase() {
   await testEcho(fallbackClient);
   await testPagedExpand(fallbackClient);
   await testWait(fallbackClient);
+  await testPagedExpandAsync(fallbackClient);
 }
 
 async function testEcho(client) {

--- a/test/fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client.js
@@ -196,9 +196,8 @@ class EchoClient {
       'wait',
       'pagedExpand',
     ];
-    this._innerCallPromises = {};
     for (const methodName of echoStubMethods) {
-      this._innerCallPromises[methodName] = echoStub.then(
+      const callPromise = echoStub.then(
         stub => (...args) => {
           return stub[methodName].apply(stub, args);
         },
@@ -206,13 +205,14 @@ class EchoClient {
           throw err;
         }
       );
-      this._innerApiCalls[methodName] = gaxModule.createApiCall(
-        this._innerCallPromises[methodName],
+      const apiCall = gaxModule.createApiCall(
+        callPromise,
         defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
       );
+      this._innerApiCalls[methodName] = apiCall;
     }
   }
 
@@ -590,7 +590,7 @@ class EchoClient {
     request = request || {};
     const callSettings = new gax.CallSettings(options);
     return this._descriptors.page.pagedExpand.asyncIterate(
-      this._innerCallPromises['pagedExpand'],
+      this._innerApiCalls.pagedExpand,
       request,
       callSettings
     );

--- a/test/unit/pagedIteration.ts
+++ b/test/unit/pagedIteration.ts
@@ -22,7 +22,7 @@ import * as sinon from 'sinon';
 import * as streamEvents from 'stream-events';
 import * as through2 from 'through2';
 import {PageDescriptor} from '../../src/paginationCalls/pageDescriptor';
-import {APICallback, GaxCallPromise} from '../../src/apitypes';
+import {APICallback, GaxCall} from '../../src/apitypes';
 import {describe, it, beforeEach} from 'mocha';
 
 import * as util from './utils';
@@ -199,7 +199,7 @@ describe('paged iteration', () => {
 
   describe('use async iterator', () => {
     const spy = sinon.spy(func);
-    let apiCall: GaxCallPromise;
+    let apiCall: GaxCall;
     beforeEach(() => {
       apiCall = util.createApiCall(spy, createOptions);
     });
@@ -210,22 +210,28 @@ describe('paged iteration', () => {
       for await (const resource of iterable) {
         counter++;
         resources.push(resource);
-        if (counter === 10) break;
+        if (counter === 10) {
+          break;
+        }
       }
-      expect(counter).to.equal(10);
+      return resources;
     }
-    it('returns an iterable, count to 10', () => {
+
+    it('returns an iterable, count to 10', async () => {
       const settings = new gax.CallSettings(
         (createOptions && createOptions.settings) || {}
       );
-      iterableChecker(descriptor.asyncIterate(apiCall, {}, settings));
+      const resources = await iterableChecker(
+        descriptor.asyncIterate(apiCall, {}, settings)
+      );
+      expect(resources.length).to.equal(10);
     });
   });
 
   describe('stream conversion', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let spy: any;
-    let apiCall: GaxCallPromise;
+    let apiCall: GaxCall;
     beforeEach(() => {
       spy = sinon.spy(func);
       apiCall = util.createApiCall(spy, createOptions);


### PR DESCRIPTION
**TL;DR:** this is a small refactor of the client functionality that was not released yet. Pretty safe to merge since async iteration in clients is not enabled yet.

---

So this turned to be a refactor that made the async iteration code a little bit simpler.

Background: it turns out async iteration, as implemented, did not work for gRPC-fallback clients. The main reason for that is that `createApiCall` is implemented differently in `fallback.ts`, and fallback clients expect that exact implementation. Long story short, it was not possible to call a stub of `pagedExpand` in `pagedExpandAsync`; fallback clients needed the result of `createApiCall`.

So... since the result of `createApiCall` is a function and not a promise, we can remove all the complicated asynchronous stuff (uninitialized promises, etc.) from the async iterator implementation, and make it pretty much straightforward by reusing the paging logic already implemented elsewhere (so I'm just disabling auto-pagination with `autoPaginate: false` and reusing the regular paginator).

The corresponding client change is coming as well (see the test client change to get an idea how the client is changed).