### PR TITLE
chore(deps): pin compodoc to v1.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "retry-request": "^4.0.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.7",
+    "@compodoc/compodoc": "1.1.13",
     "@types/download": "^8.0.0",
     "@types/fs-extra": "^8.0.1",
     "@types/mocha": "^8.0.0",


### PR DESCRIPTION
For some random legacy reason, we're still using `@compodoc/compodoc` here in `google-gax`.  So now it broke :) I filed https://github.com/compodoc/compodoc/issues/1102, but for now let's pin it to the last working version.