### PR TITLE
feat: use proto3 JSON serializer for REGAPIC workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "is-stream-ended": "^0.1.4",
     "node-fetch": "^2.6.1",
     "object-hash": "^2.1.1",
+    "proto3-json-serializer": "^0.1.0",
     "protobufjs": "6.11.2",
     "retry-request": "^4.0.0"
   },

--- a/src/fallbackProto.ts
+++ b/src/fallbackProto.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// proto-over-HTTP request encoding and decoding
+
+import {defaultToObjectOptions} from './fallback';
+import {FetchParameters} from './fallbackServiceStub';
+import {GoogleErrorDecoder} from './googleError';
+
+export function encodeRequest(
+  rpc: protobuf.Method,
+  protocol: string,
+  servicePath: string,
+  servicePort: number,
+  request: {}
+): FetchParameters {
+  const protoNamespaces: string[] = [];
+  let currNamespace = rpc.parent!;
+  while (currNamespace.name !== '') {
+    protoNamespaces.unshift(currNamespace.name);
+    currNamespace = currNamespace.parent!;
+  }
+  const protoServiceName = protoNamespaces.join('.');
+  const rpcName = rpc.name;
+
+  const headers: {[key: string]: string} = {
+    'Content-Type': 'application/x-protobuf',
+  };
+
+  const method = 'post';
+  const requestMessage = rpc.resolvedRequestType!.fromObject(request);
+  const body = rpc.resolvedRequestType!.encode(requestMessage).finish();
+  const url = `${protocol}://${servicePath}:${servicePort}/$rpc/${protoServiceName}/${rpcName}`;
+
+  return {
+    method,
+    url,
+    headers,
+    body,
+  };
+}
+
+export function decodeResponse(
+  rpc: protobuf.Method,
+  ok: boolean,
+  response: Buffer | ArrayBuffer
+): {} {
+  if (!ok) {
+    const statusDecoder = new GoogleErrorDecoder();
+    const error = statusDecoder.decodeErrorFromBuffer(response);
+    throw error;
+  }
+
+  const buffer =
+    response instanceof ArrayBuffer ? new Uint8Array(response) : response;
+  const message = rpc.resolvedResponseType!.decode(buffer);
+  return rpc.resolvedResponseType!.toObject(message, defaultToObjectOptions);
+}

--- a/src/fallbackRest.ts
+++ b/src/fallbackRest.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// proto-over-HTTP request encoding and decoding
+
+import * as serializer from 'proto3-json-serializer';
+import {defaultToObjectOptions} from './fallback';
+import {FetchParameters} from './fallbackServiceStub';
+import {hasTextDecoder, hasTextEncoder, isNodeJS} from './featureDetection';
+import {transcode} from './transcoding';
+
+if (!hasTextEncoder() || !hasTextDecoder()) {
+  if (isNodeJS()) {
+    // Node.js 10 does not have global TextDecoder
+    // TODO(@alexander-fenster): remove this logic after Node.js 10 is EOL.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const util = require('util');
+    Object.assign(global, {
+      TextDecoder: util.TextDecoder,
+      TextEncoder: util.TextEncoder,
+    });
+  } else {
+    require('fast-text-encoding');
+  }
+}
+
+export function encodeRequest(
+  rpc: protobuf.Method,
+  protocol: string,
+  servicePath: string,
+  servicePort: number,
+  request: {}
+): FetchParameters {
+  const headers: {[key: string]: string} = {
+    'Content-Type': 'application/json',
+  };
+  const message = rpc.resolvedRequestType!.fromObject(request);
+  const json = serializer.toProto3JSON(message);
+  if (!json) {
+    throw new Error(`Cannot send null request to RPC ${rpc.name}.`);
+  }
+  if (typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error(`Request to RPC ${rpc.name} must be an object.`);
+  }
+  const transcoded = transcode(
+    json,
+    rpc.parsedOptions,
+    rpc.resolvedRequestType!.fields
+  );
+  if (!transcoded) {
+    throw new Error(
+      `Cannot build HTTP request for ${JSON.stringify(json)}, method: ${
+        rpc.name
+      }`
+    );
+  }
+  const method = transcoded.httpMethod;
+  const body = JSON.stringify(transcoded.data);
+  const url = `${protocol}://${servicePath}:${servicePort}/${transcoded.url.replace(
+    /^\//,
+    ''
+  )}?${transcoded.queryString}`;
+
+  return {
+    method,
+    url,
+    headers,
+    body,
+  };
+}
+
+export function decodeResponse(
+  rpc: protobuf.Method,
+  ok: boolean,
+  response: Buffer | ArrayBuffer
+): {} {
+  // eslint-disable-next-line node/no-unsupported-features/node-builtins
+  const decodedString = new TextDecoder().decode(response);
+  const json = JSON.parse(decodedString);
+  if (!ok) {
+    const error = Object.assign(
+      new Error(json['error']['message']),
+      json.error
+    );
+    throw error;
+  }
+  const message = serializer.fromProto3JSON(rpc.resolvedResponseType!, json);
+  if (!message) {
+    throw new Error(`Received null response from RPC ${rpc.name}`);
+  }
+  return rpc.resolvedResponseType!.toObject(message, defaultToObjectOptions);
+}

