### PR TITLE
fix(REST): query string parameters must be camelCased

### DIFF
--- a/src/transcoding.ts
+++ b/src/transcoding.ts
@@ -304,13 +304,13 @@ export function transcode(
       // one field possibly goes to request data, others go to query string
       const body = httpRule.body;
       let data: string | RequestType = '';
-      const queryStringObject = deepCopy(snakeRequest);
+      const queryStringObject = deepCopy(request); // use camel case for query string
       if (body) {
-        deleteField(queryStringObject, body);
+        deleteField(queryStringObject, snakeToCamelCase(body));
         data = snakeRequest[body] as RequestType;
       }
       for (const field of matchedFields) {
-        deleteField(queryStringObject, field);
+        deleteField(queryStringObject, snakeToCamelCase(field));
       }
       const queryStringComponents = buildQueryStringComponents(
         queryStringObject

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -144,27 +144,35 @@ describe('gRPC to HTTP transcoding', () => {
     // Checking camel-snake-case conversions
     assert.deepEqual(
       transcode(
-        {snakeCaseFirst: 'first', snakeCaseBody: {snakeCaseField: 42}},
+        {
+          snakeCaseFirst: 'first',
+          snakeCaseBody: {snakeCaseField: 42},
+          fieldName: 'value',
+        },
         parsedOptions
       ),
       {
         httpMethod: 'post',
         url: '/v3/a/first',
-        queryString: '',
+        queryString: 'fieldName=value',
         data: {snakeCaseField: 42},
       }
     );
 
     assert.deepEqual(
       transcode(
-        {snakeCaseSecond: 'second', snakeCaseBody: {snakeCaseField: 42}},
+        {
+          snakeCaseSecond: 'second',
+          snakeCaseBody: {snakeCaseField: 42},
+          fieldName: 'value',
+        },
         parsedOptions
       ),
       {
         httpMethod: 'post',
         url: '/v3/b/second',
         queryString: '',
-        data: {snakeCaseBody: {snakeCaseField: 42}},
+        data: {snakeCaseBody: {snakeCaseField: 42}, fieldName: 'value'},
       }
     );
 


### PR DESCRIPTION
As discussed with @viacheslav-rostovtsev today: when building a query string for REGAPIC, the field names must be camelCased. Previously, they were sent in snake_case. Fixing in the code and adding test coverage.

(@bcoe for yoshi-nodejs review, Cc: @vam-google)
