### PR TITLE
feat: support non-slash resource in path template

### DIFF
--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -47,7 +47,6 @@ export class PathTemplate {
    */
   match(path: string): Bindings {
     let pathSegments = path.split('/');
-
     const bindings: Bindings = {};
     if (pathSegments.length !== this.segments.length) {
       // if the path contains a wildcard, then the length may differ by 1.
@@ -72,13 +71,35 @@ export class PathTemplate {
             `segment does not match, ${this.segments[index]} and  ${pathSegments[index]}.`
           );
         } else {
-          const segment = this.segments[index];
-          const variable = segment.match(/(?<={)[$0-9a-zA-Z_]+(?==.*?})/g);
+          let segment = this.segments[index];
+          const variable = segment.match(/(?<={)[$0-9a-zA-Z_]+(?==.*})/g) || [];
+          console.warn('variable: ', variable);
           if (this.segments[index].includes('**')) {
-            bindings[variable![0]] = pathSegments[0] + '/' + pathSegments[1];
+            bindings[variable[0]] = pathSegments[0] + '/' + pathSegments[1];
             pathSegments = pathSegments.slice(2);
           } else {
-            bindings[variable![0]] = pathSegments[0];
+            // segment: {blurb_id=*}.{legacy_user=*} to match pathSegments: ['bar.user2']
+            // split the match pathSegments[0] -> value: ['bar', 'user2']
+            // compare the length of two arrays, and compare array items
+            const value = pathSegments[0].split(/[-_.~]/);
+            if (value.length !== variable!.length) {
+              throw new Error(
+                `segment ${segment} does not match ${pathSegments[0]}`
+              );
+            }
+            console.warn('pathsegments: ', pathSegments);
+            for (const v of variable) {
+              bindings[v] = value[0];
+              segment = segment.replace(`{${v}=*}`, `${value[0]}`);
+              console.warn('segmenet vhange: ', segment);
+              value.shift();
+            }
+            // segment: {blurb_id=*}.{legacy_user=*} matching pathSegments: ['bar~user2'] should fail
+            if (variable.length > 1 && segment !== pathSegments[0]) {
+              throw new TypeError(
+                `non slash resource pattern ${this.segments[index]} and ${pathSegments[0]} should have same separator`
+              );
+            }
             pathSegments.shift();
           }
         }
@@ -163,6 +184,20 @@ export class PathTemplate {
           }
         }
       }
+      // {project}~{location} -> {project=*}~{location=*}
+      else if (
+        segment.match(
+          /(?<={)[0-9a-zA-Z-.~_]+(?:}[-._~]?{)[0-9a-zA-Z-.~_]+(?=})/
+        )
+      ) {
+        // [project, location]
+        const variable = segment.match(/(?<=\{).*?(?=(?:=.*?)?\})/g) || [];
+        for (const v of variable) {
+          this.bindings[v] = '*';
+          segment = segment.replace(v, v + '=*');
+        }
+        segments.push(segment);
+      }
       // {project} / {project=*} -> segments.push('{project=*}');
       //           -> bindings['project'] = '*'
       else if (segment.match(/(?<={)[0-9a-zA-Z-.~_]+(=\*)?(?=})/)) {
@@ -178,20 +213,6 @@ export class PathTemplate {
       // helloazAZ09-.~_what -> segments.push('helloazAZ09-.~_what');
       //              -> no binding in this case
       else if (segment.match(/[0-9a-zA-Z-.~_]+/)) {
-        segments.push(segment);
-      }
-      // {project}~{location} -> {project=*}~{location=*}
-      else if (
-        segment.match(
-          /(?<={)[0-9a-zA-Z-.~_]+(?:}[-._~]?{)[0-9a-zA-Z-.~_]+(?=})/
-        )
-      ) {
-        // [project, location]
-        const variable = segment.match(/(?<=\{).*?(?=(?:=.*?)?\})/g);
-        variable?.forEach(v => {
-          this.bindings[v] = '*';
-          segment.replace(v, v + '=*');
-        });
         segments.push(segment);
       }
     });

