### PR TITLE
refactor: drop lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
     "@grpc/proto-loader": "^0.5.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
+    "dlv": "^1.1.3",
     "duplexify": "^3.6.0",
     "google-auth-library": "^6.0.0",
     "is-stream-ended": "^0.1.4",
-    "lodash.at": "^4.6.0",
-    "lodash.has": "^4.5.2",
     "node-fetch": "^2.6.0",
     "protobufjs": "^6.9.0",
     "retry-request": "^4.0.0",
@@ -31,10 +30,11 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
+    "@types/dlv": "^1.1.2",
     "@types/download": "^6.2.4",
     "@types/fs-extra": "^8.0.1",
-    "@types/lodash.at": "^4.6.4",
-    "@types/lodash.has": "^4.5.4",
     "@types/mocha": "^8.0.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^10.3.2",
@@ -76,9 +76,7 @@
     "ts-loader": "^8.0.0",
     "typescript": "^3.8.3",
     "webpack": "^4.34.0",
-    "webpack-cli": "^3.3.4",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "webpack-cli": "^3.3.4"
   },
   "scripts": {
     "docs": "compodoc src/",

--- a/src/bundlingCalls/bundlingUtils.ts
+++ b/src/bundlingCalls/bundlingUtils.ts
@@ -18,7 +18,7 @@
  * Provides behavior that supports request bundling.
  */
 
-import at = require('lodash.at');
+import dlv = require('dlv');
 import {RequestType} from '../apitypes';
 
 /**
@@ -39,7 +39,7 @@ export function computeBundleId(
   const ids: unknown[] = [];
   let hasIds = false;
   for (let i = 0; i < discriminatorFields.length; ++i) {
-    const id = at(obj, discriminatorFields[i])[0];
+    const id = dlv(obj, discriminatorFields[i]);
     if (id === undefined) {
       ids.push(null);
     } else {


### PR DESCRIPTION
Ref https://github.com/developit/dlv

Per function `lodash.*` packages are deprecated and gonna be removed.
Dlv is very small and popular alternative to `lodash.at` which fits
better to the use case. And looks like `lodash.has` is unused.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
