### PR TITLE
feat(compileProtos): allow to skip JSON file generation

### DIFF
--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -89,6 +89,41 @@ describe('compileProtos tool', () => {
     assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });
 
+  it('compiles protos to JS, TS, skips JSON if asked', async function () {
+    this.timeout(20000);
+    await compileProtos.main([
+      '--skip-json',
+      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+    ]);
+    assert(!fs.existsSync(expectedJsonResultFile));
+    assert(fs.existsSync(expectedJSResultFile));
+    assert(fs.existsSync(expectedTSResultFile));
+
+    const js = await readFile(expectedJSResultFile);
+    assert(js.toString().includes('TestMessage'));
+    assert(js.toString().includes('LibraryService'));
+    assert(
+      js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+    );
+    assert(js.toString().includes('require("google-gax").protobufMinimal'));
+    assert(!js.toString().includes('require("protobufjs/minimal")'));
+
+    // check that it uses proper root object; it's taken from fixtures/package.json
+    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+
+    const ts = await readFile(expectedTSResultFile);
+    assert(ts.toString().includes('TestMessage'));
+    assert(ts.toString().includes('LibraryService'));
+    assert(ts.toString().includes('import * as Long'));
+    assert(
+      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+    );
+    assert(
+      ts.toString().includes('import {protobuf as $protobuf} from "google-gax"')
+    );
+    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
+  });
+
   it('writes an empty object if no protos are given', async () => {
     await compileProtos.main([
       path.join(

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -315,14 +315,18 @@ export async function generateRootName(directories: string[]): Promise<string> {
  * @param {string[]} directories List of directories to process. Normally, just the
  * `./src` folder of the given client library.
  */
-export async function main(directories: string[]): Promise<void> {
+export async function main(parameters: string[]): Promise<void> {
   const protoJsonFiles: string[] = [];
   let skipJson = false;
-  for (const directory of directories) {
-    if (directory === '--skip-json') {
+  const directories: string[] = [];
+  for (const parameter of parameters) {
+    if (parameter === '--skip-json') {
       skipJson = true;
       continue;
     }
+    // it's not an option so it's a directory
+    const directory = parameter;
+    directories.push(directory);
     protoJsonFiles.push(...(await findProtoJsonFiles(directory)));
   }
   const rootName = await generateRootName(directories);


### PR DESCRIPTION
For Ads legacy proto loading, proto JSON file is not needed. Let's have an option to skip its generation that will save both time and size of the resulting library.