--- a/src/fallbackServiceStub.ts
+++ b/src/fallbackServiceStub.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global window */
+/* global AbortController */
+
+import nodeFetch from 'node-fetch';
+import {Response as NodeFetchResponse} from 'node-fetch';
+import {AbortController as NodeAbortController} from 'abort-controller';
+
+import {hasWindowFetch, hasAbortController} from './featureDetection';
+import {AuthClient} from './fallback';
+
+interface NodeFetchType {
+  (url: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+export interface FallbackServiceStub {
+  // Compatible with gRPC service stub
+  [method: string]: (
+    request: {},
+    options: {},
+    metadata: {},
+    callback: (err?: Error, response?: {} | undefined) => void
+  ) => {cancel: () => void};
+}
+
+export interface FetchParameters {
+  headers: {[key: string]: string};
+  body: Buffer | Uint8Array | string;
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete';
+  url: string;
+}
+
+export function generateServiceStub(
+  rpcs: {[name: string]: protobuf.Method},
+  protocol: string,
+  servicePath: string,
+  servicePort: number,
+  authClient: AuthClient,
+  requestEncoder: (
+    rpc: protobuf.Method,
+    protocol: string,
+    servicePath: string,
+    servicePort: number,
+    request: {}
+  ) => FetchParameters,
+  responseDecoder: (
+    rpc: protobuf.Method,
+    ok: boolean,
+    response: Buffer | ArrayBuffer
+  ) => {}
+) {
+  const fetch = hasWindowFetch()
+    ? window.fetch
+    : (nodeFetch as unknown as NodeFetchType);
+
+  const serviceStub: FallbackServiceStub = {};
+  for (const [rpcName, rpc] of Object.entries(rpcs)) {
+    serviceStub[rpcName] = (
+      request: {},
+      options: {[name: string]: string},
+      _metadata: {},
+      callback: Function
+    ) => {
+      // We cannot use async-await in this function because we need to return the canceller object as soon as possible.
+      // Using plain old promises instead.
+
+      const cancelController = hasAbortController()
+        ? new AbortController()
+        : new NodeAbortController();
+      const cancelSignal = cancelController.signal;
+      let cancelRequested = false;
+
+      const fetchParameters = requestEncoder(
+        rpc,
+        protocol,
+        servicePath,
+        servicePort,
+        request
+      );
+      const url = fetchParameters.url;
+      const headers = fetchParameters.headers;
+      for (const key of Object.keys(options)) {
+        headers[key] = options[key][0];
+      }
+
+      authClient
+        .getRequestHeaders()
+        .then(authHeader => {
+          const fetchRequest = {
+            headers: {
+              ...authHeader,
+              ...headers,
+            },
+            body: fetchParameters.body as
+              | string
+              | Buffer
+              | Uint8Array
+              | undefined,
+            method: fetchParameters.method,
+            signal: cancelSignal,
+          };
+          if (
+            fetchParameters.method === 'get' ||
+            fetchParameters.method === 'delete'
+          ) {
+            delete fetchRequest['body'];
+          }
+
+          return fetch(url, fetchRequest);
+        })
+        .then((response: Response | NodeFetchResponse) => {
+          return Promise.all([
+            Promise.resolve(response.ok),
+            response.arrayBuffer(),
+          ]);
+        })
+        .then(([ok, buffer]: [boolean, Buffer | ArrayBuffer]) => {
+          const response = responseDecoder(rpc, ok, buffer);
+          callback(null, response);
+        })
+        .catch((err: Error) => {
+          if (!cancelRequested || err.name !== 'AbortError') {
+            callback(err);
+          }
+        });
+
+      return {
+        cancel: () => {
+          cancelRequested = true;
+          cancelController.abort();
+        },
+      };
+    };
+  }
+
+  return serviceStub;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,3 +109,6 @@ export {
 
 export {ServiceError, ChannelCredentials} from '@grpc/grpc-js';
 export {warn} from './warnings';
+
+import * as serializer from 'proto3-json-serializer';
+export {serializer};

--- a/test/browser-test/test.endtoend.ts
+++ b/test/browser-test/test.endtoend.ts
@@ -28,7 +28,7 @@ function sleep(timeout: number) {
 
 describe('Run tests against gRPC server', () => {
   const authStub = {
-    getRequestHeaders() {
+    async getRequestHeaders() {
       return {Authorization: 'Bearer SOME_TOKEN'};
     },
   };

--- a/test/browser-test/test.grpc-fallback.ts
+++ b/test/browser-test/test.grpc-fallback.ts
@@ -29,7 +29,7 @@ import * as EchoClient from '../fixtures/google-gax-packaging-test-app/src/v1bet
 const statusJsonProto = require('../../protos/status.json');
 
 const authStub = {
-  getRequestHeaders() {
+  async getRequestHeaders() {
     return {Authorization: 'Bearer SOME_TOKEN'};
   },
 };
@@ -86,15 +86,13 @@ describe('createStub', () => {
   it('should create a stub', async () => {
     const echoStub = await gaxGrpc.createStub(echoService, stubOptions);
 
-    assert(echoStub instanceof protobuf.rpc.Service);
-
     // The stub should consist of service methods
     assert(echoStub.echo instanceof Function);
     assert(echoStub.pagedExpand instanceof Function);
     assert(echoStub.wait instanceof Function);
 
-    // There should be 6 methods for the echo service (and 4 other methods in the object)
-    assert.strictEqual(Object.keys(echoStub).length, 10);
+    // There should be 6 methods for the echo service
+    assert.strictEqual(Object.keys(echoStub).length, 6);
 
     // Each of the service methods should take 4 arguments (so that it works with createApiCall)
     assert.strictEqual(echoStub.echo.length, 4);
@@ -103,15 +101,13 @@ describe('createStub', () => {
   it('should support optional parameters', async () => {
     const echoStub = await gaxGrpc.createStub(echoService, stubExtraOptions);
 
-    assert(echoStub instanceof protobuf.rpc.Service);
-
     // The stub should consist of methods
     assert(echoStub.echo instanceof Function);
     assert(echoStub.collect instanceof Function);
     assert(echoStub.chat instanceof Function);
 
-    // There should be 6 methods for the echo service (and 4 other members in the object)
-    assert.strictEqual(Object.keys(echoStub).length, 10);
+    // There should be 6 methods for the echo service
+    assert.strictEqual(Object.keys(echoStub).length, 6);
 
     // Each of the service methods should take 4 arguments (so that it works with createApiCall)
     assert.strictEqual(echoStub.echo.length, 4);
@@ -128,7 +124,7 @@ describe('grpc-fallback', () => {
   const savedAbortController = window.AbortController;
 
   const authStub = {
-    getRequestHeaders() {
+    async getRequestHeaders() {
       return {Authorization: 'Bearer SOME_TOKEN'};
     },
   };
@@ -269,7 +265,7 @@ describe('grpc-fallback', () => {
     sinon.replace(window, 'fetch', fakeFetch);
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
-      echoStub.echo(requestObject, {}, {}, (err: Error) => {
+      echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         assert(err instanceof Error);
         assert.strictEqual(err.message, '3 INVALID_ARGUMENT: Error message');
         assert.strictEqual(JSON.stringify(err), JSON.stringify(expectedError));

--- a/test/browser-test/test.unit.ts
+++ b/test/browser-test/test.unit.ts
@@ -34,7 +34,7 @@ describe('Run unit tests of echo client', () => {
   const error = new Error() as GoogleError;
   error.code = FAKE_STATUS_CODE;
   const authStub = {
-    getRequestHeaders() {
+    async getRequestHeaders() {
       return {Authorization: 'Bearer SOME_TOKEN'};
     },
   };

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -50,7 +50,7 @@ async function testShowcase() {
   const fakeGoogleAuth = {
     getClient: async () => {
       return {
-        getRequestHeaders: () => {
+        getRequestHeaders: async () => {
           return {
             Authorization: 'Bearer zzzz',
           };

--- a/test/unit/regapic.ts
+++ b/test/unit/regapic.ts
@@ -29,14 +29,14 @@ import {OAuth2Client} from 'google-auth-library';
 import {GrpcClientOptions} from '../../src';
 
 const authClient = {
-  getRequestHeaders() {
+  async getRequestHeaders() {
     return {Authorization: 'Bearer SOME_TOKEN'};
   },
 };
 
 const authStub = {
-  getClient() {
-    return Promise.resolve(authClient);
+  async getClient() {
+    return authClient;
   },
 };
 
@@ -99,9 +99,12 @@ describe('regapic', () => {
     );
 
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
-      echoStub.echo(requestObject, {}, {}, (err: {}, result: {content: {}}) => {
+      echoStub.echo(requestObject, {}, {}, (err?: {}, result?: {}) => {
         assert.strictEqual(err, null);
-        assert.strictEqual(requestObject.content, result.content);
+        assert.strictEqual(
+          requestObject.content,
+          (result as {content: string}).content
+        );
         done();
       });
     });
@@ -127,18 +130,19 @@ describe('regapic', () => {
       );
 
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.getShelf(
-          requestObject,
-          {},
-          {},
-          (err: {}, result: {name: {}; theme: {}; type: {}}) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual('shelf-name', result.name);
-            assert.strictEqual('TYPEONE', result.type);
-            done();
-          }
-        );
-      });
+        libStub.getShelf(requestObject, {}, {}, (err?: {}, result?: {}) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(
+            'shelf-name',
+            (result as {name: {}; theme: {}; type: {}}).name
+          );
+          assert.strictEqual(
+            'TYPEONE',
+            (result as {name: {}; theme: {}; type: {}}).type
+          );
+          done();
+        });
+      }, /* catch: */ done);
     });
 
     it('should support enum conversion in proto message request using symbolic name', done => {
@@ -159,11 +163,11 @@ describe('regapic', () => {
         })
       );
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.createShelf(requestObject, {}, {}, (err: {}) => {
+        libStub.createShelf(requestObject, {}, {}, (err?: {}) => {
           assert.strictEqual(err, null);
           done();
         });
-      });
+      }, /* catch: */ done);
     });
 
     it('should support enum conversion in proto message request using type value', done => {
@@ -184,11 +188,11 @@ describe('regapic', () => {
         })
       );
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.createShelf(requestObject, {}, {}, (err: {}) => {
+        libStub.createShelf(requestObject, {}, {}, (err?: {}) => {
           assert.strictEqual(err, null);
           done();
         });
-      });
+      }, /* catch: */ done);
     });
   });
 
@@ -213,21 +217,35 @@ describe('regapic', () => {
         })
       );
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.getBook(
-          requestObject,
-          {},
-          {},
-          (
-            err: {},
-            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
-          ) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual('book-name', result.name);
-            assert.strictEqual('9007199254740992', result.bookId);
-            done();
-          }
-        );
-      });
+        libStub.getBook(requestObject, {}, {}, (err?: {}, result?: {}) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(
+            'book-name',
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).name
+          );
+          assert.strictEqual(
+            '9007199254740992',
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).bookId
+          );
+          done();
+        });
+      }, /* catch: */ done);
     });
 
     it('small number long data type conversion in proto message response', done => {
@@ -250,21 +268,35 @@ describe('regapic', () => {
         })
       );
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.getBook(
-          requestObject,
-          {},
-          {},
-          (
-            err: {},
-            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
-          ) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual('book-name', result.name);
-            assert.strictEqual('42', result.bookId);
-            done();
-          }
-        );
-      });
+        libStub.getBook(requestObject, {}, {}, (err?: {}, result?: {}) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(
+            'book-name',
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).name
+          );
+          assert.strictEqual(
+            '42',
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).bookId
+          );
+          done();
+        });
+      }, /* catch: */ done);
     });
 
     it('long data type conversion in proto message request', done => {
@@ -288,21 +320,35 @@ describe('regapic', () => {
         })
       );
       gaxGrpc.createStub(libraryService, stubOptions).then(libStub => {
-        libStub.getBook(
-          requestObject,
-          {},
-          {},
-          (
-            err: {},
-            result: {name: {}; author: {}; title: {}; read: false; bookId: {}}
-          ) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual('book-name', result.name);
-            assert.strictEqual(bookId.toString(), result.bookId);
-            done();
-          }
-        );
-      });
+        libStub.getBook(requestObject, {}, {}, (err?: {}, result?: {}) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(
+            'book-name',
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).name
+          );
+          assert.strictEqual(
+            bookId.toString(),
+            (
+              result as {
+                name: {};
+                author: {};
+                title: {};
+                read: false;
+                bookId: {};
+              }
+            ).bookId
+          );
+          done();
+        });
+      }, /* catch: */ done);
     });
   });
 });

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -78,14 +78,17 @@ describe('gRPC to HTTP transcoding', () => {
 
   // Main transcode() function
   it('transcode', () => {
-    assert.deepEqual(transcode({parent: 'projects/project'}, parsedOptions), {
-      httpMethod: 'get',
-      url: '/v3/projects/project/supportedLanguages',
-      queryString: '',
-      data: '',
-    });
+    assert.deepStrictEqual(
+      transcode({parent: 'projects/project'}, parsedOptions),
+      {
+        httpMethod: 'get',
+        url: '/v3/projects/project/supportedLanguages',
+        queryString: '',
+        data: '',
+      }
+    );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode({parent: 'projects/project', field: 'value'}, parsedOptions),
       {
         httpMethod: 'get',
@@ -95,7 +98,7 @@ describe('gRPC to HTTP transcoding', () => {
       }
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode(
         {parent: 'projects/project', field: 'value', a: 42},
         parsedOptions
@@ -108,7 +111,7 @@ describe('gRPC to HTTP transcoding', () => {
       }
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode(
         {parent: 'post1/project', field: 'value', a: 42},
         parsedOptions
@@ -121,7 +124,7 @@ describe('gRPC to HTTP transcoding', () => {
       }
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode(
         {parent: 'post2/project', field: 'value', a: 42},
         parsedOptions
@@ -134,7 +137,7 @@ describe('gRPC to HTTP transcoding', () => {
       }
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode({parent: 'get/project', field: 'value', a: 42}, parsedOptions),
       {
         httpMethod: 'get',
@@ -145,7 +148,7 @@ describe('gRPC to HTTP transcoding', () => {
     );
 
     // Checking camel-snake-case conversions
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode(
         {
           snakeCaseFirst: 'first',
@@ -162,7 +165,7 @@ describe('gRPC to HTTP transcoding', () => {
       }
     );
 
-    assert.deepEqual(
+    assert.deepStrictEqual(
       transcode(
         {
           snakeCaseSecond: 'second',
@@ -226,7 +229,7 @@ describe('gRPC to HTTP transcoding', () => {
       getField({field: {subfield: 'stringValue'}}, 'field.subfield'),
       'stringValue'
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       getField({field: {subfield: [1, 2, 3]}}, 'field.subfield'),
       [1, 2, 3]
     );
@@ -250,35 +253,35 @@ describe('gRPC to HTTP transcoding', () => {
   it('deleteField', () => {
     const request1 = {field: 'stringValue'};
     deleteField(request1, 'field');
-    assert.deepEqual(request1, {});
+    assert.deepStrictEqual(request1, {});
 
     const request2 = {field: 'stringValue'};
     deleteField(request2, 'nosuchfield');
-    assert.deepEqual(request2, {
+    assert.deepStrictEqual(request2, {
       field: 'stringValue',
     });
 
     const request3 = {field: 'stringValue'};
     deleteField(request3, 'field.subfield');
-    assert.deepEqual(request3, {
+    assert.deepStrictEqual(request3, {
       field: 'stringValue',
     });
 
     const request4 = {field: {subfield: 'stringValue'}};
     deleteField(request4, 'field.subfield');
-    assert.deepEqual(request4, {field: {}});
+    assert.deepStrictEqual(request4, {field: {}});
 
     const request5 = {field: {subfield: 'stringValue', q: 'w'}, e: 'f'};
     deleteField(request5, 'field.subfield');
-    assert.deepEqual(request5, {field: {q: 'w'}, e: 'f'});
+    assert.deepStrictEqual(request5, {field: {q: 'w'}, e: 'f'});
 
     const request6 = {field: {subfield: 'stringValue'}};
     deleteField(request6, 'field.nosuchfield');
-    assert.deepEqual(request6, {field: {subfield: 'stringValue'}});
+    assert.deepStrictEqual(request6, {field: {subfield: 'stringValue'}});
 
     const request7 = {field: {subfield: {subsubfield: 'stringValue', q: 'w'}}};
     deleteField(request7, 'field.subfield.subsubfield');
-    assert.deepEqual(request7, {field: {subfield: {q: 'w'}}});
+    assert.deepStrictEqual(request7, {field: {subfield: {q: 'w'}}});
   });
 
   it('encodeWithSlashes', () => {
@@ -334,16 +337,16 @@ describe('gRPC to HTTP transcoding', () => {
   });
 
   it('flattenObject', () => {
-    assert.deepEqual(flattenObject({}), {});
-    assert.deepEqual(flattenObject({field: 'value'}), {field: 'value'});
-    assert.deepEqual(
+    assert.deepStrictEqual(flattenObject({}), {});
+    assert.deepStrictEqual(flattenObject({field: 'value'}), {field: 'value'});
+    assert.deepStrictEqual(
       flattenObject({field: 'value', nested: {subfield: 'subvalue'}}),
       {field: 'value', 'nested.subfield': 'subvalue'}
     );
   });
 
   it('match', () => {
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {parent: 'projects/te st', test: 'value'},
         '/v3/{parent=projects/*}/supportedLanguages'
@@ -353,14 +356,14 @@ describe('gRPC to HTTP transcoding', () => {
         url: '/v3/projects/te%20st/supportedLanguages',
       }
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {parent: 'projects/te st/locations/location', test: 'value'},
         '/v3/{parent=projects/*}/supportedLanguages'
       ),
       undefined
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {parent: 'projects/te st/locations/location', test: 'value'},
         '/v3/{parent=projects/*/locations/*}/supportedLanguages'
@@ -370,14 +373,14 @@ describe('gRPC to HTTP transcoding', () => {
         url: '/v3/projects/te%20st/locations/location/supportedLanguages',
       }
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {parent: 'projects/te st', test: 'value'},
         '/v3/{parent=projects/*}/{field=*}/supportedLanguages'
       ),
       undefined
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {parent: 'projects/te st', test: 'value', field: 42},
         '/v3/{parent=projects/*}/{field=*}/supportedLanguages'
@@ -387,7 +390,7 @@ describe('gRPC to HTTP transcoding', () => {
         url: '/v3/projects/te%20st/42/supportedLanguages',
       }
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match(
         {
           parent: 'projects/te st',
@@ -402,11 +405,11 @@ describe('gRPC to HTTP transcoding', () => {
         url: '/v3/projects/te%20st/fields/field42/a/b%2Cc/d/supportedLanguages',
       }
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match({}, '/v3/{field.subfield}/supportedLanguages'),
       undefined
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       match({field: {subfield: 42}}, '/v3/{field.subfield}/supportedLanguages'),
       {
         matchedFields: ['field.subfield'],
@@ -424,7 +427,7 @@ describe('gRPC to HTTP transcoding', () => {
       repeated: [1, 2, {a: 'b'}],
     };
     const copy = deepCopy(request as RequestType);
-    assert.deepEqual(copy, request);
+    assert.deepStrictEqual(copy, request);
     request.field.subfield = 43;
     request.repeated[0] = -1;
     (request.repeated[2] as RequestType).a = 'c';
@@ -434,14 +437,14 @@ describe('gRPC to HTTP transcoding', () => {
   });
 
   it('buildQueryStringComponents', () => {
-    assert.deepEqual(buildQueryStringComponents({field: 'value'}), [
+    assert.deepStrictEqual(buildQueryStringComponents({field: 'value'}), [
       'field=value',
     ]);
-    assert.deepEqual(buildQueryStringComponents({field: 'value', a: 42}), [
-      'field=value',
-      'a=42',
-    ]);
-    assert.deepEqual(
+    assert.deepStrictEqual(
+      buildQueryStringComponents({field: 'value', a: 42}),
+      ['field=value', 'a=42']
+    );
+    assert.deepStrictEqual(
       buildQueryStringComponents({
         field: 'value',
         repeated: [1, 2, 'z z z'],
@@ -497,11 +500,11 @@ describe('gRPC to HTTP transcoding', () => {
         list_field: [1, 2, 3],
       },
     };
-    assert.deepEqual(
+    assert.deepStrictEqual(
       requestChangeCaseAndCleanup(request, camelToSnakeCase),
       expectedSnakeCase
     );
-    assert.deepEqual(
+    assert.deepStrictEqual(
       requestChangeCaseAndCleanup(expectedSnakeCase, snakeToCamelCase),
       request
     );


### PR DESCRIPTION
In this pull request, I'm adding a feature to use the new [proto3 JSON serializer](https://www.npmjs.com/package/proto3-json-serializer) in REGAPIC workflows instead of `.toObject` and `.fromObject`, and also refactoring the very hard-to-read `src/fallback.ts` into several files which now, I believe, have much more readable structure.

In this PR, we:
- in REST transport, use `.toProto3JSON` and `.fromProto3JSON` instead of `.toObject`/`.fromObject`, so we support all the fancy JSON serialization rules;
- stop using protobuf.js "rpcImpl" mechanism, instead generating our own service stub in a straightforward way;
- extract the `fetch` logic into a separate file;
- extract the transport-related encoding and decoding of requests and responses into two separate files (one for REST, another one for proto-over-HTTP).

There is _almost_ no new code, the refactor is mostly the existing code moved around.

In general, I hope the new setup is more readable.