### PR TITLE
fix(types): use grpc call credentials type

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -64,9 +64,7 @@ export interface ClientStubOptions {
   protocol?: string;
   servicePath?: string;
   port?: number;
-  // TODO: use sslCreds?: grpc.ChannelCredentials;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sslCreds?: any;
+  sslCreds?: grpc.ChannelCredentials;
   [index: string]: string | number | undefined | {};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,4 +100,4 @@ export {
   PaginationResponse,
 } from './clientInterface';
 
-export {ServiceError} from '@grpc/grpc-js';
+export {ServiceError, ChannelCredentials} from '@grpc/grpc-js';


### PR DESCRIPTION
I need this for a fix I want to make in datastore