### PR TITLE
fix: make pagination work for empty responses

### DIFF
--- a/src/paginationCalls/pageDescriptor.ts
+++ b/src/paginationCalls/pageDescriptor.ts
@@ -25,6 +25,8 @@ import {NormalApiCaller} from '../normalCalls/normalApiCaller';
 
 import {PagedApiCaller} from './pagedApiCaller';
 
+const maxAttemptsEmptyResponse = 10;
+
 export interface ResponseType {
   [index: string]: string;
 }
@@ -143,13 +145,20 @@ export class PageDescriptor implements Descriptor {
                 value: cache.shift(),
               });
             }
-            if (nextPageRequest) {
+            let attempts = 0;
+            while (cache.length === 0 && nextPageRequest) {
               let result: {} | [ResponseType] | null;
               [result, nextPageRequest] = (await apiCall(
                 nextPageRequest!,
                 options
               )) as ResultTuple;
               cache.push(...(result as ResponseType[]));
+              if (cache.length === 0) {
+                ++attempts;
+                if (attempts > maxAttemptsEmptyResponse) {
+                  break;
+                }
+              }
             }
             if (cache.length === 0) {
               return Promise.resolve({done: true, value: undefined});

--- a/src/paginationCalls/pagedApiCaller.ts
+++ b/src/paginationCalls/pagedApiCaller.ts
@@ -81,7 +81,7 @@ export class PagedApiCaller implements APICaller {
         );
         return;
       }
-      const resources = response[resourceFieldName];
+      const resources = response[resourceFieldName] || [];
       const pageToken = response[responsePageTokenFieldName];
       let nextPageRequest = null;
       if (pageToken) {


### PR DESCRIPTION
I found that some APIs could return an empty list of resources but non-empty next page token.  The existing logic would stop the auto pagination in this case but this is incorrect since there are more resources (as we still have the next page token).

Let's keep querying for the next page even if we got an empty resources list but we have a next page token.