--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -73,7 +73,6 @@ export class PathTemplate {
         } else {
           let segment = this.segments[index];
           const variable = segment.match(/(?<={)[$0-9a-zA-Z_]+(?==.*})/g) || [];
-          console.warn('variable: ', variable);
           if (this.segments[index].includes('**')) {
             bindings[variable[0]] = pathSegments[0] + '/' + pathSegments[1];
             pathSegments = pathSegments.slice(2);
@@ -87,11 +86,9 @@ export class PathTemplate {
                 `segment ${segment} does not match ${pathSegments[0]}`
               );
             }
-            console.warn('pathsegments: ', pathSegments);
             for (const v of variable) {
               bindings[v] = value[0];
               segment = segment.replace(`{${v}=*}`, `${value[0]}`);
-              console.warn('segmenet vhange: ', segment);
               value.shift();
             }
             // segment: {blurb_id=*}.{legacy_user=*} matching pathSegments: ['bar~user2'] should fail

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -109,24 +109,27 @@ describe('PathTemplate', () => {
 
     it('should match template with non-slash resource patterns', () => {
       const template = new PathTemplate(
-        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
+        'user/{user_id}/blurbs/legacy/{blurb_a}-{blurb_b}~{legacy_user}'
       );
-      const want = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
+      const want = {
+        user_id: 'foo',
+        blurb_a: 'bara',
+        blurb_b: 'barb',
+        legacy_user: 'user',
+      };
       assert.deepStrictEqual(
-        template.match('user/foo/blurbs/legacy/bar.user2'),
+        template.match('user/foo/blurbs/legacy/bara-barb~user'),
         want
       );
     });
 
-    it('should fail template with malformed non-slash resource patterns', () => {
+    it('should not match template with malformed non-slash resource patterns', () => {
       const template = new PathTemplate(
         'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
       );
-      const want = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
-      assert.deepStrictEqual(
-        template.match('user/foo/blurbs/legacy/bar~user2'),
-        want
-      );
+      assert.throws(() => {
+        template.match('user/foo/blurbs/legacy/bar~user2');
+      }, TypeError);
     });
   });
 
@@ -179,10 +182,15 @@ describe('PathTemplate', () => {
 
     it('should render non-slash resource', () => {
       const template = new PathTemplate(
-        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
+        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}/project/{project}'
       );
-      const params = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
-      const want = 'user/foo/blurbs/legacy/bar.user2';
+      const params = {
+        user_id: 'foo',
+        blurb_id: 'bar',
+        legacy_user: 'user2',
+        project: 'pp',
+      };
+      const want = 'user/foo/blurbs/legacy/bar.user2/project/pp';
       assert.strictEqual(template.render(params), want);
     });
   });

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -106,6 +106,28 @@ describe('PathTemplate', () => {
       const want = {$0: 'foo/foo', $1: 'bar'};
       assert.deepStrictEqual(template.match('bar/foo/foo/foo/bar'), want);
     });
+
+    it('should match template with non-slash resource patterns', () => {
+      const template = new PathTemplate(
+        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
+      );
+      const want = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
+      assert.deepStrictEqual(
+        template.match('user/foo/blurbs/legacy/bar.user2'),
+        want
+      );
+    });
+
+    it('should fail template with malformed non-slash resource patterns', () => {
+      const template = new PathTemplate(
+        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
+      );
+      const want = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
+      assert.deepStrictEqual(
+        template.match('user/foo/blurbs/legacy/bar~user2'),
+        want
+      );
+    });
   });
 
   describe('method `render`', () => {
@@ -154,6 +176,15 @@ describe('PathTemplate', () => {
       const want = 'projects/testProject/sessions/123';
       assert.strictEqual(template.render(params), want);
     });
+
+    it('should render non-slash resource', () => {
+      const template = new PathTemplate(
+        'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
+      );
+      const params = {$user_id: 'foo', $blurb_id: 'bar', $legacy_user: 'user2'};
+      const want = 'user/foo/blurbs/legacy/bar.user2';
+      assert.strictEqual(template.render(params), want);
+    });
   });
 
   describe('method `inspect`', () => {
@@ -163,6 +194,8 @@ describe('PathTemplate', () => {
       '/buckets/{hello}': 'buckets/{hello=*}',
       '/buckets/{hello=what}/{world}': 'buckets/{hello=what}/{world=*}',
       '/buckets/helloazAZ09-.~_what': 'buckets/helloazAZ09-.~_what',
+      'user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}':
+        'user/{user_id=*}/blurbs/legacy/{blurb_id=*}.{legacy_user=*}',
     };
 
     Object.keys(tests).forEach(template => {


### PR DESCRIPTION
we allow non-slash resource now, for example:
```
user/{user_id}/blurbs/legacy/{blurb_id}.{legacy_user}'
```
