### PR TITLE
fix(diregapic): rest transport enum value display incorectly

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -323,7 +323,19 @@ export class GrpcClient {
       ) => {
         const [method, requestData, serviceCallback] = serviceStub[
           methodName
-        ].apply(serviceStub, [req, callback]);
+        ].apply(serviceStub, [
+          req,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (err: any, response: any) => {
+            if (!err) {
+              // converts a protobuf message instance to a plain JavaScript object with enum conversion options specified
+              response = method.resolvedResponseType.toObject(response, {
+                enums: String,
+              });
+            }
+            callback(err, response);
+          },
+        ]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let cancelController: AbortController, cancelSignal: any;
         if (isBrowser() || typeof AbortController !== 'undefined') {

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -325,8 +325,7 @@ export class GrpcClient {
           methodName
         ].apply(serviceStub, [
           req,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (err: any, response: any) => {
+          (err: Error | null, response: {}) => {
             if (!err) {
               // converts a protobuf message instance to a plain JavaScript object with enum conversion options specified
               response = method.resolvedResponseType.toObject(response, {

--- a/test/fixtures/google/example/library/v1/library.proto
+++ b/test/fixtures/google/example/library/v1/library.proto
@@ -28,7 +28,6 @@ option java_multiple_files = true;
 option java_outer_classname = "LibraryProto";
 option java_package = "com.google.example.library.v1";
 
-
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
 // resource model:
@@ -132,6 +131,9 @@ message Shelf {
 
   // The theme of the shelf
   string theme = 2;
+
+  // The enum type of the shelf.
+  ShelfType type = 3;
 }
 
 // Request message for LibraryService.CreateShelf.
@@ -255,4 +257,11 @@ message MoveBookRequest {
 
   // The name of the destination shelf.
   string other_shelf_name = 2;
+}
+
+// Enum value for shelf type.
+enum ShelfType {
+  TYPEONE = 1;
+
+  TYPETWO = 2;
 }

--- a/test/fixtures/library.json
+++ b/test/fixtures/library.json
@@ -211,6 +211,10 @@
                         "theme": {
                           "type": "string",
                           "id": 2
+                        },
+                        "type": {
+                          "type": "ShelfType",
+                          "id": 3
                         }
                       }
                     },
@@ -355,6 +359,12 @@
                           "id": 2
                         }
                       }
+                    },
+                    "ShelfType": {
+                      "values": {
+                        "TYPEONE": 1,
+                        "TYPETWO": 2
+                      }
                     }
                   }
                 }
@@ -363,14 +373,6 @@
           }
         },
         "api": {
-          "options": {
-            "go_package": "google.golang.org/genproto/googleapis/api/annotations;annotations",
-            "java_multiple_files": true,
-            "java_outer_classname": "HttpProto",
-            "java_package": "com.google.api",
-            "objc_class_prefix": "GAPI",
-            "cc_enable_arenas": true
-          },
           "nested": {
             "http": {
               "type": "HttpRule",
@@ -383,10 +385,6 @@
                   "rule": "repeated",
                   "type": "HttpRule",
                   "id": 1
-                },
-                "fullyDecodeReservedExpansion": {
-                  "type": "bool",
-                  "id": 2
                 }
               }
             },
