### PR TITLE
fix(diregapic): support int64 conversion between the pf message and JSON object

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -133,7 +133,7 @@ export class GrpcClient {
       if (!options.auth) {
         throw new Error(
           JSON.stringify(options) +
-            'You need to pass auth instance to use gRPC-fallback client in browser. Use OAuth2Client from google-auth-library.'
+          'You need to pass auth instance to use gRPC-fallback client in browser. Use OAuth2Client from google-auth-library.'
         );
       }
       this.auth = options.auth as OAuth2Client;
@@ -279,9 +279,9 @@ export class GrpcClient {
       method:
         | protobuf.Method
         | protobuf.rpc.ServiceMethod<
-            protobuf.Message<{}>,
-            protobuf.Message<{}>
-          >,
+          protobuf.Message<{}>,
+          protobuf.Message<{}>
+        >,
       requestData: Uint8Array,
       callback: protobuf.RPCImplCallback
     ) {
@@ -435,7 +435,7 @@ export class GrpcClient {
 
         const fetch = isBrowser()
           ? // eslint-disable-next-line no-undef
-            window.fetch
+          window.fetch
           : (nodeFetch as unknown as NodeFetchType);
         const fetchRequest = {
           headers,

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -403,6 +403,7 @@ export class GrpcClient {
             // TODO: use toJSON instead of toObject
             decodedRequest,
             {
+              enums: String,
               longs: String,
             }
           );

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -133,7 +133,7 @@ export class GrpcClient {
       if (!options.auth) {
         throw new Error(
           JSON.stringify(options) +
-          'You need to pass auth instance to use gRPC-fallback client in browser. Use OAuth2Client from google-auth-library.'
+            'You need to pass auth instance to use gRPC-fallback client in browser. Use OAuth2Client from google-auth-library.'
         );
       }
       this.auth = options.auth as OAuth2Client;
@@ -279,9 +279,9 @@ export class GrpcClient {
       method:
         | protobuf.Method
         | protobuf.rpc.ServiceMethod<
-          protobuf.Message<{}>,
-          protobuf.Message<{}>
-        >,
+            protobuf.Message<{}>,
+            protobuf.Message<{}>
+          >,
       requestData: Uint8Array,
       callback: protobuf.RPCImplCallback
     ) {
@@ -435,7 +435,7 @@ export class GrpcClient {
 
         const fetch = isBrowser()
           ? // eslint-disable-next-line no-undef
-          window.fetch
+            window.fetch
           : (nodeFetch as unknown as NodeFetchType);
         const fetchRequest = {
           headers,

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -168,14 +168,15 @@ export class GrpcClient {
     return root;
   }
 
-  private getServiceMethods(service: protobuf.Service) {
-    const methods = Object.keys(service.methods);
+  private static getServiceMethods(service: protobuf.Service) {
+    const methods: {[name: string]: protobuf.Method} = {};
+    for (const [methodName, methodObject] of Object.entries(service.methods)) {
+      const methodNameLowerCamelCase =
+        methodName[0].toLowerCase() + methodName.substring(1);
+      methods[methodNameLowerCamelCase] = methodObject;
+    }
 
-    const methodsLowerCamelCase = methods.map(method => {
-      return method[0].toLowerCase() + method.substring(1);
-    });
-
-    return methodsLowerCamelCase;
+    return methods;
   }
 
   /**
@@ -285,7 +286,7 @@ export class GrpcClient {
       requestData: Uint8Array,
       callback: protobuf.RPCImplCallback
     ) {
-      return [method, requestData, callback];
+      return [requestData, callback];
     }
 
     // decoder for google.rpc.Status messages
@@ -307,35 +308,44 @@ export class GrpcClient {
       false,
       false
     ) as unknown as FallbackServiceStub;
-    const methods = this.getServiceMethods(service);
 
-    const newServiceStub = service.create(
+    const methods = GrpcClient.getServiceMethods(service);
+
+    // grpcCompatibleServiceStub methods accept four parameters:
+    // request, options, metadata, and callback - similar to
+    // the stub returned by grpc.ts
+    const grpcCompatibleServiceStub = service.create(
       serviceClientImpl,
       false,
       false
     ) as unknown as FallbackServiceStub;
-    for (const methodName of methods) {
-      newServiceStub[methodName] = (
+    for (const [methodName, methodObject] of Object.entries(methods)) {
+      grpcCompatibleServiceStub[methodName] = (
         req: {},
         options: {[name: string]: string},
         metadata: {},
         callback: Function
       ) => {
-        const [method, requestData, serviceCallback] = serviceStub[
-          methodName
-        ].apply(serviceStub, [
-          req,
-          (err: Error | null, response: {}) => {
-            if (!err) {
-              // converts a protobuf message instance to a plain JavaScript object with enum, longs conversion options specified
-              response = method.resolvedResponseType.toObject(response, {
-                enums: String,
-                longs: String,
-              });
-            }
-            callback(err, response);
-          },
-        ]);
+        const [requestData, serviceCallback] = serviceStub[methodName].apply(
+          serviceStub,
+          [
+            methodObject.resolvedRequestType!.fromObject(req),
+            (err: Error | null, response: protobuf.Message<{}>) => {
+              if (!err) {
+                // converts a protobuf message instance to a plain JavaScript object
+                // with enum and long conversion options specified
+                const responseObject =
+                  methodObject.resolvedResponseType!.toObject(response, {
+                    enums: String,
+                    longs: String,
+                  });
+                callback(null, responseObject);
+              } else {
+                callback(err);
+              }
+            },
+          ]
+        );
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let cancelController: AbortController, cancelSignal: any;
         if (isBrowser() || typeof AbortController !== 'undefined') {
@@ -381,13 +391,13 @@ export class GrpcClient {
         }
 
         const protoNamespaces: string[] = [];
-        let currNamespace = method.parent;
+        let currNamespace = methodObject.parent!;
         while (currNamespace.name !== '') {
           protoNamespaces.unshift(currNamespace.name);
-          currNamespace = currNamespace.parent;
+          currNamespace = currNamespace.parent!;
         }
         const protoServiceName = protoNamespaces.join('.');
-        const rpcName = method.name;
+        const rpcName = methodObject.name;
 
         let url: string;
         let data: string;
@@ -398,8 +408,9 @@ export class GrpcClient {
         if (this.fallback === 'rest') {
           // REGAPIC: JSON over HTTP/1 with gRPC trancoding
           headers['Content-Type'] = 'application/json';
-          const decodedRequest = method.resolvedRequestType.decode(requestData);
-          const requestJSON = method.resolvedRequestType.toObject(
+          const decodedRequest =
+            methodObject.resolvedRequestType!.decode(requestData);
+          const requestJSON = methodObject.resolvedRequestType!.toObject(
             // TODO: use toJSON instead of toObject
             decodedRequest,
             {
@@ -409,14 +420,14 @@ export class GrpcClient {
           );
           const transcoded = transcode(
             requestJSON,
-            method.parsedOptions,
-            method.resolvedRequestType.fields
+            methodObject.parsedOptions,
+            methodObject.resolvedRequestType!.fields
           );
           if (!transcoded) {
             throw new Error(
               `Cannot build HTTP request for ${JSON.stringify(
                 requestJSON
-              )}, method: ${method.name}`
+              )}, method: ${methodObject.name}`
             );
           }
           httpMethod = transcoded.httpMethod;
@@ -472,9 +483,10 @@ export class GrpcClient {
                 );
                 throw error;
               }
-              const message = method.resolvedResponseType.fromObject(response);
-              const encoded = method.resolvedResponseType
-                .encode(message)
+              const message =
+                methodObject.resolvedResponseType!.fromObject(response);
+              const encoded = methodObject
+                .resolvedResponseType!.encode(message)
                 .finish();
               serviceCallback(null, encoded);
             } else {
@@ -506,7 +518,7 @@ export class GrpcClient {
         };
       };
     }
-    return newServiceStub;
+    return grpcCompatibleServiceStub;
   }
 }
 

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -327,9 +327,10 @@ export class GrpcClient {
           req,
           (err: Error | null, response: {}) => {
             if (!err) {
-              // converts a protobuf message instance to a plain JavaScript object with enum conversion options specified
+              // converts a protobuf message instance to a plain JavaScript object with enum, longs conversion options specified
               response = method.resolvedResponseType.toObject(response, {
                 enums: String,
+                longs: String,
               });
             }
             callback(err, response);
@@ -400,7 +401,10 @@ export class GrpcClient {
           const decodedRequest = method.resolvedRequestType.decode(requestData);
           const requestJSON = method.resolvedRequestType.toObject(
             // TODO: use toJSON instead of toObject
-            decodedRequest
+            decodedRequest,
+            {
+              longs: String,
+            }
           );
           const transcoded = transcode(
             requestJSON,

--- a/test/fixtures/google/example/library/v1/library.proto
+++ b/test/fixtures/google/example/library/v1/library.proto
@@ -77,7 +77,12 @@ service LibraryService {
 
   // Gets a book. Returns NOT_FOUND if the book does not exist.
   rpc GetBook(GetBookRequest) returns (Book) {
-    option (google.api.http) = { get: "/v1/{name=shelves/*/books/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=shelves/*/books/*}"
+      additional_bindings {
+        get: "/v1/{name=shelves/*/book_id/*}"
+      }
+     };
   }
 
   // Lists books in a shelf. The order is unspecified but deterministic. Newly
@@ -120,6 +125,9 @@ message Book {
 
   // Value indicating whether the book has been read.
   bool read = 4;
+
+  // The id of the book.
+  int64 book_id = 5;
 }
 
 // A Shelf contains a collection of books with a theme.
@@ -203,6 +211,9 @@ message CreateBookRequest {
 message GetBookRequest {
   // The name of the book to retrieve.
   string name = 1;
+
+  // The the id of the book.
+  string book_id = 2;
 }
 
 // Request message for LibraryService.ListBooks.

--- a/test/fixtures/google/example/library/v1/library.proto
+++ b/test/fixtures/google/example/library/v1/library.proto
@@ -77,12 +77,7 @@ service LibraryService {
 
   // Gets a book. Returns NOT_FOUND if the book does not exist.
   rpc GetBook(GetBookRequest) returns (Book) {
-    option (google.api.http) = {
-      get: "/v1/{name=shelves/*/books/*}"
-      additional_bindings {
-        get: "/v1/{name=shelves/*/book_id/*}"
-      }
-     };
+    option (google.api.http) = { get: "/v1/{name=shelves/*/books/*}" };
   }
 
   // Lists books in a shelf. The order is unspecified but deterministic. Newly

--- a/test/fixtures/google/example/library/v1/library.proto
+++ b/test/fixtures/google/example/library/v1/library.proto
@@ -77,7 +77,12 @@ service LibraryService {
 
   // Gets a book. Returns NOT_FOUND if the book does not exist.
   rpc GetBook(GetBookRequest) returns (Book) {
-    option (google.api.http) = { get: "/v1/{name=shelves/*/books/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=shelves/*/books/*}"
+      additional_bindings: {
+        get: "/v1/{name=shelves/*/book_id/*}"
+      }
+    };
   }
 
   // Lists books in a shelf. The order is unspecified but deterministic. Newly
@@ -208,7 +213,7 @@ message GetBookRequest {
   string name = 1;
 
   // The the id of the book.
-  string book_id = 2;
+  int64 book_id = 2;
 }
 
 // Request message for LibraryService.ListBooks.

--- a/test/fixtures/library.json
+++ b/test/fixtures/library.json
@@ -110,16 +110,12 @@
                           "requestType": "GetBookRequest",
                           "responseType": "Book",
                           "options": {
-                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}",
-                            "(google.api.http).additional_bindings.get": "/v1/{name=shelves/*/book_id/*}"
+                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}"
                           },
                           "parsedOptions": [
                             {
                               "(google.api.http)": {
-                                "get": "/v1/{name=shelves/*/books/*}",
-                                "additional_bindings": {
-                                  "get": "/v1/{name=shelves/*/book_id/*}"
-                                }
+                                "get": "/v1/{name=shelves/*/books/*}"
                               }
                             }
                           ]

--- a/test/fixtures/library.json
+++ b/test/fixtures/library.json
@@ -110,12 +110,16 @@
                           "requestType": "GetBookRequest",
                           "responseType": "Book",
                           "options": {
-                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}"
+                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}",
+                            "(google.api.http).additional_bindings.get": "/v1/{name=shelves/*/book_id/*}"
                           },
                           "parsedOptions": [
                             {
                               "(google.api.http)": {
-                                "get": "/v1/{name=shelves/*/books/*}"
+                                "get": "/v1/{name=shelves/*/books/*}",
+                                "additional_bindings": {
+                                  "get": "/v1/{name=shelves/*/book_id/*}"
+                                }
                               }
                             }
                           ]
@@ -199,6 +203,10 @@
                         "read": {
                           "type": "bool",
                           "id": 4
+                        },
+                        "bookId": {
+                          "type": "int64",
+                          "id": 5
                         }
                       }
                     },
@@ -296,6 +304,10 @@
                         "name": {
                           "type": "string",
                           "id": 1
+                        },
+                        "bookId": {
+                          "type": "string",
+                          "id": 2
                         }
                       }
                     },

--- a/test/fixtures/library.json
+++ b/test/fixtures/library.json
@@ -110,12 +110,16 @@
                           "requestType": "GetBookRequest",
                           "responseType": "Book",
                           "options": {
-                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}"
+                            "(google.api.http).get": "/v1/{name=shelves/*/books/*}",
+                            "(google.api.http).additional_bindings.get": "/v1/{name=shelves/*/book_id/*}"
                           },
                           "parsedOptions": [
                             {
                               "(google.api.http)": {
-                                "get": "/v1/{name=shelves/*/books/*}"
+                                "get": "/v1/{name=shelves/*/books/*}",
+                                "additional_bindings": {
+                                  "get": "/v1/{name=shelves/*/book_id/*}"
+                                }
                               }
                             }
                           ]
@@ -302,7 +306,7 @@
                           "id": 1
                         },
                         "bookId": {
-                          "type": "string",
+                          "type": "int64",
                           "id": 2
                         }
                       }

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -139,4 +139,80 @@ describe('regapic', () => {
       );
     });
   });
+
+  describe('should support long data type conversion in proto message', () => {
+    it('large number long data type conversion in proto message response', done => {
+      const requestObject = {name: 'shelves/shelf-name/books/book-name'};
+      const responseObject = {
+        name: 'book-name',
+        author: 'book-author',
+        title: 'book-title',
+        read: true,
+        bookId: '9007199254740992',
+      };
+      // incomplete types for nodeFetch, so...
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sinon.stub(nodeFetch, 'Promise' as any).returns(
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => {
+            return Promise.resolve(Buffer.from(JSON.stringify(responseObject)));
+          },
+        })
+      );
+      gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
+        libStub.getBook(
+          requestObject,
+          {},
+          {},
+          (
+            err: {},
+            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
+          ) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual('book-name', result.name);
+            assert.strictEqual('9007199254740992', result.bookId);
+            done();
+          }
+        );
+      });
+    });
+
+    it('small number long data type conversion in proto message response', done => {
+      const requestObject = {name: 'shelves/shelf-name/books/book-name'};
+      const responseObject = {
+        name: 'book-name',
+        author: 'book-author',
+        title: 'book-title',
+        read: true,
+        bookId: '42',
+      };
+      // incomplete types for nodeFetch, so...
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sinon.stub(nodeFetch, 'Promise' as any).returns(
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => {
+            return Promise.resolve(Buffer.from(JSON.stringify(responseObject)));
+          },
+        })
+      );
+      gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
+        libStub.getBook(
+          requestObject,
+          {},
+          {},
+          (
+            err: {},
+            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
+          ) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual('book-name', result.name);
+            assert.strictEqual('42', result.bookId);
+            done();
+          }
+        );
+      });
+    });
+  });
 });

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -27,6 +27,7 @@ import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {GrpcClient} from '../../src/fallback';
 import {OAuth2Client} from 'google-auth-library';
 import {GrpcClientOptions} from '../../src';
+import Long = require('long');
 
 const authClient = {
   getRequestHeaders() {
@@ -148,7 +149,7 @@ describe('regapic', () => {
         author: 'book-author',
         title: 'book-title',
         read: true,
-        bookId: '9007199254740992',
+        bookId: 9007199254740992,
       };
       // incomplete types for nodeFetch, so...
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -185,7 +186,7 @@ describe('regapic', () => {
         author: 'book-author',
         title: 'book-title',
         read: true,
-        bookId: '42',
+        bookId: 42,
       };
       // incomplete types for nodeFetch, so...
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -27,7 +27,6 @@ import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {GrpcClient} from '../../src/fallback';
 import {OAuth2Client} from 'google-auth-library';
 import {GrpcClientOptions} from '../../src';
-import Long = require('long');
 
 const authClient = {
   getRequestHeaders() {
@@ -224,7 +223,7 @@ describe('regapic', () => {
         author: 'book-author',
         title: 'book-title',
         read: true,
-        bookId: '9007199254740992',
+        bookId: bookId,
       };
       // incomplete types for nodeFetch, so...
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -247,7 +246,7 @@ describe('regapic', () => {
           ) => {
             assert.strictEqual(err, null);
             assert.strictEqual('book-name', result.name);
-            assert.strictEqual('9007199254740992', result.bookId);
+            assert.strictEqual(bookId.toString(), result.bookId);
             done();
           }
         );

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -214,5 +214,43 @@ describe('regapic', () => {
         );
       });
     });
+
+    it('long data type conversion in proto message request', done => {
+      const bookId = 9007199254740992;
+      const requestObject = {name: `shelves/shelf-name/book_id/${bookId}`};
+      const responseObject = {
+        name: 'book-name',
+        author: 'book-author',
+        title: 'book-title',
+        read: true,
+        bookId: '9007199254740992',
+      };
+      // incomplete types for nodeFetch, so...
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sinon.stub(nodeFetch, 'Promise' as any).returns(
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => {
+            return Promise.resolve(Buffer.from(JSON.stringify(responseObject)));
+          },
+        })
+      );
+      gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
+        libStub.getBook(
+          requestObject,
+          {},
+          {},
+          (
+            err: {},
+            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
+          ) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual('book-name', result.name);
+            assert.strictEqual('9007199254740992', result.bookId);
+            done();
+          }
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Similar to #1015, support int64 conversion from protobuf message to JSON object.

[protobufjs](https://github.com/protobufjs/protobuf.js)

Message.toObject(message: Message [, options: ConversionOptions]): Object
converts a message instance to an arbitrary plain JavaScript object for interoperability with other libraries or storage. The resulting plain JavaScript object might still satisfy the requirements of a valid message depending on the actual conversion options specified, but most of the time it does not.

```
var object = AwesomeMessage.toObject(message, {
  enums: String,  // enums as string names
  longs: String,  // longs as strings (requires long.js)
  bytes: String,  // bytes as base64 encoded strings
  defaults: true, // includes default values
  arrays: true,   // populates empty arrays (repeated fields) even if defaults=false
  objects: true,  // populates empty objects (map fields) even if defaults=false
  oneofs: true    // includes virtual oneof fields set to the present field's name
});
```

