### PR TITLE
feat(diregapic)(pagination): support map handle for DIREGAPIC Pagination

### DIFF
--- a/src/paginationCalls/pageDescriptor.ts
+++ b/src/paginationCalls/pageDescriptor.ts
@@ -143,7 +143,7 @@ export class PageDescriptor implements Descriptor {
     const asyncIterable = {
       [Symbol.asyncIterator]() {
         let nextPageRequest: RequestType | null | undefined = request;
-        const cache: {}[] = [];
+        const cache: Array<ResponseType | [string, ResponseType]> = [];
         return {
           async next() {
             if (cache.length > 0) {
@@ -162,7 +162,7 @@ export class PageDescriptor implements Descriptor {
               // For pagination response with protobuf map type, use tuple as representation.
               if (result && !Array.isArray(result)) {
                 for (const [key, value] of Object.entries(result)) {
-                  cache.push([key, value]);
+                  cache.push([key, value as ResponseType]);
                 }
               } else {
                 cache.push(...(result as ResponseType[]));

--- a/src/paginationCalls/pageDescriptor.ts
+++ b/src/paginationCalls/pageDescriptor.ts
@@ -159,7 +159,7 @@ export class PageDescriptor implements Descriptor {
                 nextPageRequest!,
                 options
               )) as ResultTuple;
-              // Pagination return as map object pair with stirng key and any object value.
+              // For pagination response with protobuf map type, use tuple as representation.
               if (result && !Array.isArray(result)) {
                 for (const [key, value] of Object.entries(result)) {
                   cache.push([key, value]);

--- a/src/paginationCalls/pageDescriptor.ts
+++ b/src/paginationCalls/pageDescriptor.ts
@@ -159,7 +159,14 @@ export class PageDescriptor implements Descriptor {
                 nextPageRequest!,
                 options
               )) as ResultTuple;
-              cache.push(...(result as ResponseType[]));
+              // Pagination return as map object pair with stirng key and any object value.
+              if (result && !Array.isArray(result)) {
+                for (const [key, value] of Object.entries(result)) {
+                  cache.push([key, value]);
+                }
+              } else {
+                cache.push(...(result as ResponseType[]));
+              }
               if (cache.length === 0) {
                 ++attempts;
                 if (attempts > maxAttemptsEmptyResponse) {

--- a/test/unit/pagedIteration.ts
+++ b/test/unit/pagedIteration.ts
@@ -538,7 +538,6 @@ describe('REGAPIC Pagination', () => {
           break;
         }
       }
-      console.log('================resources:: ', resources);
       return resources;
     }
 


### PR DESCRIPTION
The DIREGAPIC pagination design suggests that the client libraries should return the whole contents of the dictionary key as a single resource being paginated. In the TypeScript implementation, we use [tuple](https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple) as representation. 

Next TODO: Update client library surface of pagination response iterator type. [Changes in gapic-generator-typescript](https://github.com/googleapis/gapic-generator-typescript/pull/922)

On the client side, the usage is 
```
const mapIterables = await client.aggregatedListAsync({
  project,
  region,
  maxResults,
})

for await (const [key, value] of mapIterables) {
  console.log("aggregatedListAsync iterable key: ", key);
  console.log("aggregatedListAsync iterable value: ", value);
  require('fs').appendFileSync("/tmp/out.json", JSON.stringify({key: key, value: value}, null, '  ') + ',\r\n');
}
```

The output:
```
{
  "key": "global",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "global"
        }
      ],
      "message": "There are no results for scope 'global' on this page."
    }
  }
},
{
  "key": "regions/us-central1",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/us-central1"
        }
      ],
      "message": "There are no results for scope 'regions/us-central1' on this page."
    }
  }
},
{
  "key": "regions/us-central2",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/us-central2"
        }
      ],
      "message": "There are no results for scope 'regions/us-central2' on this page."
    }
  }
},
{
  "key": "regions/europe-west1",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/europe-west1"
        }
      ],
      "message": "There are no results for scope 'regions/europe-west1' on this page."
    }
  }
},
{
  "key": "regions/us-west1",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/us-west1"
        }
      ],
      "message": "There are no results for scope 'regions/us-west1' on this page."
    }
  }
},
{
  "key": "regions/asia-east1",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/asia-east1"
        }
      ],
      "message": "There are no results for scope 'regions/asia-east1' on this page."
    }
  }
},
{
  "key": "regions/us-east1",
  "value": {
    "addresses": [
      {
        "id": "5011754511478056813",
        "kind": "compute#address",
        "name": "test-address-0",
        "creationTimestamp": "2021-05-28T23:04:50.044-07:00",
        "region": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1",
        "status": "RESERVED",
        "addressType": "EXTERNAL",
        "description": "",
        "selfLink": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1/addresses/test-address-0",
        "address": "35.237.96.161",
        "networkTier": "PREMIUM"
      },
      {
        "id": "1036412484008568684",
        "kind": "compute#address",
        "name": "test-address-1",
        "creationTimestamp": "2021-05-28T23:04:51.044-07:00",
        "region": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1",
        "status": "RESERVED",
        "addressType": "EXTERNAL",
        "description": "",
        "selfLink": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1/addresses/test-address-1",
        "address": "35.196.61.221",
        "networkTier": "PREMIUM"
      },
      {
        "id": "6976094650828089196",
        "kind": "compute#address",
        "name": "test-address-2",
        "creationTimestamp": "2021-05-28T23:04:51.890-07:00",
        "region": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1",
        "status": "RESERVED",
        "addressType": "EXTERNAL",
        "description": "",
        "selfLink": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1/addresses/test-address-2",
        "address": "35.190.159.73",
        "networkTier": "PREMIUM"
      },
      {
        "id": "311669785402042219",
        "kind": "compute#address",
        "name": "test-address-3",
        "creationTimestamp": "2021-05-28T23:04:52.769-07:00",
        "region": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1",
        "status": "RESERVED",
        "addressType": "EXTERNAL",
        "description": "",
        "selfLink": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1/addresses/test-address-3",
        "address": "35.243.170.233",
        "networkTier": "PREMIUM"
      },
      {
        "id": "5308273027754780522",
        "kind": "compute#address",
        "name": "test-address-4",
        "creationTimestamp": "2021-05-28T23:04:53.619-07:00",
        "region": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1",
        "status": "RESERVED",
        "addressType": "EXTERNAL",
        "description": "",
        "selfLink": "https://www.googleapis.com/compute/v1/projects/gapic-images/regions/us-east1/addresses/test-address-4",
        "address": "34.74.32.45",
        "networkTier": "PREMIUM"
      }
    ]
  }
},
{
  "key": "regions/asia-northeast1",
  "value": {
    "warning": {
      "code": "NO_RESULTS_ON_PAGE",
      "data": [
        {
          "key": "scope",
          "value": "regions/asia-northeast1"
        }
      ],
      "message": "There are no results for scope 'regions/asia-northeast1' on this page."
    }
  }
},
...
```