### PR TITLE
fix: import long in the proto .d.ts files

### DIFF
--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as Long from 'long';
 import * as $protobuf from "protobufjs";
 /** Namespace google. */

--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -1,3 +1,4 @@
+import * as Long from 'long';
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as Long from 'long';
 import * as $protobuf from "protobufjs";
 /** Namespace google. */

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -1,3 +1,4 @@
+import * as Long from 'long';
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#376. It works for us because we exclude `node_modules` in `tsconfig.json` across all our libraries.