### PR TITLE
fix(diregapic): support field name IPProtocol gRPC transcoding

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -45,5 +45,8 @@ export function snakeToCamelCase(str: string) {
   if (splitted.length === 0) {
     return str;
   }
-  return [splitted[0], ...splitted.slice(1).map(capitalize)].join('');
+  return [
+    str.charAt(0) === '_' ? capitalize(splitted[0]) : splitted[0],
+    ...splitted.slice(1).map(capitalize),
+  ].join('');
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,7 @@
  * to snake_case (normally used in proto definitions).
  */
 export function camelToSnakeCase(str: string) {
-  return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+  return str.replace(/(?!^)[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 }
 
 /**
@@ -41,12 +41,10 @@ export function snakeToCamelCase(str: string) {
   const splitted = str
     .split(/(?=[A-Z])|[\s\W_]+/)
     .filter(w => w.length > 0)
-    .map(word => word.toLowerCase());
+    //
+    .map((word, index) => (index === 0 ? word : word.toLowerCase()));
   if (splitted.length === 0) {
     return str;
   }
-  return [
-    str.charAt(0) === '_' ? capitalize(splitted[0]) : splitted[0],
-    ...splitted.slice(1).map(capitalize),
-  ].join('');
+  return [splitted[0], ...splitted.slice(1).map(capitalize)].join('');
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,6 +19,7 @@
  * to snake_case (normally used in proto definitions).
  */
 export function camelToSnakeCase(str: string) {
+  // Keep the first position capitalization, otherwise decapitalize with underscore.
   return str.replace(/(?!^)[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 }
 
@@ -41,7 +42,7 @@ export function snakeToCamelCase(str: string) {
   const splitted = str
     .split(/(?=[A-Z])|[\s\W_]+/)
     .filter(w => w.length > 0)
-    //
+    // Keep the capitalization for the first split.
     .map((word, index) => (index === 0 ? word : word.toLowerCase()));
   if (splitted.length === 0) {
     return str;

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -188,6 +188,42 @@ describe('gRPC to HTTP transcoding', () => {
     );
   });
 
+  it('transcode should not decapitalize the first capital letter', () => {
+    assert.deepStrictEqual(
+      transcode(
+        {
+          parent: 'post1/project',
+          IPProtocol: 'tcp',
+        },
+        parsedOptions
+      ),
+      {
+        httpMethod: 'post',
+        queryString: '',
+        url: '/v3/post1/project/supportedLanguages',
+        data: {
+          IPProtocol: 'tcp',
+        },
+      }
+    );
+    assert.deepStrictEqual(
+      transcode(
+        {
+          parent: 'post2/project',
+          IPProtocol: 'tcp',
+          field: 'value',
+        },
+        parsedOptions
+      ),
+      {
+        httpMethod: 'post',
+        queryString: 'IPProtocol=tcp',
+        url: '/v3/post2/project/supportedLanguages',
+        data: 'value',
+      }
+    );
+  });
+
   it('transcode should ignore inherited properties', () => {
     // In this test we emulate protobuf object that has inherited circular
     // references in the prototype. This is supposed to be a pure JS code

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -222,6 +222,23 @@ describe('gRPC to HTTP transcoding', () => {
         data: 'value',
       }
     );
+    assert.deepStrictEqual(
+      transcode(
+        {
+          parent: 'post1/project',
+          iPProtocol: 'tcp',
+        },
+        parsedOptions
+      ),
+      {
+        httpMethod: 'post',
+        queryString: '',
+        url: '/v3/post1/project/supportedLanguages',
+        data: {
+          iPProtocol: 'tcp',
+        },
+      }
+    );
   });
 
   it('transcode should ignore inherited properties', () => {

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -24,6 +24,7 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('test123'), 'test123');
     assert.strictEqual(camelToSnakeCase('testAbc'), 'test_abc');
     assert.strictEqual(camelToSnakeCase('testAbcDef'), 'test_abc_def');
+    assert.strictEqual(camelToSnakeCase('IPProtocol'), '_i_p_protocol');
   });
 
   it('snakeToCamelCase', () => {
@@ -31,5 +32,6 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('test123'), 'test123');
     assert.strictEqual(snakeToCamelCase('test_abc'), 'testAbc');
     assert.strictEqual(snakeToCamelCase('test_abc_def'), 'testAbcDef');
+    assert.strictEqual(snakeToCamelCase('_i_p_protocol'), 'IPProtocol');
   });
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -24,7 +24,8 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('test123'), 'test123');
     assert.strictEqual(camelToSnakeCase('testAbc'), 'test_abc');
     assert.strictEqual(camelToSnakeCase('testAbcDef'), 'test_abc_def');
-    assert.strictEqual(camelToSnakeCase('IPProtocol'), '_i_p_protocol');
+    assert.strictEqual(camelToSnakeCase('IPProtocol'), 'I_p_protocol');
+    assert.strictEqual(camelToSnakeCase('iPProtocol'), 'i_p_protocol');
   });
 
   it('snakeToCamelCase', () => {
@@ -32,6 +33,6 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('test123'), 'test123');
     assert.strictEqual(snakeToCamelCase('test_abc'), 'testAbc');
     assert.strictEqual(snakeToCamelCase('test_abc_def'), 'testAbcDef');
-    assert.strictEqual(snakeToCamelCase('_i_p_protocol'), 'IPProtocol');
+    assert.strictEqual(snakeToCamelCase('I_p_protocol'), 'IPProtocol');
   });
 });


### PR DESCRIPTION
Gax-nodejs incorrectly sets fields that have capitalized letters(`IPProtocol`) when gRPC transcoding the request. As a result, a service throws an error for the request with invalid field `iPProtocol`.
```
Error: Invalid value for field 'resource.allowed[0].IPProtocol': ''. Must be one of ["ah", "all", "esp", "icmp", "ipip", "sctp", "tcp", "udp"] or an IP protocol number between 0 and 255.
``` 
https://cloud.google.com/compute/docs/reference/rest/v1/firewalls/insert

Solution:
According to `camelToSnakeCase`, any uppercase replaced by `_` with lowercase. Therefore, we only need to check if the field is started by underscore `_`, if it is we use capital letters instead.