### PR TITLE
fix(compileProtos): mention library protos before common protos

### DIFF
--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -236,9 +236,9 @@ async function compileProtos(
     '--target',
     'json',
     '-p',
-    path.join(__dirname, '..', '..', 'protos'),
-    '-p',
     'protos',
+    '-p',
+    path.join(__dirname, '..', '..', 'protos'),
     '-o',
     jsonOutput,
   ];
@@ -253,9 +253,9 @@ async function compileProtos(
     '--target',
     'static-module',
     '-p',
-    path.join(__dirname, '..', '..', 'protos'),
-    '-p',
     'protos',
+    '-p',
+    path.join(__dirname, '..', '..', 'protos'),
     '-o',
     jsOutput,
   ];


### PR DESCRIPTION
This one is weird. The order of proto file lookup, both in `protoc` and in `pbjs`, depends on the order of folders listed in their `-I` / `-p` options (correspondingly). Apparently, in `compileProtos` script, we first listed the common protos from Gax, and then listed the library protos. Apparently, this does not always work.

Fails:

```
$ npx pbjs --target json -p ./node_modules/google-gax/protos -p protos -o protos/protos.json proto
s/google/api/servicecontrol/v1/*.proto
no such Type or Enum 'google.logging.type.LogSeverity' in Type .google.api.servicecontrol.v1.LogEntry
```

Works:
```
$ npx pbjs --target json -p protos -p ./node_modules/google-gax/protos -o protos/protos.json proto
s/google/api/servicecontrol/v1/*.proto
```

(the two commands differ only in the order of `-p` options passed)

I cannot fully explain the failure at this moment, and it might as well be a bug in `pbjs`, but at least I know how to workaround it by switching an order, and I believe the new order makes more sense (since we should always prioritize the proto file from the API over the common proto file).