### PR TITLE
fix(deps): pin protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "is-stream-ended": "^0.1.4",
     "node-fetch": "^2.6.1",
     "object-hash": "^2.1.1",
-    "protobufjs": "^6.10.2",
+    "protobufjs": "6.11.2",
     "retry-request": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Let's pin protobuf.js to the current version for now.