### PR TITLE
feat: cache loaded protos

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -85,6 +85,9 @@ export class GrpcClient {
     filename: string | string[],
     options: grpcProtoLoader.Options
   ) {
+    if (!filename) {
+      return undefined;
+    }
     return JSON.stringify(filename) + ' ' + JSON.stringify(options);
   }
 
@@ -166,11 +169,13 @@ export class GrpcClient {
     ignoreCache = false
   ) {
     const cacheKey = GrpcClient.protoCacheKey(filename, options);
-    let grpcPackage = GrpcClient.protoCache.get(cacheKey);
+    let grpcPackage = cacheKey ? GrpcClient.protoCache.get(cacheKey) : undefined;
     if (ignoreCache || !grpcPackage) {
       const packageDef = grpcProtoLoader.loadSync(filename, options);
       grpcPackage = this.grpc.loadPackageDefinition(packageDef);
-      GrpcClient.protoCache.set(cacheKey, grpcPackage);
+      if (cacheKey) {
+        GrpcClient.protoCache.set(cacheKey, grpcPackage);
+      }
     }
     return grpcPackage;
   }

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -90,7 +90,10 @@ export class GrpcClient {
     filename: string | string[],
     options: grpcProtoLoader.Options
   ) {
-    if (!filename) {
+    if (
+      !filename ||
+      (Array.isArray(filename) && (filename.length === 0 || !filename[0]))
+    ) {
       return undefined;
     }
     return JSON.stringify(filename) + ' ' + JSON.stringify(options);

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -178,7 +178,9 @@ export class GrpcClient {
     ignoreCache = false
   ) {
     const cacheKey = GrpcClient.protoCacheKey(filename, options);
-    let grpcPackage = cacheKey ? GrpcClient.protoCache.get(cacheKey) : undefined;
+    let grpcPackage = cacheKey
+      ? GrpcClient.protoCache.get(cacheKey)
+      : undefined;
     if (ignoreCache || !grpcPackage) {
       const packageDef = grpcProtoLoader.loadSync(filename, options);
       grpcPackage = this.grpc.loadPackageDefinition(packageDef);

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -79,7 +79,12 @@ export class GrpcClient {
   private static protoCache = new Map<string, grpc.GrpcObject>();
 
   /**
-   * Key for proto cache map
+   * Key for proto cache map. We are doing our best to make sure we respect
+   * the options, so if the same proto file is loaded with different set of
+   * options, the cache won't be used.  Since some of the options are
+   * Functions (e.g. `enums: String` - see below in `loadProto()`),
+   * they will be omitted from the cache key.  If the cache breaks anything
+   * for you, use the `ignoreCache` parameter of `loadProto()` to disable it.
    */
   private static protoCacheKey(
     filename: string | string[],
@@ -159,9 +164,13 @@ export class GrpcClient {
 
   /**
    * Loads the gRPC service from the proto file(s) at the given path and with the
-   * given options.
+   * given options. Caches the loaded protos so the subsequent loads don't do
+   * any disk reads.
    * @param filename The path to the proto file(s).
    * @param options Options for loading the proto file.
+   * @param ignoreCache Defaults to `false`. Set it to `true` if the caching logic
+   *   incorrectly decides that the options object is the same, or if you want to
+   *   re-read the protos from disk for any other reason.
    */
   loadFromProto(
     filename: string | string[],
@@ -181,11 +190,15 @@ export class GrpcClient {
   }
 
   /**
-   * Load grpc proto service from a filename hooking in googleapis common protos
-   * when necessary.
+   * Load gRPC proto service from a filename looking in googleapis common protos
+   * when necessary. Caches the loaded protos so the subsequent loads don't do
+   * any disk reads.
    * @param {String} protoPath - The directory to search for the protofile.
    * @param {String|String[]} filename - The filename(s) of the proto(s) to be loaded.
    *   If omitted, protoPath will be treated as a file path to load.
+   * @param ignoreCache Defaults to `false`. Set it to `true` if the caching logic
+   *   incorrectly decides that the options object is the same, or if you want to
+   *   re-read the protos from disk for any other reason.
    * @return {Object<string, *>} The gRPC loaded result (the toplevel namespace
    *   object).
    */

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -352,6 +352,40 @@ describe('grpc', () => {
         grpcClient.loadProto.bind(null, nonExistentDir, nonExistentFile)
       );
     });
+
+    it('should cache the loaded proto', () => {
+      const proto1 = grpcClient.loadProto(TEST_PATH, TEST_FILE);
+      const proto2 = grpcClient.loadProto(TEST_PATH, TEST_FILE);
+      assert.strictEqual(proto1, proto2);
+    });
+
+    it('should not take proto from cache if parameters differ', () => {
+      const iamService = path.join('google', 'iam', 'v1', 'iam_policy.proto');
+      const proto1 = grpcClient.loadProto(TEST_PATH, TEST_FILE);
+      const proto2 = grpcClient.loadProto(TEST_PATH, iamService);
+      assert.notStrictEqual(proto1, proto2);
+    });
+
+    it('should ignore cache if asked', () => {
+      const proto1 = grpcClient.loadProto(
+        TEST_PATH,
+        TEST_FILE,
+        /*ignoreCache:*/ true
+      );
+      const proto2 = grpcClient.loadProto(
+        TEST_PATH,
+        TEST_FILE,
+        /*ignoreCache:*/ true
+      );
+      assert.notStrictEqual(proto1, proto2);
+    });
+
+    it('should clear the proto cache if asked', () => {
+      const proto1 = grpcClient.loadProto(TEST_PATH, TEST_FILE);
+      GrpcClient.clearProtoCache();
+      const proto2 = grpcClient.loadProto(TEST_PATH, TEST_FILE);
+      assert.notStrictEqual(proto1, proto2);
+    });
   });
 
   describe('GoogleProtoFilesRoot', () => {


### PR DESCRIPTION
@aohren requested this for Ads client libraries, I think it will also benefit other libraries that have huge proto JSONs.

Let's cache the loaded gRPC proto package and reuse it later (if a user creates another instance of the client).

At this point, this will only work for gRPC clients (fallback or REGAPIC don't go through this code).