### PR TITLE
test: make tests work in Node 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,9 @@ jobs:
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
       # dependencies that don't match our engines field:
-      - run: npm install --production --engine-strict
+      - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
+      # Clean up the production install, before installing dev/production:
+      - run: rm -rf node_modules
       - run: npm install
       - run: npm test
       - name: coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 13]
+        node: [10, 12, 14, 15]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -15,6 +15,7 @@
  */
 
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable no-undef */
 
 import * as assert from 'assert';
 import {describe, it, beforeEach, afterEach, before, after} from 'mocha';
@@ -28,7 +29,7 @@ import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {GrpcClient} from '../../src/fallback';
 
 // @ts-ignore
-const hasAbortController = typeof AbortController !== "undefined";
+const hasAbortController = typeof AbortController !== 'undefined';
 
 const authClient = {
   getRequestHeaders() {
@@ -133,7 +134,9 @@ describe('grpc-fallback', () => {
     stubOptions: {};
   const createdAbortControllers: string[] = [];
   // @ts-ignore
-  const savedAbortController = hasAbortController? AbortController : abortController.AbortController;
+  const savedAbortController = hasAbortController
+    ? AbortController
+    : abortController.AbortController;
 
   before(() => {
     stubOptions = {
@@ -159,7 +162,6 @@ describe('grpc-fallback', () => {
       // @ts-ignore
       createdAbortControllers.push(this);
     };
-
 
     if (hasAbortController) {
       // @ts-ignore

--- a/test/unit/streaming.ts
+++ b/test/unit/streaming.ts
@@ -216,20 +216,39 @@ describe('streaming', () => {
     let receivedMetadata: {};
     let receivedStatus: {};
     let receivedResponse: {};
+    let finished = false;
+
+    function check() {
+      if (
+        typeof receivedMetadata !== 'undefined' &&
+        typeof receivedStatus !== 'undefined' &&
+        typeof receivedResponse !== 'undefined' &&
+        finished
+      ) {
+        assert.deepStrictEqual(receivedMetadata, responseMetadata);
+        assert.deepStrictEqual(receivedStatus, status);
+        assert.deepStrictEqual(receivedResponse, expectedResponse);
+        done();
+      }
+    }
+
+    // Note: in Node v15 the order of events has changed: 'status' comes after 'finish'.
+    // It might be a Node bug; we'll just make sure the code works.
     s.on('metadata', data => {
       receivedMetadata = data;
+      check();
     });
     s.on('status', data => {
       receivedStatus = data;
+      check();
     });
     s.on('response', data => {
       receivedResponse = data;
+      check();
     });
     s.on('finish', () => {
-      assert.deepStrictEqual(receivedMetadata, responseMetadata);
-      assert.deepStrictEqual(receivedStatus, status);
-      assert.deepStrictEqual(receivedResponse, expectedResponse);
-      done();
+      finished = true;
+      check();
     });
     assert.strictEqual(s.readable, true);
     assert.strictEqual(s.writable, true);


### PR DESCRIPTION
Node 15 introduced `AbortController` (so the test that mocks it now needs to be aware of which `AbortController` to mock - the Node 15 one or the one from `abort-controller` module).

Also, Node 15 apparently broke something in stream handling (the order of events coming has changed). Fixed the test to account for that possible change.