@@ -404,10 +402,6 @@
                 }
               },
               "fields": {
-                "selector": {
-                  "type": "string",
-                  "id": 1
-                },
                 "get": {
                   "type": "string",
                   "id": 2
@@ -432,13 +426,13 @@
                   "type": "CustomHttpPattern",
                   "id": 8
                 },
+                "selector": {
+                  "type": "string",
+                  "id": 1
+                },
                 "body": {
                   "type": "string",
                   "id": 7
-                },
-                "responseBody": {
-                  "type": "string",
-                  "id": 12
                 },
                 "additionalBindings": {
                   "rule": "repeated",
@@ -462,15 +456,6 @@
           }
         },
         "protobuf": {
-          "options": {
-            "go_package": "google.golang.org/protobuf/types/descriptorpb",
-            "java_package": "com.google.protobuf",
-            "java_outer_classname": "DescriptorProtos",
-            "csharp_namespace": "Google.Protobuf.Reflection",
-            "objc_class_prefix": "GPB",
-            "cc_enable_arenas": true,
-            "optimize_for": "SPEED"
-          },
           "nested": {
             "FileDescriptorSet": {
               "fields": {
@@ -607,10 +592,6 @@
                     "end": {
                       "type": "int32",
                       "id": 2
-                    },
-                    "options": {
-                      "type": "ExtensionRangeOptions",
-                      "id": 3
                     }
                   }
                 },
@@ -627,21 +608,6 @@
                   }
                 }
               }
-            },
-            "ExtensionRangeOptions": {
-              "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
             },
             "FieldDescriptorProto": {
               "fields": {
@@ -684,10 +650,6 @@
                 "options": {
                   "type": "FieldOptions",
                   "id": 8
-                },
-                "proto3Optional": {
-                  "type": "bool",
-                  "id": 17
                 }
               },
               "nested": {
@@ -748,30 +710,6 @@
                 "options": {
                   "type": "EnumOptions",
                   "id": 3
-                },
-                "reservedRange": {
-                  "rule": "repeated",
-                  "type": "EnumReservedRange",
-                  "id": 4
-                },
-                "reservedName": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 5
-                }
-              },
-              "nested": {
-                "EnumReservedRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    }
-                  }
                 }
               }
             },
@@ -828,17 +766,11 @@
                 },
                 "clientStreaming": {
                   "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 5
                 },
                 "serverStreaming": {
                   "type": "bool",
-                  "id": 6,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 6
                 }
               }
             },
