### PR TITLE
fix(deps): use google-auth-library with defaultScopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",
-    "google-auth-library": "^6.0.0",
+    "google-auth-library": "^6.1.3",
     "is-stream-ended": "^0.1.4",
     "node-fetch": "^2.6.1",
     "protobufjs": "^6.9.0",


### PR DESCRIPTION
Make sure the `google-auth-library` we use supports `defaultScopes`.