### PR TITLE
fix: add an internal getOperation method in operation client

### DIFF
--- a/src/longRunningCalls/longrunning.ts
+++ b/src/longRunningCalls/longrunning.ts
@@ -182,7 +182,7 @@ export class Operation extends EventEmitter {
     }
     const request = new operationProtos.google.longrunning.GetOperationRequest();
     request.name = this.latestResponse.name;
-    this.currentCallPromise_ = operationsClient.getOperation(
+    this.currentCallPromise_ = operationsClient.getOperationInternal(
       request,
       this._callOptions!
     );

--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -162,7 +162,19 @@ export class OperationsClient {
   }
 
   // Service calls
-
+  getOperationInternal(
+    request: protos.google.longrunning.GetOperationRequest,
+    options?: gax.CallOptions,
+    callback?: Callback<
+      protos.google.longrunning.Operation,
+      protos.google.longrunning.GetOperationRequest,
+      {} | null | undefined
+    >
+  ): CancellablePromise<ResultTuple> {
+    request = request || {};
+    options = options || {};
+    return this.innerApiCalls.getOperation(request, options, callback);
+  }
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
    * method to poll the operation result at intervals as recommended by the API
@@ -208,7 +220,7 @@ export class OperationsClient {
       protos.google.longrunning.GetOperationRequest,
       {} | null | undefined
     >
-  ): CancellablePromise<ResultTuple> {
+  ): Promise<protos.google.longrunning.Operation> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
       callback = (optionsOrCallback as unknown) as Callback<

--- a/test/unit/longrunning.ts
+++ b/test/unit/longrunning.ts
@@ -121,6 +121,7 @@ describe('longrunning', () => {
       return Promise.resolve();
     });
     return {
+      getOperationInternal: getOperationSpy,
       getOperation: getOperationSpy,
       cancelOperation: cancelOperationSpy,
       cancelGetOperationSpy,

--- a/test/unit/operationClient.ts
+++ b/test/unit/operationClient.ts
@@ -24,6 +24,7 @@ import {OperationsClientBuilder} from '../../src/operationsClient';
 import * as protobuf from 'protobufjs';
 import {GrpcClient} from '../../src/grpc';
 import {PassThrough} from 'stream';
+import {ResultTuple} from '../../src/apitypes';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -201,6 +202,110 @@ describe('operation client', () => {
       );
       await assert.rejects(async () => {
         await client.getOperation(request);
+      }, expectedError);
+      assert(
+        (client.innerApiCalls.getOperation as SinonStub)
+          .getCall(0)
+          .calledWith(request)
+      );
+    });
+  });
+  describe('getOperationInternal ', () => {
+    it('invokes getOperationInternal without error', async () => {
+      const grpcClient = new GrpcClient();
+      const clientOptions = {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      };
+      const client = new OperationsClientBuilder(grpcClient).operationsClient(
+        clientOptions
+      );
+
+      const request = generateSampleMessage(
+        new protos.google.longrunning.GetOperationRequest()
+      );
+      const expectedResponse: ResultTuple = [
+        new protos.google.longrunning.Operation(),
+        null,
+        new protos.google.longrunning.Operation(),
+      ];
+      client.innerApiCalls.getOperation = stubSimpleCall(expectedResponse);
+      const promise = client.getOperationInternal(request);
+      assert(promise.cancel());
+      const response = await promise;
+      assert.deepStrictEqual(response, [expectedResponse]);
+      assert(
+        (client.innerApiCalls.getOperation as SinonStub)
+          .getCall(0)
+          .calledWith(request)
+      );
+    });
+
+    it('invokes getOperation without error using callback', async () => {
+      const grpcClient = new GrpcClient();
+      const clientOptions = {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      };
+      const client = new OperationsClientBuilder(grpcClient).operationsClient(
+        clientOptions
+      );
+
+      const request = generateSampleMessage(
+        new protos.google.longrunning.GetOperationRequest()
+      );
+      const expectedResponse: ResultTuple = [
+        new protos.google.longrunning.Operation(),
+        null,
+        new protos.google.longrunning.Operation(),
+      ];
+      client.innerApiCalls.getOperation = stubSimpleCallWithCallback(
+        expectedResponse
+      );
+      const promise = new Promise((resolve, reject) => {
+        client.getOperationInternal(
+          request,
+          undefined,
+          (
+            err?: Error | null,
+            result?: protos.google.longrunning.Operation | null
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(result);
+            }
+          }
+        );
+      });
+      const response = await promise;
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.getOperation as SinonStub)
+          .getCall(0)
+          .calledWith(request /* callback function above */)
+      );
+    });
+
+    it('invokes getOperationInternal with error', async () => {
+      const grpcClient = new GrpcClient();
+      const clientOptions = {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      };
+      const client = new OperationsClientBuilder(grpcClient).operationsClient(
+        clientOptions
+      );
+      const request = generateSampleMessage(
+        new protos.google.longrunning.GetOperationRequest()
+      );
+      const expectedError = new Error('expected');
+      client.innerApiCalls.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(async () => {
+        await client.getOperationInternal(request);
       }, expectedError);
       assert(
         (client.innerApiCalls.getOperation as SinonStub)

--- a/test/unit/operationClient.ts
+++ b/test/unit/operationClient.ts
@@ -230,7 +230,7 @@ describe('operation client', () => {
         new protos.google.longrunning.Operation(),
       ];
       client.innerApiCalls.getOperation = stubSimpleCall(expectedResponse);
-      const response = client.getOperationInternal(request);
+      const response = await client.getOperationInternal(request);
       assert.deepStrictEqual(response, [expectedResponse]);
       assert(
         (client.innerApiCalls.getOperation as SinonStub)

--- a/test/unit/operationClient.ts
+++ b/test/unit/operationClient.ts
@@ -230,9 +230,7 @@ describe('operation client', () => {
         new protos.google.longrunning.Operation(),
       ];
       client.innerApiCalls.getOperation = stubSimpleCall(expectedResponse);
-      const promise = client.getOperationInternal(request);
-      assert(promise.cancel());
-      const response = await promise;
+      const response = client.getOperationInternal(request);
       assert.deepStrictEqual(response, [expectedResponse]);
       assert(
         (client.innerApiCalls.getOperation as SinonStub)


### PR DESCRIPTION
`longrunning.ts` needs a `getOperation` method which returns a cancellable promise, while external users call `getOperation` method to get a response as a longrunning `Operation`. So we decide to separate the call, one is `getOperationInternal` for longrunning, it returns `CancellablePromise<ResultTuple>`. And the other one is for external users which returns `Operation` type.

related change: https://github.com/googleapis/gapic-generator-typescript/pull/420
