### PR TITLE
fix: segment in path template can contain wildcard

### DIFF
--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -122,8 +122,6 @@ export class PathTemplate {
    *   parsed
    */
   render(bindings: Bindings): string {
-    console.warn('bindings: ', bindings);
-    console.warn('this.binding: ', this.bindings);
     if (Object.keys(bindings).length !== Object.keys(this.bindings).length) {
       throw new TypeError(
         `The number of variables ${
@@ -172,13 +170,10 @@ export class PathTemplate {
    */
   private parsePathTemplate(data: string): string[] {
     const pathSegments = splitPathTemplate(data);
-    console.warn('===> split pathSegments: ', pathSegments);
     let index = 0;
     let wildCardCount = 0;
     const segments: string[] = [];
     pathSegments.forEach(segment => {
-      console.warn('===> segment: ', segment);
-
       // * or ** -> segments.push('{$0=*}');
       //         -> bindings['$0'] = '*'
       if (segment === '*' || segment === '**') {
@@ -232,7 +227,6 @@ export class PathTemplate {
         throw new TypeError('Can not have more than one wildcard.');
       }
     });
-    console.warn('segments: ', segments);
     return segments;
   }
 }

--- a/test/system-test/test.clientlibs.ts
+++ b/test/system-test/test.clientlibs.ts
@@ -83,7 +83,7 @@ async function runSystemTest(packageName: string): Promise<void> {
     stdio: 'inherit',
   });
 }
-
+// nodejs-kms does not have system test.
 async function runSamplesTest(packageName: string): Promise<void> {
   await execa('npm', ['run', 'samples-test'], {
     cwd: packageName,

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -32,6 +32,13 @@ describe('PathTemplate', () => {
       };
       assert.throws(shouldFail, TypeError);
     });
+
+    it('should fail on multiple path wildcards', () => {
+      const shouldFail = () => {
+        return new PathTemplate('buckets/*/**/{project=**}/objects/*');
+      };
+      assert.throws(shouldFail, TypeError);
+    });
   });
 
   describe('method `match`', () => {
@@ -150,6 +157,17 @@ describe('PathTemplate', () => {
         $3: 'google.com:a-b',
       };
       const want = 'buckets/f/o/o/objects/google.com:a-b';
+      assert.strictEqual(template.render(params), want);
+    });
+    it('should render atomic resource', () => {
+      const template = new PathTemplate(
+        'projects/{project}/metricDescriptors/{metric_descriptor=**}'
+      );
+      const params = {
+        project: 'project-name',
+        metric_descriptor: 'descriptor',
+      };
+      const want = 'projects/project-name/metricDescriptors/descriptor';
       assert.strictEqual(template.render(params), want);
     });
     it('should render atomic resource', () => {


### PR DESCRIPTION
[monitoring](https://github.com/googleapis/nodejs-monitoring/pull/436) now fails for this.