### PR TITLE
fix: remove version from protobuf unique root name

### DIFF
--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,5 +1,4 @@
 {
   "_why?": "This is a fake package.json for compileProtos test.",
-  "name": "@org/fake-package",
-  "version": "42.0.7-prealpha84"
+  "name": "@org/fake-package"
 }

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -72,11 +72,7 @@ describe('compileProtos tool', () => {
     );
 
     // check that it uses proper root object; it's taken from fixtures/package.json
-    assert(
-      js
-        .toString()
-        .includes('$protobuf.roots._org_fake_package_42_0_7_prealpha84')
-    );
+    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
 
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
@@ -151,7 +147,7 @@ describe('compileProtos tool', () => {
     const rootName = await compileProtos.generateRootName([
       path.join(__dirname, '..', '..', 'test', 'fixtures', 'dts-update'),
     ]);
-    assert.strictEqual(rootName, '_org_fake_package_42_0_7_prealpha84_protos');
+    assert.strictEqual(rootName, '_org_fake_package_protos');
   });
 
   it('falls back to the default name for protobuf root if unable to guess', async () => {

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -267,18 +267,15 @@ export async function generateRootName(directories: string[]): Promise<string> {
   // We need to provide `-r root` option to `pbjs -t static-module`, otherwise
   // we'll have big problems if two different libraries are used together.
   // It's OK to play some guessing game here: if we locate `package.json`
-  // with a package name and version, we'll use it; otherwise, we'll fallback
-  // to 'default'.
+  // with a package name, we'll use it; otherwise, we'll fallback to 'default'.
   for (const directory of directories) {
     const packageJson = path.resolve(directory, '..', 'package.json');
     if (fs.existsSync(packageJson)) {
       const json = JSON.parse((await readFile(packageJson)).toString()) as {
         name: string;
-        version: string;
       };
       const name = json.name.replace(/[^\w\d]/g, '_');
-      const version = json.version.replace(/[^\w\d]/g, '_');
-      const hopefullyUniqueName = `${name}_${version}_protos`;
+      const hopefullyUniqueName = `${name}_protos`;
       return hopefullyUniqueName;
     }
   }


### PR DESCRIPTION
Having the package version there is too much since it updates every time we bump a version. Just the package name is enough.