### PR TITLE
fix: types for setImmediate calls

### DIFF
--- a/src/call.ts
+++ b/src/call.ts
@@ -78,11 +78,18 @@ export class OngoingCall {
     if (this.completed) {
       return;
     }
-    // eslint-disable-next-line
-    const canceller = func(argument, (...args: any[]) => {
-      this.completed = true;
-      setImmediate(this.callback!, ...args);
-    });
+    const canceller = func(
+      argument,
+      (
+        err: GoogleError | null,
+        response?: ResponseType,
+        next?: NextPageRequestType,
+        rawResponse?: RawResponseType
+      ) => {
+        this.completed = true;
+        setImmediate(this.callback!, err, response, next, rawResponse);
+      }
+    );
     this.cancelFunc = () => canceller.cancel();
   }
 }

--- a/src/paginationCalls/pageDescriptor.ts
+++ b/src/paginationCalls/pageDescriptor.ts
@@ -18,7 +18,14 @@ import * as ended from 'is-stream-ended';
 import {PassThrough, Transform} from 'stream';
 
 import {APICaller} from '../apiCaller';
-import {GaxCall, APICallback, RequestType, ResultTuple} from '../apitypes';
+import {
+  GaxCall,
+  APICallback,
+  RequestType,
+  ResultTuple,
+  NextPageRequestType,
+  RawResponseType,
+} from '../apitypes';
 import {Descriptor} from '../descriptor';
 import {CallSettings} from '../gax';
 import {NormalApiCaller} from '../normalCalls/normalApiCaller';
@@ -62,9 +69,9 @@ export class PageDescriptor implements Descriptor {
     let started = false;
     function callback(
       err: Error | null,
-      resources: Array<{}>,
-      next: {},
-      apiResp: {}
+      resources: Array<ResponseType>,
+      next: NextPageRequestType,
+      apiResp: RawResponseType
     ) {
       if (err) {
         stream.emit('error', err);
@@ -101,7 +108,7 @@ export class PageDescriptor implements Descriptor {
         request = next;
         started = false;
       } else {
-        setImmediate(apiCall, next, options, callback);
+        setImmediate(apiCall, next, options, callback as APICallback);
       }
     }
     stream.on('resume', () => {

--- a/src/paginationCalls/resourceCollector.ts
+++ b/src/paginationCalls/resourceCollector.ts
@@ -18,6 +18,7 @@ import {
   SimpleCallbackFunction,
   NextPageRequestType,
   RequestType,
+  APICallback,
 } from '../apitypes';
 
 /**
@@ -71,7 +72,7 @@ export class ResourceCollector {
     const callback = (
       ...args: [Error | null, Array<{}>, NextPageRequestType]
     ) => this.callback(...args);
-    setImmediate(this.apiCall, nextPageRequest, callback);
+    setImmediate(this.apiCall, nextPageRequest, callback as APICallback);
   }
 
   processAllPages(firstRequest: RequestType): Promise<Array<{}>> {
@@ -83,7 +84,7 @@ export class ResourceCollector {
       const callback = (
         ...args: [Error | null, Array<{}>, NextPageRequestType]
       ) => this.callback(...args);
-      setImmediate(this.apiCall, firstRequest, callback);
+      setImmediate(this.apiCall, firstRequest, callback as APICallback);
     });
   }
 }


### PR DESCRIPTION
The compilation was broken by the new `@types/node` release that changed something in `setImmediate()` declaration. I'm fixing types for `setImmediate()` calls to make it work and getting rid of the spread parameter, since we always know which parameters are being passed to the callback.