@@ -854,10 +786,7 @@
                 },
                 "javaMultipleFiles": {
                   "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 10
                 },
                 "javaGenerateEqualsAndHash": {
                   "type": "bool",
@@ -868,10 +797,7 @@
                 },
                 "javaStringCheckUtf8": {
                   "type": "bool",
-                  "id": 27,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 27
                 },
                 "optimizeFor": {
                   "type": "OptimizeMode",
@@ -886,45 +812,23 @@
                 },
                 "ccGenericServices": {
                   "type": "bool",
-                  "id": 16,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 16
                 },
                 "javaGenericServices": {
                   "type": "bool",
-                  "id": 17,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 17
                 },
                 "pyGenericServices": {
                   "type": "bool",
-                  "id": 18,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "phpGenericServices": {
-                  "type": "bool",
-                  "id": 42,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 18
                 },
                 "deprecated": {
                   "type": "bool",
-                  "id": 23,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 23
                 },
                 "ccEnableArenas": {
                   "type": "bool",
-                  "id": 31,
-                  "options": {
-                    "default": true
-                  }
+                  "id": 31
                 },
                 "objcClassPrefix": {
                   "type": "string",
@@ -933,26 +837,6 @@
                 "csharpNamespace": {
                   "type": "string",
                   "id": 37
-                },
-                "swiftPrefix": {
-                  "type": "string",
-                  "id": 39
-                },
-                "phpClassPrefix": {
-                  "type": "string",
-                  "id": 40
-                },
-                "phpNamespace": {
-                  "type": "string",
-                  "id": 41
-                },
-                "phpMetadataNamespace": {
-                  "type": "string",
-                  "id": 44
-                },
-                "rubyPackage": {
-                  "type": "string",
-                  "id": 45
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -986,24 +870,15 @@
               "fields": {
                 "messageSetWireFormat": {
                   "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 1
                 },
                 "noStandardDescriptorAccessor": {
                   "type": "bool",
-                  "id": 2,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 2
                 },
                 "deprecated": {
                   "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 3
                 },
                 "mapEntry": {
                   "type": "bool",
@@ -1025,10 +900,6 @@
                 [
                   8,
                   8
-                ],
-                [
-                  9,
-                  9
                 ]
               ]
             },
@@ -1054,24 +925,15 @@
                 },
                 "lazy": {
                   "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 5
                 },
                 "deprecated": {
                   "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 3
                 },
                 "weak": {
                   "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 10
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -1131,10 +993,7 @@
                 },
                 "deprecated": {
                   "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 3
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -1147,22 +1006,13 @@
                   1000,
                   536870911
                 ]
-              ],
-              "reserved": [
-                [
-                  5,
-                  5
-                ]
               ]
             },
             "EnumValueOptions": {
               "fields": {
                 "deprecated": {
                   "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 1
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -1181,10 +1031,7 @@
               "fields": {
                 "deprecated": {
                   "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
+                  "id": 33
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -1203,17 +1050,7 @@
               "fields": {
                 "deprecated": {
                   "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "idempotencyLevel": {
-                  "type": "IdempotencyLevel",
-                  "id": 34,
-                  "options": {
-                    "default": "IDEMPOTENCY_UNKNOWN"
-                  }
+                  "id": 33
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -1226,16 +1063,7 @@
                   1000,
                   536870911
                 ]
-              ],
-              "nested": {
-                "IdempotencyLevel": {
-                  "values": {
-                    "IDEMPOTENCY_UNKNOWN": 0,
-                    "NO_SIDE_EFFECTS": 1,
-                    "IDEMPOTENT": 2
-                  }
-                }
-              }
+              ]
             },
             "UninterpretedOption": {
               "fields": {

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -21,6 +21,7 @@ import * as assert from 'assert';
 import {describe, it, afterEach, before} from 'mocha';
 import * as nodeFetch from 'node-fetch';
 import * as protobuf from 'protobufjs';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {GrpcClient} from '../../src/fallback';
@@ -49,7 +50,9 @@ const opts = {
 describe('regapic', () => {
   let gaxGrpc: GrpcClient,
     protos: protobuf.NamespaceBase,
+    libProtos: protobuf.NamespaceBase,
     echoService: protobuf.Service,
+    libraryService: protobuf.Service,
     stubOptions: {};
 
   before(() => {
@@ -61,6 +64,17 @@ describe('regapic', () => {
     gaxGrpc = new GrpcClient(opts);
     protos = gaxGrpc.loadProto(echoProtoJson);
     echoService = protos.lookupService('Echo');
+    const TEST_JSON = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'test',
+      'fixtures',
+      'library.json'
+    );
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    libProtos = gaxGrpc.loadProtoJSON(require(TEST_JSON));
+    libraryService = libProtos.lookupService('LibraryService');
     stubOptions = {
       servicePath: 'foo.example.com',
       port: 443,
@@ -90,6 +104,39 @@ describe('regapic', () => {
         assert.strictEqual(requestObject.content, result.content);
         done();
       });
+    });
+  });
+
+  it('should support enum conversion in proto message response', done => {
+    const requestObject = {name: 'shelves/shelf-name'};
+    const responseObject = {
+      name: 'shelf-name',
+      theme: 'shelf-theme',
+      type: 1,
+    };
+    // incomplete types for nodeFetch, so...
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sinon.stub(nodeFetch, 'Promise' as any).returns(
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: () => {
+          return Promise.resolve(Buffer.from(JSON.stringify(responseObject)));
+        },
+      })
+    );
+
+    gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
+      libStub.getShelf(
+        requestObject,
+        {},
+        {},
+        (err: {}, result: {name: {}; theme: {}; type: {}}) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual('shelf-name', result.name);
+          assert.strictEqual('TYPEONE', result.type);
+          done();
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
GCE GAPIC TypeScript [issue](https://github.com/googleapis/gapic-generator-typescript/issues/885)

Convert protobuf message to Javascript object with enum conversion option.
`Message.toObject(message: Message [, options: ConversionOptions]): Object` ([source](https://github.com/protobufjs/protobuf.js#toolset))