### PR TITLE
feat: Allow to decide if to retry based on error message

### DIFF
--- a/src/createApiCall.ts
+++ b/src/createApiCall.ts
@@ -91,8 +91,8 @@ export function createApiCall(
         if (
           !streaming &&
           retry &&
-          retry.retryCodes &&
-          retry.retryCodes.length > 0
+          (retry.shouldRetryFn ||
+            (retry.retryCodes && retry.retryCodes.length > 0))
         ) {
           retry.backoffSettings.initialRpcTimeoutMillis =
             retry.backoffSettings.initialRpcTimeoutMillis ||

--- a/src/gax.ts
+++ b/src/gax.ts
@@ -78,19 +78,10 @@ export type ShouldRetryFnType = (
  * @property {ShouldRetryFnType} shouldRetryFn - predicate function that would check if
  *   given error should be retried.
  */
-export class RetryOptions {
+export interface RetryOptions {
   retryCodes: number[];
   backoffSettings: BackoffSettings;
   shouldRetryFn?: ShouldRetryFnType;
-  constructor(
-    retryCodes: number[],
-    backoffSettings: BackoffSettings,
-    shouldRetryFn?: ShouldRetryFnType
-  ) {
-    this.retryCodes = retryCodes;
-    this.backoffSettings = backoffSettings;
-    this.shouldRetryFn = shouldRetryFn;
-  }
 }
 
 export interface RetryRequestOptions {

--- a/src/normalCalls/retries.ts
+++ b/src/normalCalls/retries.ts
@@ -107,7 +107,11 @@ export function retryable(
           return;
         }
         canceller = null;
-        if (retry.retryCodes.indexOf(err!.code!) < 0) {
+        if (
+          (!retry.retryCodes || retry.retryCodes.indexOf(err!.code!) < 0) &&
+          (!retry.shouldRetryFn ||
+            !retry.shouldRetryFn(err!, response, rawResponse))
+        ) {
           err.note =
             'Exception occurred in retry method that was ' +
             'not classified as transient';

--- a/test/unit/apiCallable.ts
+++ b/test/unit/apiCallable.ts
@@ -627,7 +627,7 @@ describe('retryable', () => {
     const spy = sinon.spy(fail);
 
     const backoff = gax.createBackoffSettings(3, 2, 24, 5, 2, 80, 2500);
-    const retryOptions = new gax.RetryOptions([FAKE_STATUS_CODE_1], backoff);
+    const retryOptions = gax.createRetryOptions([FAKE_STATUS_CODE_1], backoff);
     const apiCall = createApiCall(spy, {
       settings: {timeout: 0, retry: retryOptions},
     });


### PR DESCRIPTION
It adds shouldRetryFn option to normal calls that could be used to
specify custom retry logic based on response.
This way retry is not limited to be only decided based on error codes.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-node-core#377 🦕
