### PR TITLE
fix: do not throw error on empty LRO response

### DIFF
--- a/src/longRunningCalls/longrunning.ts
+++ b/src/longRunningCalls/longrunning.ts
@@ -311,13 +311,11 @@ export class Operation extends EventEmitter {
           }
           // special case: some APIs fail to set either result or error
           // but set done = true (e.g. speech with silent file).
-          // Don't hang forever in this case.
+          // Some APIs just use this for the normal completion
+          // (e.g. nodejs-contact-center-insights), so let's just return
+          // an empty response in this case.
           if (rawResponse!.done) {
-            const error = new GoogleError(
-              'Long running operation has finished but there was no result'
-            );
-            error.code = Status.UNKNOWN;
-            setImmediate(emit, 'error', error);
+            setImmediate(emit, 'complete', {}, metadata, rawResponse);
             return;
           }
           setTimeout(() => {

--- a/test/unit/longrunning.ts
+++ b/test/unit/longrunning.ts
@@ -487,16 +487,16 @@ describe('longrunning', () => {
         apiCall({})
           .then(responses => {
             const operation = responses[0] as longrunning.Operation;
-            const promise = operation.promise();
+            const promise = operation.promise() as Promise<[{}, {}, {}]>;
             return promise;
           })
-          .then(() => {
-            done(new Error('Should not get here.'));
-          })
-          .catch(error => {
-            assert(error instanceof Error);
+          .then(([response, metadata, rawResponse]) => {
+            assert.deepStrictEqual(response, {});
+            assert.strictEqual(metadata, METADATA_VAL);
+            assert.deepStrictEqual(rawResponse, BAD_OP);
             done();
-          });
+          })
+          .catch(done);
       });
     });
 


### PR DESCRIPTION
Inspired by https://github.com/googleapis/nodejs-contact-center-insights/pull/34/files#r690783654. Some APIs end LRO without setting either result or error (but set `done: true`), that condition was previously considered an error but looks like it's OK to just return an empty response object in this case.