### PR TITLE
feat: promote ErrorInfo fields

### DIFF
--- a/src/call.ts
+++ b/src/call.ts
@@ -119,8 +119,13 @@ export class OngoingCallPromise extends OngoingCall {
     ) => {
       if (err) {
         const decoder = new GoogleErrorDecoder();
-        const decodedErr = decoder.decodeMetadata(err);
-        rejectCallback(decodedErr);
+        try {
+          const decodedErr = decoder.decodeMetadata(err);
+          rejectCallback(decodedErr);
+        } catch (decodeErr) {
+          // Ignore the decoder error now, and return back original error.
+          rejectCallback(err);
+        }
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);
       } else {

--- a/src/call.ts
+++ b/src/call.ts
@@ -118,11 +118,9 @@ export class OngoingCallPromise extends OngoingCall {
       rawResponse?: RawResponseType
     ) => {
       if (err) {
-        if (err.metadata) {
-          const decoder = new GoogleErrorDecoder();
-          rejectCallback(decoder.decodeMetadata(err));
-        }
-        rejectCallback(err);
+        const decoder = new GoogleErrorDecoder();
+        const decodedErr = decoder.decode(err);
+        rejectCallback(decodedErr);
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);
       } else {

--- a/src/call.ts
+++ b/src/call.ts
@@ -119,7 +119,7 @@ export class OngoingCallPromise extends OngoingCall {
     ) => {
       if (err) {
         const decoder = new GoogleErrorDecoder();
-        const decodedErr = decoder.decode(err);
+        const decodedErr = decoder.decodeMetadata(err);
         rejectCallback(decodedErr);
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);

--- a/src/call.ts
+++ b/src/call.ts
@@ -120,9 +120,7 @@ export class OngoingCallPromise extends OngoingCall {
       if (err) {
         if (err.metadata) {
           const decoder = new GoogleErrorDecoder();
-          err.statusDetails = decoder.decodeRpcStatusDetails(
-            err.metadata.get('grpc-status-details-bin') as Buffer[]
-          );
+          rejectCallback(decoder.decodeMetadata(err));
         }
         rejectCallback(err);
       } else if (response !== undefined) {

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -139,7 +139,7 @@ export class GoogleErrorDecoder {
     return status;
   }
 
-  decode(err: GoogleError): GoogleError {
+  decodeMetadata(err: GoogleError): GoogleError {
     if (!err.metadata) {
       return err;
     }

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -139,7 +139,7 @@ export class GoogleErrorDecoder {
     return status;
   }
 
-  decodeMetadata(err: GoogleError): GoogleError {
+  decode(err: GoogleError): GoogleError {
     if (!err.metadata) {
       return err;
     }
@@ -152,7 +152,7 @@ export class GoogleErrorDecoder {
     if (err.metadata.get('google.rpc.errorinfo-bin')) {
       const buffer = err.metadata.get('google.rpc.errorinfo-bin') as Buffer[];
       if (buffer.length > 1) {
-        throw new Error(
+        throw new GoogleError(
           `Multiple ErrorInfo type encoded in err.metadata.get('google.rpc.errorinfo-bin'): ${err.metadata.get(
             'google.rpc.errorinfo-bin'
           )}`

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -133,6 +133,7 @@ describe('decode metadata for ErrorInfo', () => {
       domain: 'googleapis.com',
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const errorProtoJson = require('../../protos/status.json');
     const root = protobuf.Root.fromJSON(errorProtoJson);
     const errorInfoType = root.lookupType('ErrorInfo');

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -175,7 +175,7 @@ describe('decode metadata for ErrorInfo', () => {
       }
     );
     const decoder = new GoogleErrorDecoder();
-    const decodedError = decoder.decodeMetadata(grpcError);
+    const decodedError = decoder.decode(grpcError);
     assert(decodedError instanceof GoogleError);
     assert.strictEqual(decodedError.domain, errorInfoObj.domain);
     assert.strictEqual(decodedError.reason, errorInfoObj.reason);

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -20,7 +20,8 @@ import * as fs from 'fs';
 import * as util from 'util';
 import * as protobuf from 'protobufjs';
 import * as path from 'path';
-import {GoogleErrorDecoder} from '../../src/googleError';
+import {GoogleError, GoogleErrorDecoder} from '../../src/googleError';
+import {Metadata} from '@grpc/grpc-js';
 
 interface MyObj {
   type: string;
@@ -117,6 +118,45 @@ describe('gRPC-google error decoding', () => {
       decoder.decodeProtobufAny(any);
     } catch (err) {
       assert.strictEqual(0, err.toString().indexOf('Error: no such type'));
+    }
+  });
+});
+
+describe('decode metadata for ErrorInfo', () => {
+  it('metadata contains key google.rpc.errorinfo-bin', async () => {
+    const errorInfoObj = {
+      metadata: {
+        consumer: 'projects/455411330361',
+        service: 'translate.googleapis.com',
+      },
+      reason: 'SERVICE_DISABLED',
+      domain: 'googleapis.com',
+    };
+
+    const errorProtoJson = require('../../protos/status.json');
+    const root = protobuf.Root.fromJSON(errorProtoJson);
+    const errorInfoType = root.lookupType('ErrorInfo');
+    const buffer = errorInfoType.encode(errorInfoObj).finish() as Buffer;
+    const metadata = new Metadata();
+    metadata.set('google.rpc.errorinfo-bin', buffer);
+    const grpcError = Object.assign(
+      new GoogleError('mock error with ErrorInfo'),
+      {
+        code: 7,
+        metadata: metadata,
+      }
+    );
+    const decoder = new GoogleErrorDecoder();
+    const decodedError = decoder.decodeMetadata(grpcError);
+    assert(decodedError instanceof GoogleError);
+    assert.strictEqual(decodedError.domain, errorInfoObj.domain);
+    assert.strictEqual(decodedError.reason, errorInfoObj.reason);
+    for (const [key, value] of Object.entries(errorInfoObj.metadata)) {
+      assert.ok(decodedError.metadata);
+      assert.strictEqual(
+        (decodedError.metadata.get(key) as Array<string>).shift(),
+        value
+      );
     }
   });
 });

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -175,7 +175,7 @@ describe('decode metadata for ErrorInfo', () => {
       }
     );
     const decoder = new GoogleErrorDecoder();
-    const decodedError = decoder.decode(grpcError);
+    const decodedError = decoder.decodeMetadata(grpcError);
     assert(decodedError instanceof GoogleError);
     assert.strictEqual(decodedError.domain, errorInfoObj.domain);
     assert.strictEqual(decodedError.reason, errorInfoObj.reason);


### PR DESCRIPTION
As part of error improvement project, if service team provides the [ErrorInfo](https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112-L136) in the error, client library promot the ErrorInfo fields (`domain`, `reason`, `metadata`) as first-class returning to the end-user. This allows user easily access the fields by `error. domain`, `error.reason`, `error.metadata`.

As `metadata` field has been occupied before, based on the design guidance, avoid breaking change on metadata, we add the key, value in this [metadata](https://github.com/googleapis/gax-nodejs/blob/master/src/grpc.ts#L83) object.

Testing: Currently `Chemist` implement the ErrorInfo, we use nodejs-translate client library to call `translateText` method. To get the error, disabled the cloud project `Translate API`. The error log works as expected:
```
Error: 7 PERMISSION_DENIED: Cloud Translation API has not been used in project ... before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=...then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
    ... {
  code: 7,
  details: 'Cloud Translation API has not been used in project ... before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=... then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
  metadata: Metadata {
    internalRepr: Map(6) {
      'google.rpc.errorinfo-bin' => [Array],
      'google.rpc.help-bin' => [Array],
      'grpc-status-details-bin' => [Array],
      'grpc-server-stats-bin' => [Array],
      'service' => [Array],
      'consumer' => [Array]
    },
    options: {}
  },
  statusDetails: [ Help { links: [Array] } ],
  reason: 'SERVICE_DISABLED',
  domain: 'googleapis.com'
}
```
Sample code:
```
async function main() {
  const {TranslationServiceClient} = require('@google-cloud/translate');
  const client = new TranslationServiceClient();
// disable the api
  const projectId = await client.getProjectId()
  const parent = client.locationPath(projectId, 'location')
  const request = {
    contents: ['hello', 'world'],
    parent: parent,
    targetLanguageCode: 'ru'
  }
  try {
    const [response] = await client.translateText(request);
  } catch (err) {
    console.log(err);
  }
}

main()
```

