### PR TITLE
fix: properly bundle requests with snake_case

### DIFF
--- a/src/bundlingCalls/bundleDescriptor.ts
+++ b/src/bundlingCalls/bundleDescriptor.ts
@@ -22,6 +22,32 @@ import {BundleApiCaller} from './bundleApiCaller';
 import {BundleExecutor} from './bundleExecutor';
 
 /**
+ * Capitalizes the first character of the given string.
+ */
+function capitalize(str: string) {
+  if (str.length === 0) {
+    return str;
+  }
+  return str[0].toUpperCase() + str.slice(1);
+}
+
+/**
+ * Converts a given string from snake_case (normally used in proto definitions) to
+ * camelCase (used by protobuf.js)
+ */
+function toCamelCase(str: string) {
+  // split on spaces, non-alphanumeric, or capital letters
+  const splitted = str
+    .split(/(?=[A-Z])|[\s\W_]+/)
+    .filter(w => w.length > 0)
+    .map(word => word.toLowerCase());
+  if (splitted.length === 0) {
+    return str;
+  }
+  return [splitted[0], ...splitted.slice(1).map(capitalize)].join('');
+}
+
+/**
  * A descriptor for calls that can be bundled into one call.
  */
 export class BundleDescriptor implements Descriptor {
@@ -68,7 +94,9 @@ export class BundleDescriptor implements Descriptor {
       subresponseField = null;
     }
     this.bundledField = bundledField;
-    this.requestDiscriminatorFields = requestDiscriminatorFields;
+    this.requestDiscriminatorFields = requestDiscriminatorFields.map(
+      toCamelCase
+    );
     this.subresponseField = subresponseField;
     this.byteLengthFunction = byteLengthFunction;
   }

--- a/test/unit/bundling.ts
+++ b/test/unit/bundling.ts
@@ -977,4 +977,53 @@ describe('bundleable', () => {
     });
     p.cancel();
   });
+
+  it('properly processes camel case fields', done => {
+    const descriptor = new BundleDescriptor(
+      'data',
+      ['log_name'],
+      'data',
+      byteLength
+    );
+    const settings = {
+      settings: {bundleOptions},
+      descriptor,
+    };
+    const spy = sinon.spy(func);
+    const callback = sinon.spy(() => {
+      if (callback.callCount === 4) {
+        assert.strictEqual(spy.callCount, 2); // we expect two requests, each has two items
+        done();
+      }
+    });
+    const apiCall = createApiCall(spy, settings);
+    apiCall({data: ['data1'], logName: 'log1'}, undefined, err => {
+      if (err) {
+        done(err);
+      } else {
+        callback();
+      }
+    });
+    apiCall({data: ['data1'], logName: 'log2'}, undefined, err => {
+      if (err) {
+        done(err);
+      } else {
+        callback();
+      }
+    });
+    apiCall({data: ['data2'], logName: 'log1'}, undefined, err => {
+      if (err) {
+        done(err);
+      } else {
+        callback();
+      }
+    });
+    apiCall({data: ['data2'], logName: 'log2'}, undefined, err => {
+      if (err) {
+        done(err);
+      } else {
+        callback();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-logging/issues/909. In the bundling configuration the `log_name` field is in snake_case, while the request object has `logName` in camelCase, so it's not used in the bundle ID computation. Fixing this by converting all field names to camelCase, it happens once in `BundleDescriptor` constructor so does not affect runtime in any way.