### PR TITLE
fix: protoCache map key support Buffer type

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -81,7 +81,7 @@ export class GrpcClient {
   authClient?: AuthClient;
   fallback: boolean | 'rest' | 'proto';
   grpcVersion: string;
-  private static protoCache = new Map<string | Buffer, protobuf.Root>();
+  private static protoCache = new Map<string, protobuf.Root>();
 
   /**
    * In rare cases users might need to deallocate all memory consumed by loaded protos.
@@ -134,7 +134,7 @@ export class GrpcClient {
   }
 
   loadProtoJSON(json: protobuf.INamespace, ignoreCache = false) {
-    const hash = objectHash(json);
+    const hash = objectHash(json).toString();
     const cached = GrpcClient.protoCache.get(hash);
     if (cached && !ignoreCache) {
       return cached;

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -81,7 +81,7 @@ export class GrpcClient {
   authClient?: AuthClient;
   fallback: boolean | 'rest' | 'proto';
   grpcVersion: string;
-  private static protoCache = new Map<string, protobuf.Root>();
+  private static protoCache = new Map<string | Buffer, protobuf.Root>();
 
   /**
    * In rare cases users might need to deallocate all memory consumed by loaded protos.

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -111,7 +111,7 @@ export class GrpcClient {
   grpc: GrpcModule;
   grpcVersion: string;
   fallback: boolean | 'rest' | 'proto';
-  private static protoCache = new Map<string | Buffer, grpc.GrpcObject>();
+  private static protoCache = new Map<string, grpc.GrpcObject>();
 
   /**
    * Key for proto cache map. We are doing our best to make sure we respect
@@ -292,7 +292,7 @@ export class GrpcClient {
   }
 
   loadProtoJSON(json: protobuf.INamespace, ignoreCache = false) {
-    const hash = objectHash(json);
+    const hash = objectHash(json).toString();
     const cached = GrpcClient.protoCache.get(hash);
     if (cached && !ignoreCache) {
       return cached;

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -111,7 +111,7 @@ export class GrpcClient {
   grpc: GrpcModule;
   grpcVersion: string;
   fallback: boolean | 'rest' | 'proto';
-  private static protoCache = new Map<string, grpc.GrpcObject>();
+  private static protoCache = new Map<string | Buffer, grpc.GrpcObject>();
 
   /**
    * Key for proto cache map. We are doing our best to make sure we respect


### PR DESCRIPTION
[Tests](https://github.com/googleapis/gax-nodejs/pull/1105/checks?check_run_id=3593200000) fails at 
```
Argument of type 'string | Buffer' is not assignable to parameter of type 'string'.
  Type 'Buffer' is not assignable to type 'string'.
  ```

The current `GrpcClient.protoCache` map key is `String` type.  [hash](https://github.com/googleapis/gax-nodejs/blob/main/src/fallback.ts#L137) return `String | Buffer`.

Fix Solution:
Option 1: Allow maps key has two types, String | Buffer
Option 2: Secure the key as String type, but turn the `hash` value from `objectHash` Buffer to String by using `toString()`,

