### PR TITLE
feat: make OperationsClient closeable

### DIFF
--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -128,10 +128,11 @@ export class OperationsClient {
 
     for (const methodName of operationsStubMethods) {
       const innerCallPromise = this.operationsStub.then(
-        stub => (...args: Array<{}>) => {
-          const func = stub[methodName];
-          return func.apply(stub, args);
-        },
+        stub =>
+          (...args: Array<{}>) => {
+            const func = stub[methodName];
+            return func.apply(stub, args);
+          },
         err => () => {
           throw err;
         }

--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -229,7 +229,7 @@ export class OperationsClient {
   ): Promise<[protos.google.longrunning.Operation]> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = (optionsOrCallback as unknown) as Callback<
+      callback = optionsOrCallback as unknown as Callback<
         protos.google.longrunning.Operation,
         protos.google.longrunning.GetOperationRequest,
         {} | null | undefined
@@ -337,7 +337,7 @@ export class OperationsClient {
   ): Promise<protos.google.longrunning.ListOperationsResponse> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = (optionsOrCallback as unknown) as Callback<
+      callback = optionsOrCallback as unknown as Callback<
         protos.google.longrunning.ListOperationsResponse,
         protos.google.longrunning.ListOperationsRequest,
         {} | null | undefined
@@ -437,7 +437,7 @@ export class OperationsClient {
     const callSettings = new gax.CallSettings(options);
     return this.descriptor.listOperations.asyncIterate(
       this.innerApiCalls.listOperations as GaxCall,
-      (request as unknown) as RequestType,
+      request as unknown as RequestType,
       callSettings
     ) as AsyncIterable<protos.google.longrunning.ListOperationsResponse>;
   }
@@ -489,7 +489,7 @@ export class OperationsClient {
   ): Promise<protos.google.protobuf.Empty> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = (optionsOrCallback as unknown) as Callback<
+      callback = optionsOrCallback as unknown as Callback<
         protos.google.longrunning.CancelOperationRequest,
         protos.google.protobuf.Empty,
         {} | null | undefined
@@ -544,7 +544,7 @@ export class OperationsClient {
   ): Promise<protos.google.protobuf.Empty> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = (optionsOrCallback as unknown) as Callback<
+      callback = optionsOrCallback as unknown as Callback<
         protos.google.protobuf.Empty,
         protos.google.longrunning.DeleteOperationRequest,
         {} | null | undefined

--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -64,6 +64,7 @@ export class OperationsClient {
   auth?: GoogleAuth | OAuth2Client;
   innerApiCalls: {[name: string]: Function};
   descriptor: {[method: string]: PageDescriptor};
+  operationsStub: Promise<{[method: string]: Function}>;
   constructor(
     gaxGrpc: GrpcClient | FallbackGrpcClient,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -112,7 +113,7 @@ export class OperationsClient {
     };
     // Put together the "service stub" for
     // google.longrunning.Operations.
-    const operationsStub = gaxGrpc.createStub(
+    this.operationsStub = gaxGrpc.createStub(
       opts.fallback
         ? operationsProtos.lookupService('google.longrunning.Operations')
         : operationsProtos.google.longrunning.Operations,
@@ -126,12 +127,11 @@ export class OperationsClient {
     ];
 
     for (const methodName of operationsStubMethods) {
-      const innerCallPromise = operationsStub.then(
-        stub =>
-          (...args: Array<{}>) => {
-            const func = stub[methodName];
-            return func.apply(stub, args);
-          },
+      const innerCallPromise = this.operationsStub.then(
+        stub => (...args: Array<{}>) => {
+          const func = stub[methodName];
+          return func.apply(stub, args);
+        },
         err => () => {
           throw err;
         }
@@ -142,6 +142,11 @@ export class OperationsClient {
         this.descriptor[methodName]
       );
     }
+  }
+
+  /** Closes this operations client. */
+  close() {
+    this.operationsStub.then(stub => stub.close());
   }
 
   /**
@@ -224,7 +229,7 @@ export class OperationsClient {
   ): Promise<[protos.google.longrunning.Operation]> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = optionsOrCallback as unknown as Callback<
+      callback = (optionsOrCallback as unknown) as Callback<
         protos.google.longrunning.Operation,
         protos.google.longrunning.GetOperationRequest,
         {} | null | undefined
@@ -332,7 +337,7 @@ export class OperationsClient {
   ): Promise<protos.google.longrunning.ListOperationsResponse> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = optionsOrCallback as unknown as Callback<
+      callback = (optionsOrCallback as unknown) as Callback<
         protos.google.longrunning.ListOperationsResponse,
         protos.google.longrunning.ListOperationsRequest,
         {} | null | undefined
@@ -432,7 +437,7 @@ export class OperationsClient {
     const callSettings = new gax.CallSettings(options);
     return this.descriptor.listOperations.asyncIterate(
       this.innerApiCalls.listOperations as GaxCall,
-      request as unknown as RequestType,
+      (request as unknown) as RequestType,
       callSettings
     ) as AsyncIterable<protos.google.longrunning.ListOperationsResponse>;
   }
@@ -484,7 +489,7 @@ export class OperationsClient {
   ): Promise<protos.google.protobuf.Empty> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = optionsOrCallback as unknown as Callback<
+      callback = (optionsOrCallback as unknown) as Callback<
         protos.google.longrunning.CancelOperationRequest,
         protos.google.protobuf.Empty,
         {} | null | undefined
@@ -539,7 +544,7 @@ export class OperationsClient {
   ): Promise<protos.google.protobuf.Empty> {
     let options: gax.CallOptions;
     if (optionsOrCallback instanceof Function && callback === undefined) {
-      callback = optionsOrCallback as unknown as Callback<
+      callback = (optionsOrCallback as unknown) as Callback<
         protos.google.protobuf.Empty,
         protos.google.longrunning.DeleteOperationRequest,
         {} | null | undefined


### PR DESCRIPTION
Adds a `close` function to the `OperationsClient` to close the underlying gRPC stub.

Towards https://github.com/googleapis/gapic-generator-typescript/issues/823 and https://github.com/googleapis/nodejs-spanner/issues/1306
