### PR TITLE
fix: use @grpc/grpc-js v1.0.0, pass grpc options properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.7.2",
+    "@grpc/grpc-js": "~1.0.0",
     "@grpc/proto-loader": "^0.5.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
@@ -24,7 +24,7 @@
     "lodash.at": "^4.6.0",
     "lodash.has": "^4.5.2",
     "node-fetch": "^2.6.0",
-    "protobufjs": "^6.8.9",
+    "protobufjs": "^6.9.0",
     "retry-request": "^4.0.0",
     "semver": "^6.0.0",
     "walkdir": "^0.4.0"

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -268,11 +268,17 @@ export class GrpcClient {
     const serviceAddress = options.servicePath + ':' + options.port;
     const creds = await this._getCredentials(options);
     const grpcOptions: ClientOptions = {};
+    // @grpc/grpc-js limits max receive message length starting from v0.8.0
+    grpcOptions['grpc.max_receive_message_length'] = -1;
     Object.keys(options).forEach(key => {
+      // the older versions had a bug which required users to call an option
+      // grpc.grpc.* to make it actually pass to gRPC as grpc.*, let's handle
+      // this here until the next major release
+      if (key.startsWith('grpc.grpc.')) {
+        key = key.replace(/^grpc\./, '');
+      }
       if (key.startsWith('grpc.')) {
-        grpcOptions[key.replace(/^grpc\./, '')] = options[key] as
-          | string
-          | number;
+        grpcOptions[key] = options[key] as string | number;
       }
     });
     const stub = new CreateStub(

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -269,6 +269,8 @@ export class GrpcClient {
     const creds = await this._getCredentials(options);
     const grpcOptions: ClientOptions = {};
     // @grpc/grpc-js limits max receive message length starting from v0.8.0
+    // https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%400.8.0
+    // To keep the existing behavior and avoid libraries breakage, we pass -1 there as suggested.
     grpcOptions['grpc.max_receive_message_length'] = -1;
     Object.keys(options).forEach(key => {
       // the older versions had a bug which required users to call an option

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -50,7 +50,8 @@ describe('compileProtos tool', () => {
     process.chdir(cwd);
   });
 
-  it('compiles protos to JSON, JS, TS', async () => {
+  it('compiles protos to JSON, JS, TS', async function () {
+    this.timeout(20000);
     await compileProtos.main([
       path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
     ]);


### PR DESCRIPTION
Let's start using `@grpc/grpc-js` v1.0.0.

Since starting from v0.8.x `@grpc/grpc-js` enforces `grpc.max_receive_message_length`, we need to pass an extra gRPC option to disable it. Apparently we had a bug in the option code that stripped `grpc.` from the option names, so the client actually needed to pass `grpc.grpc.*` instead of `grpc.*` :)  Removing this now would be a breaking change, so I'll have a temporary fix in place until the time when we go to 3.0.0, just in case.