### PR TITLE
feat: support proto3 optional fields in exported protos

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "execa": "^4.0.0",
     "file-loader": "^6.0.0",
     "fs-extra": "^9.0.0",
-    "google-proto-files": "^2.0.0",
+    "google-proto-files": "^2.1.0",
     "gts": "^2.0.0",
     "is-docker": "^2.0.0",
     "json-loader": "^0.5.7",


### PR DESCRIPTION
In this PR, I'm just making sure we use v2.1.0+ of `google-proto-files`. It will pull the latest `google/protobuf/compiler/plugin.proto` that has support for a new plugin feature (`optional` syntax for `proto3`).