### PR TITLE
fix: fallback can now be a string

### DIFF
--- a/src/clientInterface.ts
+++ b/src/clientInterface.ts
@@ -35,7 +35,7 @@ export interface ClientOptions
   libName?: string;
   libVersion?: string;
   clientConfig?: gax.ClientConfig;
-  fallback?: boolean;
+  fallback?: boolean | 'rest' | 'proto';
   apiEndpoint?: string;
 }
 

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -75,7 +75,7 @@ export class GrpcClient {
   auth: GoogleAuth;
   grpc: GrpcModule;
   grpcVersion: string;
-  fallback: boolean;
+  fallback: boolean | 'rest' | 'proto';
   private static protoCache = new Map<string, grpc.GrpcObject>();
 
   /**


### PR DESCRIPTION
In #939, I made the `fallback` parameter accept `rest` or `proto` (depending on fallback type to use: proto over HTTP or REGAPIC), but forgot to change it in other places to make two implementations of `GrpcClient` compatible. Fixing that now.