### PR TITLE
fix: do not pass undefined as option values

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -280,6 +280,7 @@ export class GrpcClient {
     // To keep the existing behavior and avoid libraries breakage, we pass -1 there as suggested.
     grpcOptions['grpc.max_receive_message_length'] = -1;
     Object.keys(options).forEach(key => {
+      const value = options[key];
       // the older versions had a bug which required users to call an option
       // grpc.grpc.* to make it actually pass to gRPC as grpc.*, let's handle
       // this here until the next major release
@@ -290,7 +291,7 @@ export class GrpcClient {
         if (grpcGcpOptions.includes(key)) {
           key = key.replace(/^grpc\./, '');
         }
-        grpcOptions[key] = options[key] as string | number;
+        grpcOptions[key] = value as string | number;
       }
     });
     const stub = new CreateStub(

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -172,7 +172,9 @@ describe('grpc', () => {
         'grpc.max_send_message_length': 10 * 1024 * 1024,
         'grpc.initial_reconnect_backoff_ms': 10000,
         other_dummy_options: 'test',
-        'grpc.callInvocationTransformer': () => {},
+        'grpc.callInvocationTransformer': () => {
+          return 42;
+        },
         'grpc.channelFactoryOverride': () => {},
         'grpc.gcpApiConfig': {},
       };
@@ -190,6 +192,11 @@ describe('grpc', () => {
           'channelFactoryOverride',
           'gcpApiConfig',
         ]);
+        // check values
+        expect(stub.options['grpc.max_send_message_length']).to.eq(
+          10 * 1024 * 1024
+        );
+        expect(stub.options['callInvocationTransformer']()).to.eq(42);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (expect(stub.options).to.not.have as any).key([
           'servicePath',


### PR DESCRIPTION
This finally fixes the options processing problem I introduced in #809 and only partially fixed in #814. 

Basically, when you change the key, don't expect that you will still be able to find a value.

Also, if your unit tests only check for keys, don't expect they will catch this bug.

Lessons learned :)