### PR TITLE
fix(deps): drop semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "is-stream-ended": "^0.1.4",
     "node-fetch": "^2.6.1",
     "protobufjs": "^6.9.0",
-    "retry-request": "^4.0.0",
-    "semver": "^6.0.0"
+    "retry-request": "^4.0.0"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
@@ -37,7 +36,6 @@
     "@types/proxyquire": "^1.3.28",
     "@types/pumpify": "^1.4.1",
     "@types/rimraf": "^3.0.0",
-    "@types/semver": "^6.0.0",
     "@types/sinon": "^9.0.0",
     "c8": "^7.0.0",
     "codecov": "^3.1.0",

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -95,6 +95,15 @@ export class GrpcClient {
     this.auth = options.auth || new GoogleAuth(options);
     this.fallback = false;
 
+    const minimumVersion = 10;
+    const major = Number(process.version.match(/^v(\d+)/)?.[1]);
+    if (Number.isNaN(major) || major < minimumVersion) {
+      const errorMessage =
+        `Node.js v${minimumVersion}.0.0 is a minimum requirement. To learn about legacy version support visit: ` +
+        'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
+      throw new Error(errorMessage);
+    }
+
     if ('grpc' in options) {
       this.grpc = options.grpc!;
       this.grpcVersion = '';

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -21,7 +21,6 @@ import * as grpc from '@grpc/grpc-js';
 import {OutgoingHttpHeaders} from 'http';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
-import * as semver from 'semver';
 
 import * as gax from './gax';
 import {ClientOptions} from '@grpc/grpc-js/build/src/client';
@@ -95,14 +94,6 @@ export class GrpcClient {
   constructor(options: GrpcClientOptions = {}) {
     this.auth = options.auth || new GoogleAuth(options);
     this.fallback = false;
-
-    const minimumVersion = '10.0.0';
-    if (semver.lt(process.version, minimumVersion)) {
-      const errorMessage =
-        `Node.js v${minimumVersion} is a minimum requirement. To learn about legacy version support visit: ` +
-        'https://github.com/googleapis/google-cloud-node#supported-nodejs-versions';
-      throw new Error(errorMessage);
-    }
 
     if ('grpc' in options) {
       this.grpc = options.grpc!;


### PR DESCRIPTION
Semver is used to check node version. Though the package already have
"engines" field which prevents installing legacy node versions. As a
result the check can never show error.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
