### PR TITLE
fix: update google-auth-library to v7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",
     "fast-text-encoding": "^1.0.3",
-    "google-auth-library": "^6.1.3",
+    "google-auth-library": "^7.0.2",
     "is-stream-ended": "^0.1.4",
     "node-fetch": "^2.6.1",
     "protobufjs": "^6.10.2",

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -54,6 +54,7 @@ import {
   JWT,
   UserRefreshClient,
   GoogleAuthOptions,
+  BaseExternalAccountClient,
 } from 'google-auth-library';
 import {OperationsClientBuilder} from './operationsClient';
 import {GrpcClientOptions, ClientStubOptions} from './grpc';
@@ -89,7 +90,12 @@ interface FallbackServiceStub {
 
 export class GrpcClient {
   auth?: OAuth2Client | GoogleAuth;
-  authClient?: OAuth2Client | Compute | JWT | UserRefreshClient;
+  authClient?:
+    | OAuth2Client
+    | Compute
+    | JWT
+    | UserRefreshClient
+    | BaseExternalAccountClient;
   fallback: boolean | 'rest' | 'proto';
   grpcVersion: string;
 


### PR DESCRIPTION
Update dependency to google-auth-library to `v7.0.2`.
This also requires adding `BaseExternalAccountClient` as an acceptable `AuthClient` in `GrpcClient#authClient`.
