### PR TITLE
fix: load LRO proto JSON using require

### DIFF
--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -16,7 +16,6 @@
 
 import {GoogleAuth, OAuth2Client} from 'google-auth-library';
 import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
-import * as path from 'path';
 import {ClientOptions, Callback} from './clientInterface';
 
 import {GaxCall, ResultTuple, RequestType} from './apitypes';
@@ -29,6 +28,7 @@ import * as protos from '../protos/operations';
 import configData = require('./operations_client_config.json');
 import {Transform} from 'stream';
 import {CancellablePromise} from './call';
+import protoJson = require('../protos/operations.json');
 
 export const SERVICE_ADDRESS = 'longrunning.googleapis.com';
 const version = require('../../package.json').version;
@@ -563,17 +563,7 @@ export class OperationsClientBuilder {
    */
   constructor(gaxGrpc: GrpcClient | FallbackGrpcClient) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let operationsProtos: any; // loaded protos have any type
-    if (gaxGrpc.fallback) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const protoJson = require('../../protos/operations.json');
-      operationsProtos = gaxGrpc.loadProto(protoJson);
-    } else {
-      operationsProtos = gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos', 'operations.json')
-      );
-      Object.assign(this, operationsProtos.google.longrunning);
-    }
+    const operationsProtos = gaxGrpc.loadProtoJSON(protoJson);
 
     /**
      * Build a new instance of {@link OperationsClient}.


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-translate/issues/663.

There is one more place where we loaded the protos using `fs` - this is for LRO client in gax. Replacing it with `require` as well.