### PR TITLE
fix(mtls): remove unused clientCertSource method

### DIFF
--- a/src/clientInterface.ts
+++ b/src/clientInterface.ts
@@ -37,9 +37,6 @@ export interface ClientOptions
   clientConfig?: gax.ClientConfig;
   fallback?: boolean | 'rest' | 'proto';
   apiEndpoint?: string;
-  // clientCertSource must return a tuple of cert and key, which
-  // are used to configure mTLS:
-  clientCertSource?: () => [string, string];
 }
 
 export interface Descriptors {

--- a/src/clientInterface.ts
+++ b/src/clientInterface.ts
@@ -39,7 +39,7 @@ export interface ClientOptions
   apiEndpoint?: string;
   // clientCertSource must return a tuple of cert and key, which
   // are used to configure mTLS:
-  clientCertSource?: (callback: () => [string, string]) => void;
+  clientCertSource?: () => [string, string];
 }
 
 export interface Descriptors {


### PR DESCRIPTION
It feels more idiomatic for Node.js to simply provide `cert` and `key` as parameters, let's drop `clientCertSource` for now.