### PR TITLE
feat(mtls): support for GOOGLE_API_USE_CLIENT_CERTIFICATE/GOOGLE_API_USE_MTLS_ENDPOINT

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -274,7 +274,13 @@ export class GrpcClient {
    * @param {number} opts.port - The port of the service.
    * @return {Promise} A promise which resolves to a gRPC-fallback service stub, which is a protobuf.js service stub instance modified to match the gRPC stub API
    */
-  async createStub(service: protobuf.Service, opts: ClientStubOptions) {
+  async createStub(
+    service: protobuf.Service,
+    opts: ClientStubOptions,
+    // For consistency with createStub in grpc.ts, customServicePath is defined:
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    customServicePath?: boolean
+  ) {
     // an RPC function to be passed to protobufjs RPC API
     function serviceClientImpl(
       method:

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -15,9 +15,12 @@
  */
 
 import * as grpcProtoLoader from '@grpc/proto-loader';
+import {execFile} from 'child_process';
 import * as fs from 'fs';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as grpc from '@grpc/grpc-js';
+import {homedir} from 'os';
+import {join} from 'path';
 import {OutgoingHttpHeaders} from 'http';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
@@ -47,6 +50,34 @@ export interface GrpcClientOptions extends GoogleAuthOptions {
 
 export interface MetadataValue {
   equals: Function;
+}
+
+/*
+ * Async version of readFile.
+ *
+ * @returns {Promise} Contents of file at path.
+ */
+async function readFileAsync(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, 'utf8', (err, content) => {
+      if (err) return reject(err);
+      else resolve(content);
+    });
+  });
+}
+
+/*
+ * Async version of execFile.
+ *
+ * @returns {Promise} stdout from command execution.
+ */
+async function execFileAsync(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, (err, stdout) => {
+      if (err) return reject(err);
+      else resolve(stdout);
+    });
+  });
 }
 
 export interface Metadata {
@@ -347,9 +378,14 @@ export class GrpcClient {
    * @param {number} options.port - The port of the service.
    * @param {grpcTypes.ClientCredentials=} options.sslCreds - The credentials to be used
    *   to set up gRPC connection.
+   * @param {string} defaultServicePath - The default service path.
    * @return {Promise} A promise which resolves to a gRPC stub instance.
    */
-  async createStub(CreateStub: typeof ClientStub, options: ClientStubOptions) {
+  async createStub(
+    CreateStub: typeof ClientStub,
+    options: ClientStubOptions,
+    customServicePath?: boolean
+  ) {
     // The following options are understood by grpc-gcp and need a special treatment
     // (should be passed without a `grpc.` prefix)
     const grpcGcpOptions = [
@@ -357,8 +393,16 @@ export class GrpcClient {
       'grpc.channelFactoryOverride',
       'grpc.gcpApiConfig',
     ];
-    const serviceAddress = options.servicePath + ':' + options.port;
-    const creds = await this._getCredentials(options);
+    const [cert, key] = await this._detectClientCertificate(options);
+    const servicePath = this._mtlsServicePath(
+      options.servicePath,
+      customServicePath,
+      cert,
+      key
+    );
+    const opts = Object.assign({}, options, {cert, key, servicePath});
+    const serviceAddress = servicePath + ':' + opts.port;
+    const creds = await this._getCredentials(opts);
     const grpcOptions: ClientOptions = {};
     // @grpc/grpc-js limits max receive/send message length starting from v0.8.0
     // https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%400.8.0
@@ -366,7 +410,7 @@ export class GrpcClient {
     grpcOptions['grpc.max_receive_message_length'] = -1;
     grpcOptions['grpc.max_send_message_length'] = -1;
     grpcOptions['grpc.initial_reconnect_backoff_ms'] = 1000;
-    Object.keys(options).forEach(key => {
+    Object.keys(opts).forEach(key => {
       const value = options[key];
       // the older versions had a bug which required users to call an option
       // grpc.grpc.* to make it actually pass to gRPC as grpc.*, let's handle
@@ -387,6 +431,86 @@ export class GrpcClient {
       grpcOptions as ClientOptions
     );
     return stub;
+  }
+
+  /**
+   * Detect mTLS client certificate based on logic described in
+   * https://google.aip.dev/auth/4114.
+   *
+   * @param {object} [options] - The configuration object.
+   * @returns {Promise} Resolves array of strings representing cert and key.
+   */
+  async _detectClientCertificate(opts?: ClientOptions) {
+    const certRegex =
+      /(?<cert>-----BEGIN CERTIFICATE-----[\s\S]*-----END CERTIFICATE-----)/;
+    const keyRegex =
+      /(?<key>-----BEGIN PRIVATE KEY-----[\s\S]*-----END PRIVATE KEY-----)/;
+    // If GOOGLE_API_USE_CLIENT_CERTIFICATE is true...:
+    if (
+      typeof process !== 'undefined' &&
+      process?.env?.GOOGLE_API_USE_CLIENT_CERTIFICATE === 'true'
+    ) {
+      if (opts?.cert && opts?.key) {
+        return [opts.cert, opts.key];
+      }
+      // If context aware metadata exists, run the cert provider command,
+      // parse the output to extract cert and key, and use this cert/key.
+      const metadataPath = join(
+        homedir(),
+        '.secureConnect',
+        'context_aware_metadata.json'
+      );
+      const metadata = JSON.parse(await readFileAsync(metadataPath));
+      if (!metadata.cert_provider_command) {
+        throw Error('no cert_provider_command found');
+      }
+      const stdout = await execFileAsync(
+        metadata.cert_provider_command[0],
+        metadata.cert_provider_command.slice(1)
+      );
+      const matchCert = stdout.toString().match(certRegex);
+      const matchKey = stdout.toString().match(keyRegex);
+      if (!(matchCert?.groups && matchKey?.groups)) {
+        throw Error('unable to parse certificate and key');
+      } else {
+        return [matchCert.groups.cert, matchKey.groups.key];
+      }
+    }
+    // If GOOGLE_API_USE_CLIENT_CERTIFICATE is not set or false,
+    // use no cert or key:
+    return [undefined, undefined];
+  }
+
+  /**
+   * Return service path, taking into account mTLS logic.
+   * See: https://google.aip.dev/auth/4114
+   *
+   * @returns {string} The DNS address for this service.
+   */
+  _mtlsServicePath(
+    servicePath: string | undefined,
+    customServicePath: boolean | undefined,
+    cert: string,
+    key: string
+  ): string | undefined {
+    // If user provides a custom service path, return the current service
+    // path and do not attempt to add mtls subdomain:
+    if (customServicePath || !servicePath) return servicePath;
+    if (
+      typeof process !== 'undefined' &&
+      process?.env?.GOOGLE_API_USE_MTLS_ENDPOINT === 'never'
+    ) {
+      // It was explicitly asked that mtls endpoint not be used:
+      return servicePath;
+    } else if (
+      (typeof process !== 'undefined' &&
+        process?.env?.GOOGLE_API_USE_MTLS_ENDPOINT === 'always') ||
+      (cert && key)
+    ) {
+      // Either auto-detect or explicit setting of endpoint:
+      return servicePath.replace('googleapis.com', 'mtls.googleapis.com');
+    }
+    return servicePath;
   }
 
   /**

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -397,8 +397,7 @@ export class GrpcClient {
     const servicePath = this._mtlsServicePath(
       options.servicePath,
       customServicePath,
-      cert,
-      key
+      cert && key
     );
     const opts = Object.assign({}, options, {cert, key, servicePath});
     const serviceAddress = servicePath + ':' + opts.port;
@@ -490,8 +489,7 @@ export class GrpcClient {
   _mtlsServicePath(
     servicePath: string | undefined,
     customServicePath: boolean | undefined,
-    cert: string,
-    key: string
+    hasCertificate: boolean
   ): string | undefined {
     // If user provides a custom service path, return the current service
     // path and do not attempt to add mtls subdomain:
@@ -505,7 +503,7 @@ export class GrpcClient {
     } else if (
       (typeof process !== 'undefined' &&
         process?.env?.GOOGLE_API_USE_MTLS_ENDPOINT === 'always') ||
-      (cert && key)
+      hasCertificate
     ) {
       // Either auto-detect or explicit setting of endpoint:
       return servicePath.replace('googleapis.com', 'mtls.googleapis.com');

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -484,6 +484,9 @@ export class GrpcClient {
    * Return service path, taking into account mTLS logic.
    * See: https://google.aip.dev/auth/4114
    *
+   * @param {string|undefined} servicePath - The path of the service.
+   * @param {string|undefined} customServicePath - Did the user provide a custom service URL.
+   * @param {boolean} hasCertificate - Was a certificate found.
    * @returns {string} The DNS address for this service.
    */
   _mtlsServicePath(

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -19,7 +19,7 @@ import {execFile} from 'child_process';
 import * as fs from 'fs';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as grpc from '@grpc/grpc-js';
-import {homedir} from 'os';
+import * as os from 'os';
 import {join} from 'path';
 import {OutgoingHttpHeaders} from 'http';
 import * as path from 'path';
@@ -455,7 +455,7 @@ export class GrpcClient {
       // If context aware metadata exists, run the cert provider command,
       // parse the output to extract cert and key, and use this cert/key.
       const metadataPath = join(
-        homedir(),
+        os.homedir(),
         '.secureConnect',
         'context_aware_metadata.json'
       );

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -441,9 +441,9 @@ export class GrpcClient {
    */
   async _detectClientCertificate(opts?: ClientOptions) {
     const certRegex =
-      /(?<cert>-----BEGIN CERTIFICATE-----[\s\S]*-----END CERTIFICATE-----)/;
+      /(?<cert>-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----)/s;
     const keyRegex =
-      /(?<key>-----BEGIN PRIVATE KEY-----[\s\S]*-----END PRIVATE KEY-----)/;
+      /(?<key>-----BEGIN PRIVATE KEY-----.*?-----END PRIVATE KEY-----)/s;
     // If GOOGLE_API_USE_CLIENT_CERTIFICATE is true...:
     if (
       typeof process !== 'undefined' &&

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -23,7 +23,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
-import {rmdirSync, mkdirSync, writeFileSync} from 'fs';
+import {mkdirSync, writeFileSync} from 'fs';
+import {sync as rimrafSync} from 'rimraf';
 import {afterEach, describe, it, beforeEach} from 'mocha';
 
 import {protobuf} from '../../src/index';
@@ -643,9 +644,9 @@ dvorak
       process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'true';
       const client = gaxGrpc();
       const [cert, key] = await client._detectClientCertificate();
-      assert.strictEqual(cert, certExpected);
-      assert.strictEqual(key, keyExpected);
-      rmdirSync(tmpFolder, {recursive: true}); // Cleanup.
+      assert.ok(cert.includes('qwerty'));
+      assert.ok(key.includes('dvorak'));
+      rimrafSync(tmpFolder); // Cleanup.
     });
   });
 });

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -622,7 +622,6 @@ dvorak
     };
     afterEach(() => {
       sandbox.restore();
-      rmdirSync(tmpFolder, {recursive: true});
       delete process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE;
     });
     it('does not read certificate if GOOGLE_API_USE_CLIENT_CERTIFICATE not set', async () => {
@@ -646,6 +645,7 @@ dvorak
       const [cert, key] = await client._detectClientCertificate();
       assert.strictEqual(cert, certExpected);
       assert.strictEqual(key, keyExpected);
+      rmdirSync(tmpFolder, {recursive: true}); // Cleanup.
     });
   });
 });

--- a/test/unit/grpc.ts
+++ b/test/unit/grpc.ts
@@ -19,9 +19,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import * as assert from 'assert';
+import * as os from 'os';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
+import {rmdirSync, mkdirSync, writeFileSync} from 'fs';
 import {afterEach, describe, it, beforeEach} from 'mocha';
 
 import {protobuf} from '../../src/index';
@@ -568,9 +570,8 @@ describe('grpc', () => {
   });
 
   describe('_mtlsServicePath', () => {
-    beforeEach(() => {
+    afterEach(() => {
       delete process.env.GOOGLE_API_USE_MTLS_ENDPOINT;
-      delete process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE;
     });
     it('returns custom service path if one provided', () => {
       const expected = 'https://foo.googleapis.com';
@@ -608,9 +609,43 @@ describe('grpc', () => {
     });
   });
   describe('_detectClientCertificate', () => {
+    const tmpFolder = 'tmp-secure-context';
     const sandbox = sinon.createSandbox();
+    const certExpected = `-----BEGIN CERTIFICATE-----
+qwerty
+-----END CERTIFICATE-----`;
+    const keyExpected = `-----BEGIN PRIVATE KEY-----
+dvorak
+-----END PRIVATE KEY-----`;
+    const metadataFileContents = {
+      cert_provider_command: ['echo', certExpected, keyExpected],
+    };
     afterEach(() => {
       sandbox.restore();
+      rmdirSync(tmpFolder, {recursive: true});
+      delete process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE;
+    });
+    it('does not read certificate if GOOGLE_API_USE_CLIENT_CERTIFICATE not set', async () => {
+      const client = gaxGrpc();
+      const [cert, key] = await client._detectClientCertificate();
+      assert.strictEqual(cert, undefined);
+      assert.strictEqual(key, undefined);
+    });
+    it('reads certificate and key from command in metadata file', async () => {
+      // Pretend that "tmp-secure-context" in the current folder is the
+      // home directory, so that we can test logic for loading
+      // context_aware_metadata.json from well known location:
+      const tmpdir = path.join(tmpFolder, '.secureConnect');
+      mkdirSync(tmpdir, {recursive: true});
+      const metadataFile = path.join(tmpdir, 'context_aware_metadata.json');
+      writeFileSync(metadataFile, JSON.stringify(metadataFileContents), 'utf8');
+      sandbox.stub(os, 'homedir').returns(tmpFolder);
+      // Create a client and test the certificate detection flow:
+      process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'true';
+      const client = gaxGrpc();
+      const [cert, key] = await client._detectClientCertificate();
+      assert.strictEqual(cert, certExpected);
+      assert.strictEqual(key, keyExpected);
     });
   });
 });


### PR DESCRIPTION
Implementation of logic for loading client certificates.

TODO: add unit tests. ✅ 
Refs: https://github.com/googleapis/gapic-generator-typescript/pull/900
CC: @arithmetic1728
