### PR TITLE
fix: fix match logic for path template

### DIFF
--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -35,8 +35,6 @@ export class PathTemplate {
   constructor(data: string) {
     this.data = data;
     this.segments = this.parsePathTemplate(data);
-    console.warn('this.bindings: ', this.bindings);
-    console.warn('this.segments: ', this.segments);
     this.size = this.segments.length;
   }
 
@@ -75,7 +73,6 @@ export class PathTemplate {
         } else {
           let segment = this.segments[index];
           const variable = segment.match(/(?<={)[$0-9a-zA-Z_]+(?==.*})/g) || [];
-          console.warn(variable);
           if (segment.includes('**')) {
             bindings[variable[0]] = pathSegments[0] + '/' + pathSegments[1];
             pathSegments = pathSegments.slice(2);

--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -35,6 +35,8 @@ export class PathTemplate {
   constructor(data: string) {
     this.data = data;
     this.segments = this.parsePathTemplate(data);
+    console.warn('this.bindings: ', this.bindings);
+    console.warn('this.segments: ', this.segments);
     this.size = this.segments.length;
   }
 
@@ -73,29 +75,36 @@ export class PathTemplate {
         } else {
           let segment = this.segments[index];
           const variable = segment.match(/(?<={)[$0-9a-zA-Z_]+(?==.*})/g) || [];
-          if (this.segments[index].includes('**')) {
+          console.warn(variable);
+          if (segment.includes('**')) {
             bindings[variable[0]] = pathSegments[0] + '/' + pathSegments[1];
             pathSegments = pathSegments.slice(2);
           } else {
-            // segment: {blurb_id=*}.{legacy_user=*} to match pathSegments: ['bar.user2']
-            // split the match pathSegments[0] -> value: ['bar', 'user2']
-            // compare the length of two arrays, and compare array items
-            const value = pathSegments[0].split(/[-_.~]/);
-            if (value.length !== variable!.length) {
-              throw new Error(
-                `segment ${segment} does not match ${pathSegments[0]}`
-              );
-            }
-            for (const v of variable) {
-              bindings[v] = value[0];
-              segment = segment.replace(`{${v}=*}`, `${value[0]}`);
-              value.shift();
-            }
-            // segment: {blurb_id=*}.{legacy_user=*} matching pathSegments: ['bar~user2'] should fail
-            if (variable.length > 1 && segment !== pathSegments[0]) {
-              throw new TypeError(
-                `non slash resource pattern ${this.segments[index]} and ${pathSegments[0]} should have same separator`
-              );
+            // atomic resource
+            if (variable.length === 1) {
+              bindings[variable[0]] = pathSegments[0];
+            } else {
+              // non-slash resource
+              // segment: {blurb_id=*}.{legacy_user=*} to match pathSegments: ['bar.user2']
+              // split the match pathSegments[0] -> value: ['bar', 'user2']
+              // compare the length of two arrays, and compare array items
+              const value = pathSegments[0].split(/[-_.~]/);
+              if (value.length !== variable!.length) {
+                throw new Error(
+                  `segment ${segment} does not match ${pathSegments[0]}`
+                );
+              }
+              for (const v of variable) {
+                bindings[v] = value[0];
+                segment = segment.replace(`{${v}=*}`, `${value[0]}`);
+                value.shift();
+              }
+              // segment: {blurb_id=*}.{legacy_user=*} matching pathSegments: ['bar~user2'] should fail
+              if (segment !== pathSegments[0]) {
+                throw new TypeError(
+                  `non slash resource pattern ${this.segments[index]} and ${pathSegments[0]} should have same separator`
+                );
+              }
             }
             pathSegments.shift();
           }
@@ -197,8 +206,8 @@ export class PathTemplate {
       }
       // {project} / {project=*} -> segments.push('{project=*}');
       //           -> bindings['project'] = '*'
-      else if (segment.match(/(?<={)[0-9a-zA-Z-.~_]+(=\*)?(?=})/)) {
-        const variable = segment.match(/(?<={)[0-9a-zA-Z-.~_]+(=\*)?(?=})/);
+      else if (segment.match(/(?<={)[0-9a-zA-Z-.~_]+(?=(=\*)?})/)) {
+        const variable = segment.match(/(?<={)[0-9a-zA-Z-.~_]+(?=(=\*)?})/);
         this.bindings[variable![0]] = '*';
         segments.push(`{${variable![0]}=*}`);
       }

--- a/test/unit/pagedIteration.ts
+++ b/test/unit/pagedIteration.ts
@@ -351,7 +351,7 @@ describe('paged iteration', () => {
       });
     });
 
-    it.only('cooperates with google-cloud-node usage', done => {
+    it('cooperates with google-cloud-node usage', done => {
       let stream;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const output = streamEvents((pumpify as any).obj()) as pumpify;

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -76,6 +76,13 @@ describe('PathTemplate', () => {
             hello: 'world',
           },
         },
+        {
+          path: 'buckets/long-door-651',
+          template: 'buckets/{project}',
+          want: {
+            project: 'long-door-651',
+          },
+        },
       ];
       tests.forEach(t => {
         const template = new PathTemplate(t.template);
@@ -143,6 +150,14 @@ describe('PathTemplate', () => {
         $3: 'google.com:a-b',
       };
       const want = 'buckets/f/o/o/objects/google.com:a-b';
+      assert.strictEqual(template.render(params), want);
+    });
+    it('should render atomic resource', () => {
+      const template = new PathTemplate('buckets/{project=*}');
+      const params = {
+        project: 'long-project-name',
+      };
+      const want = 'buckets/long-project-name';
       assert.strictEqual(template.render(params), want);
     });
 


### PR DESCRIPTION
failing case: match `projects/{project=*}` with `project: long-project-name` from dialogflow sample-test
https://github.com/googleapis/nodejs-dialogflow/pull/617

the original logic is to check the matching string (`long-project-name`) if it can be divided by `-_.~`, to decide whether it's non-slash resource (for example match `{user_a}-{user_b}` with `usera-userb`). but it will fail for the above case.
Now we check the segments `{project=*}` if it has multiple brackets, it will be taken as non-slash resource (for example `{user_a}-{user_b}`