### PR TITLE
fix(deps): use @grpc/grpc-js ~1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "~1.0.0",
+    "@grpc/grpc-js": "~1.1.0",
     "@grpc/proto-loader": "^0.5.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compileProtos": "./build/tools/compileProtos.js"
   },
   "dependencies": {
-    "@grpc/grpc-js": "~1.1.0",
+    "@grpc/grpc-js": "~1.1.1",
     "@grpc/proto-loader": "^0.5.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",

--- a/test/fixtures/google-gax-packaging-test-app/package.json
+++ b/test/fixtures/google-gax-packaging-test-app/package.json
@@ -24,7 +24,7 @@
     "prettier": "^1.17.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.5.0",
+    "@grpc/grpc-js": "~1.1.0",
     "google-gax": "file:./google-gax.tgz",
     "protobufjs": "^6.8.8"
   },

--- a/test/fixtures/google-gax-packaging-test-app/package.json
+++ b/test/fixtures/google-gax-packaging-test-app/package.json
@@ -24,7 +24,7 @@
     "prettier": "^1.17.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "~1.1.0",
+    "@grpc/grpc-js": "~1.1.1",
     "google-gax": "file:./google-gax.tgz",
     "protobufjs": "^6.8.8"
   },


### PR DESCRIPTION
This PR bumps the minor version of `@grpc/grpc-js` to 1.1.x.

Cc: @murgatroid99
