### PR TITLE
feat: properly decode error in fallback scenario, export FallbackServiceError type

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -35,8 +35,8 @@ import {GaxCall, GRPCCall} from './apitypes';
 import {Descriptor} from './descriptor';
 import {createApiCall as _createApiCall} from './createApiCall';
 import {isBrowser} from './isbrowser';
-import {FallbackErrorDecoder} from './fallbackError';
-
+import {FallbackErrorDecoder, FallbackServiceError} from './fallbackError';
+export {FallbackServiceError};
 export {PathTemplate} from './pathTemplate';
 export {routingHeader};
 export {CallSettings, constructSettings, RetryOptions} from './gax';

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -333,8 +333,8 @@ export class GrpcClient {
           })
           .then(([ok, buffer]: [boolean, Buffer | ArrayBuffer]) => {
             if (!ok) {
-              const status = statusDecoder.decodeRpcStatus(buffer);
-              throw new Error(JSON.stringify(status));
+              const error = statusDecoder.decodeErrorFromBuffer(buffer);
+              throw error;
             }
             serviceCallback(null, new Uint8Array(buffer));
           })

--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -252,11 +252,10 @@ describe('grpc-fallback', () => {
   it('should handle an error', done => {
     const requestObject = {content: 'test-content'};
     // example of an actual google.rpc.Status error message returned by Language API
-    const expectedError = {
+    const expectedError = Object.assign(new Error('Error message'), {
       code: 3,
-      message: 'Error message',
       details: [],
-    };
+    });
 
     const fakeFetch = sinon.fake.resolves({
       ok: false,
@@ -272,7 +271,9 @@ describe('grpc-fallback', () => {
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err: Error) => {
-        assert.strictEqual(err.message, JSON.stringify(expectedError));
+        assert(err instanceof Error);
+        assert.strictEqual(err.message, '3 INVALID_ARGUMENT: Error message');
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(expectedError));
         done();
       });
     });

--- a/test/unit/fallbackError.ts
+++ b/test/unit/fallbackError.ts
@@ -48,4 +48,36 @@ describe('gRPC-fallback error decoding', () => {
       JSON.stringify(expectedError)
     );
   });
+
+  it('decodes error and status code', () => {
+    // example of an actual google.rpc.Status error message returned by Language API
+    const fixtureName = path.resolve(__dirname, '..', 'fixtures', 'error.bin');
+    const errorBin = fs.readFileSync(fixtureName);
+    const expectedError = Object.assign(
+      new Error(
+        '3 INVALID_ARGUMENT: One of content, or gcs_content_uri must be set.'
+      ),
+      {
+        code: 3,
+        details: [
+          {
+            fieldViolations: [
+              {
+                field: 'document.content',
+                description: 'Must have some text content to annotate.',
+              },
+            ],
+          },
+        ],
+      }
+    );
+    const decoder = new FallbackErrorDecoder();
+    const decodedError = decoder.decodeErrorFromBuffer(errorBin);
+    assert(decodedError instanceof Error);
+    // nested error messages have different types so we can't use deepStrictEqual here
+    assert.strictEqual(
+      JSON.stringify(decodedError),
+      JSON.stringify(expectedError)
+    );
+  });
 });

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -242,9 +242,10 @@ describe('grpc-fallback', () => {
     // example of an actual google.rpc.Status error message returned by Language API
     const fixtureName = path.resolve(__dirname, '..', 'fixtures', 'error.bin');
     const errorBin = fs.readFileSync(fixtureName);
+    const expectedMessage =
+      '3 INVALID_ARGUMENT: One of content, or gcs_content_uri must be set.';
     const expectedError = {
       code: 3,
-      message: 'One of content, or gcs_content_uri must be set.',
       details: [
         {
           fieldViolations: [
@@ -267,8 +268,10 @@ describe('grpc-fallback', () => {
     );
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
-      echoStub.echo(requestObject, {}, {}, (err: {message: string}) => {
-        assert.strictEqual(err.message, JSON.stringify(expectedError));
+      echoStub.echo(requestObject, {}, {}, (err: Error) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.message, expectedMessage);
+        assert.strictEqual(JSON.stringify(err), JSON.stringify(expectedError));
         done();
       });
     });


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#395. Adapted a piece of error processing from `@grpc/grpc-js` to use in the fallback scenario.