### PR TITLE
[DO NOT MERGE] fix: releasing 1.15.2-grpc on top of 1.15.2 with legacy grpc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-gax",
-  "version": "1.15.2",
+  "version": "1.15.2-grpc",
   "description": "Google API Extensions",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -21,6 +21,7 @@
     "abort-controller": "^3.0.0",
     "duplexify": "^3.6.0",
     "google-auth-library": "^5.0.0",
+    "grpc": "^1.24.2",
     "is-stream-ended": "^0.1.4",
     "lodash.at": "^4.6.0",
     "lodash.has": "^4.5.2",

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -18,6 +18,7 @@ import * as grpcProtoLoader from '@grpc/proto-loader';
 import * as fs from 'fs';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as grpc from '@grpc/grpc-js';
+import * as grpcLegacy from 'grpc';
 import {OutgoingHttpHeaders} from 'http';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
@@ -107,15 +108,8 @@ export class GrpcClient {
       this.grpc = options.grpc!;
       this.grpcVersion = '';
     } else {
-      if (semver.gte(process.version, '8.13.0')) {
-        this.grpc = grpc;
-        this.grpcVersion = require('@grpc/grpc-js/package.json').version;
-      } else {
-        const errorMessage =
-          'To use @grpc/grpc-js you must run your code on Node.js v8.13.0 or newer. Please see README if you need to use an older version. ' +
-          'https://github.com/googleapis/gax-nodejs/blob/master/README.md';
-        throw new Error(errorMessage);
-      }
+      this.grpc = (grpcLegacy as unknown) as GrpcModule;
+      this.grpcVersion = require('grpc/package.json').version;
     }
   }
 

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -35,7 +35,7 @@ function gaxGrpc(options?: GrpcClientOptions) {
 describe('grpc', () => {
   describe('grpcVersion', () => {
     it('holds the proper grpc version', () => {
-      const grpcModule = '@grpc/grpc-js';
+      const grpcModule = 'grpc';
       const grpcVersion = require(`${grpcModule}/package.json`).version;
       expect(gaxGrpc().grpcVersion).to.eq(grpcVersion);
     });


### PR DESCRIPTION
We'll use it to workaround https://github.com/googleapis/nodejs-dlp/issues/445 by using legacy `grpc`.