### PR TITLE
fix: typescript 3.9.3 compilation

### DIFF
--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -84,8 +84,7 @@ describe('createStub', () => {
   });
 
   it('should create a stub', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const echoStub: any = await gaxGrpc.createStub(echoService, stubOptions);
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
 
     assert(echoStub instanceof protobuf.rpc.Service);
 
@@ -102,11 +101,7 @@ describe('createStub', () => {
   });
 
   it('should support optional parameters', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const echoStub: any = await gaxGrpc.createStub(
-      echoService,
-      stubExtraOptions
-    );
+    const echoStub = await gaxGrpc.createStub(echoService, stubExtraOptions);
 
     assert(echoStub instanceof protobuf.rpc.Service);
 

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -89,8 +89,7 @@ describe('createStub', () => {
   });
 
   it('should create a stub', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const echoStub: any = await gaxGrpc.createStub(echoService, stubOptions);
+    const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
 
     assert(echoStub instanceof protobuf.rpc.Service);
 
@@ -107,11 +106,7 @@ describe('createStub', () => {
   });
 
   it('should support optional parameters', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const echoStub: any = await gaxGrpc.createStub(
-      echoService,
-      stubExtraOptions
-    );
+    const echoStub = await gaxGrpc.createStub(echoService, stubExtraOptions);
 
     assert(echoStub instanceof protobuf.rpc.Service);
 


### PR DESCRIPTION
This is the first known case where the compilation is fixed by _removing_ `any` and not by _adding_ one. TypeScript is becoming perfect in handling types :)