### PR TITLE
feat: no protobuf dependency in generated js, d.ts

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -413,6 +413,8 @@ export function createApiCall(
 }
 
 export {protobuf};
+import * as protobufMinimal from 'protobufjs/minimal';
+export {protobufMinimal};
 
 // Different environments or bundlers may or may not respect "browser" field
 // in package.json (e.g. Electron does not respect it, but if you run the code

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -413,8 +413,7 @@ export function createApiCall(
 }
 
 export {protobuf};
-import * as protobufMinimal from 'protobufjs/minimal';
-export {protobufMinimal};
+export * as protobufMinimal from 'protobufjs/minimal';
 
 // Different environments or bundlers may or may not respect "browser" field
 // in package.json (e.g. Electron does not respect it, but if you run the code

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,7 @@ export const version = require('../../package.json').version;
 
 import * as protobuf from 'protobufjs';
 export {protobuf};
-import * as protobufMinimal from 'protobufjs/minimal';
-export {protobufMinimal};
+export * as protobufMinimal from 'protobufjs/minimal';
 
 import * as fallback from './fallback';
 export {fallback};

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,8 @@ export const version = require('../../package.json').version;
 
 import * as protobuf from 'protobufjs';
 export {protobuf};
+import * as protobufMinimal from 'protobufjs/minimal';
+export {protobufMinimal};
 
 import * as fallback from './fallback';
 export {fallback};

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -70,6 +70,8 @@ describe('compileProtos tool', () => {
     assert(
       js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
+    assert(js.toString().includes('require("google-gax").protobufMinimal'));
+    assert(!js.toString().includes('require("protobufjs/minimal")'));
 
     // check that it uses proper root object; it's taken from fixtures/package.json
     assert(js.toString().includes('$protobuf.roots._org_fake_package'));
@@ -81,6 +83,10 @@ describe('compileProtos tool', () => {
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
+    assert(
+      ts.toString().includes('import {protobuf as $protobuf} from "google-gax"')
+    );
+    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });
 
   it('writes an empty object if no protos are given', async () => {

--- a/test/unit/exports.ts
+++ b/test/unit/exports.ts
@@ -56,6 +56,12 @@ describe('exports', () => {
     it('exports fallback', () => {
       assert(typeof index.fallback === 'object');
     });
+    it('exports protobuf', () => {
+      assert(typeof index.protobuf === 'object');
+    });
+    it('exports protobufMinimal', () => {
+      assert(typeof index.protobufMinimal === 'object');
+    });
   });
 
   describe('fallback', () => {
@@ -86,6 +92,12 @@ describe('exports', () => {
     it('exports version', () => {
       assert(typeof fallback.version === 'string');
       assert.strictEqual(fallback.version, version + '-fallback');
+    });
+    it('exports protobuf', () => {
+      assert(typeof fallback.protobuf === 'object');
+    });
+    it('exports protobufMinimal', () => {
+      assert(typeof fallback.protobufMinimal === 'object');
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-text-to-speech/issues/423. The generated `protos/protos.js` and `protos/protos.d.ts` should not depend directly on either `protobufjs` or (even worse) `protobufjs/minimal`. To fix that:

- reexport `protobufjs/minimal` from gax in both regular and fallback scenarios;
- fix the generated `.js` and `.d.ts` files to make them depend on the gax-exported `protobuf` / `protobufMinimal`.

This change has a potential to break the world, so I will release it as a pre-release before making it go live.