### PR TITLE
fix: strip grpc. prefix for grpc-gcp options

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -265,6 +265,13 @@ export class GrpcClient {
    * @return {Promise} A promise which resolves to a gRPC stub instance.
    */
   async createStub(CreateStub: typeof ClientStub, options: ClientStubOptions) {
+    // The following options are understood by grpc-gcp and need a special treatment
+    // (should be passed without a `grpc.` prefix)
+    const grpcGcpOptions = [
+      'grpc.callInvocationTransformer',
+      'grpc.channelFactoryOverride',
+      'grpc.gcpApiConfig',
+    ];
     const serviceAddress = options.servicePath + ':' + options.port;
     const creds = await this._getCredentials(options);
     const grpcOptions: ClientOptions = {};
@@ -280,6 +287,9 @@ export class GrpcClient {
         key = key.replace(/^grpc\./, '');
       }
       if (key.startsWith('grpc.')) {
+        if (grpcGcpOptions.includes(key)) {
+          key = key.replace(/^grpc\./, '');
+        }
         grpcOptions[key] = options[key] as string | number;
       }
     });

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -172,6 +172,9 @@ describe('grpc', () => {
         'grpc.max_send_message_length': 10 * 1024 * 1024,
         'grpc.initial_reconnect_backoff_ms': 10000,
         other_dummy_options: 'test',
+        'grpc.callInvocationTransformer': () => {},
+        'grpc.channelFactoryOverride': () => {},
+        'grpc.gcpApiConfig': {},
       };
       // @ts-ignore
       return grpcClient.createStub(DummyStub, opts).then(stub => {
@@ -183,6 +186,9 @@ describe('grpc', () => {
           'grpc.max_send_message_length',
           'grpc.initial_reconnect_backoff_ms',
           'grpc.max_receive_message_length', // added by createStub
+          'callInvocationTransformer', // note: no grpc. prefix for grpc-gcp options
+          'channelFactoryOverride',
+          'gcpApiConfig',
         ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (expect(stub.options).to.not.have as any).key([


### PR DESCRIPTION
gRPC options are weird. Regular gRPC options are prefixed `grpc.` and should be passed down as `grpc.*`, while the three known `grpc-gcp` options should be passed without a prefix.

This partially rolls back my refactor in #809 to make `grpc-gcp` work.