### PR TITLE
feat: promote error info field in http error

### DIFF
--- a/src/call.ts
+++ b/src/call.ts
@@ -118,7 +118,10 @@ export class OngoingCallPromise extends OngoingCall {
       rawResponse?: RawResponseType
     ) => {
       if (err) {
-        rejectCallback(GoogleError.parseGRPCStatusDetails(err));
+        if (err.metadata && err.metadata.get('grpc-status-details-bin')) {
+          rejectCallback(GoogleError.parseGRPCStatusDetails(err));
+        }
+        rejectCallback(err);
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);
       } else {

--- a/src/call.ts
+++ b/src/call.ts
@@ -118,7 +118,8 @@ export class OngoingCallPromise extends OngoingCall {
       rawResponse?: RawResponseType
     ) => {
       if (err) {
-        if (err.metadata && err.metadata.get('grpc-status-details-bin')) {
+        // If gRPC metadata exist, parsed google.rpc.status details.
+        if (err.metadata) {
           rejectCallback(GoogleError.parseGRPCStatusDetails(err));
         } else {
           rejectCallback(err);

--- a/src/call.ts
+++ b/src/call.ts
@@ -25,7 +25,7 @@ import {
   ResultTuple,
   SimpleCallbackFunction,
 } from './apitypes';
-import {GoogleError, GoogleErrorDecoder} from './googleError';
+import {GoogleError} from './googleError';
 
 export class OngoingCall {
   callback: APICallback;
@@ -118,14 +118,7 @@ export class OngoingCallPromise extends OngoingCall {
       rawResponse?: RawResponseType
     ) => {
       if (err) {
-        const decoder = new GoogleErrorDecoder();
-        try {
-          const decodedErr = decoder.decodeMetadata(err);
-          rejectCallback(decodedErr);
-        } catch (decodeErr) {
-          // Ignore the decoder error now, and return back original error.
-          rejectCallback(err);
-        }
+        rejectCallback(GoogleError.parseGRPCStatusDetails(err));
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);
       } else {

--- a/src/call.ts
+++ b/src/call.ts
@@ -120,8 +120,9 @@ export class OngoingCallPromise extends OngoingCall {
       if (err) {
         if (err.metadata && err.metadata.get('grpc-status-details-bin')) {
           rejectCallback(GoogleError.parseGRPCStatusDetails(err));
+        } else {
+          rejectCallback(err);
         }
-        rejectCallback(err);
       } else if (response !== undefined) {
         resolveCallback([response, next || null, rawResponse || null]);
       } else {

--- a/src/fallbackRest.ts
+++ b/src/fallbackRest.ts
@@ -95,6 +95,16 @@ export function decodeResponse(
       new Error(json['error']['message']),
       json.error
     );
+    // Promote the ErrorInfo fields as first-class citizen in error.
+    const errorInfo = json.error.details.find(
+      (item: {[x: string]: string}) =>
+        item['@type'] === 'type.googleapis.com/google.rpc.ErrorInfo'
+    );
+    if (errorInfo) {
+      error.reason = errorInfo.reason;
+      error.domain = errorInfo.domain;
+      error.metadata = errorInfo.metadata;
+    }
     throw error;
   }
   const message = serializer.fromProto3JSON(rpc.resolvedResponseType!, json);

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -67,7 +67,7 @@ export class GoogleError extends Error {
     // Rename "detials" to "statusDetails".
     error.statusDetails = json['error']['details'];
     delete error.details;
-    // Promote the ErrorInfo fields as first-class citizen in error.
+    // Promote the ErrorInfo fields as error's top-level.
     const errorInfo = !json['error']['details']
       ? undefined
       : json['error']['details'].find(

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -89,7 +89,7 @@ interface FallbackStatusObject {
   details: Array<{}>;
   reason?: string;
   domain?: string;
-  metadata?: {string: string};
+  errorInfoMetadata?: {string: string};
 }
 
 interface ProtobufAny {

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -76,7 +76,7 @@ interface RpcStatus {
 
 interface GRPCStatusDetailsObject {
   details: protobuf.Message<{}>[];
-  errorInfo: ErrorInfo | undefined;
+  errorInfo?: ErrorInfo;
 }
 
 interface ErrorInfo {
@@ -89,7 +89,6 @@ export class GoogleErrorDecoder {
   root: protobuf.Root;
   anyType: protobuf.Type;
   statusType: protobuf.Type;
-  errorInfoType: protobuf.Type;
 
   constructor() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -97,7 +96,6 @@ export class GoogleErrorDecoder {
     this.root = protobuf.Root.fromJSON(errorProtoJson);
     this.anyType = this.root.lookupType('google.protobuf.Any');
     this.statusType = this.root.lookupType('google.rpc.Status');
-    this.errorInfoType = this.root.lookupType('google.rpc.ErrorInfo');
   }
 
   decodeProtobufAny(anyValue: ProtobufAny): protobuf.Message<{}> {

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -63,6 +63,8 @@ export class GoogleError extends Error {
       new GoogleError(json['error']['message']),
       json.error
     );
+    // Keep consistency with gRPC statusDetails fields. gRPC details has been occupied before.
+    // Rename "detials" to "statusDetails".
     error.statusDetails = json['error']['details'];
     delete error.details;
     // Promote the ErrorInfo fields as first-class citizen in error.
@@ -75,7 +77,7 @@ export class GoogleError extends Error {
     if (errorInfo) {
       error.reason = errorInfo.reason;
       error.domain = errorInfo.domain;
-      // error.metadata has been occupized for gRPC metadata, so we use
+      // error.metadata has been occupied for gRPC metadata, so we use
       // errorInfoMetadat to represent ErrorInfo' metadata field. Keep
       // consistency with gRPC ErrorInfo metadata field name.
       error.errorInfoMetadata = errorInfo.metadata;

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -25,6 +25,7 @@ export class GoogleError extends Error {
   statusDetails?: string | protobuf.Message<{}>[];
   reason?: string;
   domain?: string;
+  errorInfoMetadata?: {string: string};
 
   // Parse details field in google.rpc.status wire over gRPC medatadata.
   // Promote google.rpc.ErrorInfo if exist.
@@ -42,11 +43,7 @@ export class GoogleError extends Error {
         if (statusDetailsObj && statusDetailsObj.errorInfo) {
           err.reason = statusDetailsObj.errorInfo.reason;
           err.domain = statusDetailsObj.errorInfo.domain;
-          for (const [key, value] of Object.entries(
-            statusDetailsObj.errorInfo.metadata
-          )) {
-            err.metadata.set(key, value);
-          }
+          err.errorInfoMetadata = statusDetailsObj.errorInfo.metadata;
         }
       }
     } catch (decodeErr) {

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -37,7 +37,11 @@ export class GoogleError extends Error {
           decoder.decodeGRPCStatusDetails(
             err.metadata.get('grpc-status-details-bin') as []
           );
-        if (statusDetailsObj && statusDetailsObj.details.length > 0) {
+        if (
+          statusDetailsObj &&
+          statusDetailsObj.details &&
+          statusDetailsObj.details.length > 0
+        ) {
           err.statusDetails = statusDetailsObj.details;
         }
         if (statusDetailsObj && statusDetailsObj.errorInfo) {
@@ -47,7 +51,7 @@ export class GoogleError extends Error {
         }
       }
     } catch (decodeErr) {
-      return err;
+      // ignoring the error
     }
     return err;
   }

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -63,6 +63,8 @@ export class GoogleError extends Error {
       new GoogleError(json['error']['message']),
       json.error
     );
+    error.statusDetails = json['error']['details'];
+    delete error.details;
     // Promote the ErrorInfo fields as first-class citizen in error.
     const errorInfo = !json['error']['details']
       ? undefined
@@ -86,7 +88,7 @@ export type FallbackServiceError = FallbackStatusObject & Error;
 interface FallbackStatusObject {
   code: Status;
   message: string;
-  details: Array<{}>;
+  statusDetails: Array<{}>;
   reason?: string;
   domain?: string;
   errorInfoMetadata?: {string: string};
@@ -165,7 +167,7 @@ export class GoogleErrorDecoder {
     const result = {
       code: status.code,
       message: status.message,
-      details,
+      statusDetails: details,
       reason: errorInfo?.reason,
       domain: errorInfo?.domain,
       errorInfoMetadata: errorInfo?.metadata,
@@ -177,7 +179,7 @@ export class GoogleErrorDecoder {
   // Adapted from https://github.com/grpc/grpc-node/blob/main/packages/grpc-js/src/call.ts#L79
   callErrorFromStatus(status: FallbackStatusObject): FallbackServiceError {
     status.message = `${status.code} ${Status[status.code]}: ${status.message}`;
-    return Object.assign(new Error(status.message), status);
+    return Object.assign(new GoogleError(status.message), status);
   }
 
   // Decodes gRPC-fallback error which is an instance of google.rpc.Status,

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -158,7 +158,11 @@ async function testEchoError(client) {
   } catch (err) {
       clearTimeout(timer);
       assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
-      const errorInfo = objs.find(item => item.type === 'google.rpc.ErrorInfo')?.value;
+      const errorInfo = objs.reduce(item => {
+        if (item.type === 'google.rpc.ErrorInfo') {
+          return item.value;
+        }});
+      assert.ok(errorInfo)
       assert.strictEqual(err.domain, errorInfo.domain)
       assert.strictEqual(err.reason, errorInfo.reason)
       assert.strictEqual(JSON.stringify(err.errorInfoMetadata), JSON.stringify(errorInfo.metadata));

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -159,8 +159,8 @@ async function testEchoError(client) {
       clearTimeout(timer);
       assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
       const errorInfo = objs.reduce(item => {
-        if (item.type === 'google.rpc.ErrorInfo') {
-          return item.value;
+        if (item['type'] === 'google.rpc.ErrorInfo') {
+          return item['value'];
         }});
       assert.ok(errorInfo)
       assert.strictEqual(err.domain, errorInfo.domain)

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -161,13 +161,7 @@ async function testEchoError(client) {
       const errorInfo = objs.find(item => item.type === 'google.rpc.ErrorInfo')?.value;
       assert.strictEqual(err.domain, errorInfo.domain)
       assert.strictEqual(err.reason, errorInfo.reason)
-      for (const [key, value] of Object.entries(errorInfo.metadata)) {
-        assert.ok(err.metadata);
-        assert.strictEqual(
-          err.metadata.get(key).shift(),
-          value
-        );
-      }
+      assert.strictEqual(JSON.stringify(err.errorInfoMetadata), JSON.stringify(errorInfo.metadata));
   }
 }
 

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -129,7 +129,7 @@ async function testEchoError(client) {
   const root = protobuf.loadSync(
     path.join(protos_path, 'error_details.proto')
   );
-  const objs = JSON.parse(data);
+  const objs = Array.from(JSON.parse(data));
   const details = [];
   const expectedDetails = [];
   for (const obj of objs) {

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -86,6 +86,7 @@ async function testShowcase() {
   await testWait(grpcClient);
 
   await testEcho(fallbackClient);
+  await testEchoError(fallbackClient, true);
   await testPagedExpand(fallbackClient);
   await testWait(fallbackClient);
   await testPagedExpandAsync(fallbackClient);
@@ -103,7 +104,7 @@ async function testEcho(client) {
   assert.deepStrictEqual(request.content, response.content);
 }
 
-async function testEchoError(client) {
+async function testEchoError(client, rest) {
   const readFile = util.promisify(fs.readFile);
 
   const fixtureName = path.resolve(
@@ -161,7 +162,7 @@ async function testEchoError(client) {
       await client.echo(request);
   } catch (err) {
       clearTimeout(timer);
-      assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
+      assert.strictEqual(rest ? JSON.stringify(err.details) : JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
       assert.ok(errorInfo)
       assert.strictEqual(err.domain, errorInfo.domain)
       assert.strictEqual(err.reason, errorInfo.reason)

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -86,7 +86,7 @@ async function testShowcase() {
   await testWait(grpcClient);
 
   await testEcho(fallbackClient);
-  await testEchoError(fallbackClient, true);
+  await testEchoError(fallbackClient);
   await testPagedExpand(fallbackClient);
   await testWait(fallbackClient);
   await testPagedExpandAsync(fallbackClient);
@@ -104,7 +104,7 @@ async function testEcho(client) {
   assert.deepStrictEqual(request.content, response.content);
 }
 
-async function testEchoError(client, rest) {
+async function testEchoError(client) {
   const readFile = util.promisify(fs.readFile);
 
   const fixtureName = path.resolve(
@@ -162,7 +162,7 @@ async function testEchoError(client, rest) {
       await client.echo(request);
   } catch (err) {
       clearTimeout(timer);
-      assert.strictEqual(rest ? JSON.stringify(err.details) : JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
+      assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
       assert.ok(errorInfo)
       assert.strictEqual(err.domain, errorInfo.domain)
       assert.strictEqual(err.reason, errorInfo.reason)

--- a/test/fixtures/google-gax-packaging-test-app/src/index.js
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.js
@@ -129,7 +129,7 @@ async function testEchoError(client) {
   const root = protobuf.loadSync(
     path.join(protos_path, 'error_details.proto')
   );
-  const objs = Array.from(JSON.parse(data));
+  const objs = JSON.parse(JSON.stringify(data));
   const details = [];
   const expectedDetails = [];
   for (const obj of objs) {
@@ -158,10 +158,7 @@ async function testEchoError(client) {
   } catch (err) {
       clearTimeout(timer);
       assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
-      const errorInfo = objs.reduce(item => {
-        if (item['type'] === 'google.rpc.ErrorInfo') {
-          return item['value'];
-        }});
+      const errorInfo = objs.find(item => item.type === 'google.rpc.ErrorInfo').value;
       assert.ok(errorInfo)
       assert.strictEqual(err.domain, errorInfo.domain)
       assert.strictEqual(err.reason, errorInfo.reason)

--- a/test/unit/fallbackError.ts
+++ b/test/unit/fallbackError.ts
@@ -109,7 +109,7 @@ describe('gRPC-fallback error decoding', () => {
         details: [errorInfo],
         reason: errorInfo.reason,
         domain: errorInfo.domain,
-        metadata: errorInfo.metadata,
+        errorInfoMetadata: errorInfo.metadata,
       }
     );
     const status = Object.assign(new Error('mock error.'), {
@@ -122,9 +122,8 @@ describe('gRPC-fallback error decoding', () => {
     });
     const Status = root.lookupType('google.rpc.Status');
     const statusBuffer = Status.encode(status).finish() as Buffer;
-    const errorBin = fs.readFileSync(statusBuffer);
     const decoder = new GoogleErrorDecoder();
-    const decodedError = decoder.decodeErrorFromBuffer(errorBin);
+    const decodedError = decoder.decodeErrorFromBuffer(statusBuffer);
     assert(decodedError instanceof Error);
     // nested error messages have different types so we can't use deepStrictEqual here
     assert.strictEqual(

--- a/test/unit/fallbackError.ts
+++ b/test/unit/fallbackError.ts
@@ -19,7 +19,7 @@ import {describe, it} from 'mocha';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
-import {GoogleErrorDecoder} from '../../src/googleError';
+import {GoogleError, GoogleErrorDecoder} from '../../src/googleError';
 
 describe('gRPC-fallback error decoding', () => {
   it('decodes error', () => {
@@ -42,11 +42,11 @@ describe('gRPC-fallback error decoding', () => {
     };
     const decoder = new GoogleErrorDecoder();
     const decodedError = decoder.decodeRpcStatus(errorBin);
-
-    // nested error messages have different types so we can't use deepStrictEqual here
+    assert.strictEqual(decodedError.code, expectedError.code);
+    assert.strictEqual(decodedError.message, expectedError.message);
     assert.strictEqual(
-      JSON.stringify(decodedError),
-      JSON.stringify(expectedError)
+      JSON.stringify(decodedError.statusDetails),
+      JSON.stringify(expectedError.details)
     );
   });
 
@@ -74,11 +74,13 @@ describe('gRPC-fallback error decoding', () => {
     );
     const decoder = new GoogleErrorDecoder();
     const decodedError = decoder.decodeErrorFromBuffer(errorBin);
-    assert(decodedError instanceof Error);
-    // nested error messages have different types so we can't use deepStrictEqual here
+    assert(decodedError instanceof GoogleError);
+
+    assert.strictEqual(decodedError.code, expectedError.code);
+    assert.strictEqual(decodedError.message, expectedError.message);
     assert.strictEqual(
-      JSON.stringify(decodedError),
-      JSON.stringify(expectedError)
+      JSON.stringify(decodedError.statusDetails),
+      JSON.stringify(expectedError.details)
     );
   });
 
@@ -127,11 +129,12 @@ describe('gRPC-fallback error decoding', () => {
     const statusBuffer = Status.encode(status).finish() as Buffer;
     const decoder = new GoogleErrorDecoder();
     const decodedError = decoder.decodeErrorFromBuffer(statusBuffer);
-    assert(decodedError instanceof Error);
-    // nested error messages have different types so we can't use deepStrictEqual here
+    assert(decodedError instanceof GoogleError);
+    assert.strictEqual(decodedError.code, expectedError.code);
+    assert.strictEqual(decodedError.message, expectedError.message);
     assert.strictEqual(
-      JSON.stringify(decodedError),
-      JSON.stringify(expectedError)
+      JSON.stringify(decodedError.statusDetails),
+      JSON.stringify(expectedError.details)
     );
   });
 });

--- a/test/unit/fallbackError.ts
+++ b/test/unit/fallbackError.ts
@@ -44,7 +44,10 @@ describe('gRPC-fallback error decoding', () => {
     const decodedError = decoder.decodeRpcStatus(errorBin);
 
     // nested error messages have different types so we can't use deepStrictEqual here
-    assert.equal(JSON.stringify(decodedError), JSON.stringify(expectedError));
+    assert.strictEqual(
+      JSON.stringify(decodedError),
+      JSON.stringify(expectedError)
+    );
   });
 
   it('decodes error and status code', () => {

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -203,13 +203,10 @@ describe('parse grpc status details with ErrorInfo from grpc metadata', () => {
     assert(decodedError instanceof GoogleError);
     assert.strictEqual(decodedError.domain, errorInfoObj.domain);
     assert.strictEqual(decodedError.reason, errorInfoObj.reason);
-    for (const [key, value] of Object.entries(errorInfoObj.metadata)) {
-      assert.ok(decodedError.metadata);
-      assert.strictEqual(
-        (decodedError.metadata.get(key) as Array<string>).shift(),
-        value
-      );
-    }
+    assert.strictEqual(
+      JSON.stringify(decodedError.errorInfoMetadata),
+      JSON.stringify(errorInfoObj.metadata)
+    );
   });
   it('metadata has no key grpc-status-details-bin', async () => {
     const metadata = new Metadata();

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -87,10 +87,10 @@ describe('gRPC-google error decoding', () => {
 
   it('does not decode when no error exists', () => {
     // example of when there's no grpc-error available to be decoded
-    const emptyBuffer: Buffer[] = [];
+    const emptyArr: Buffer[] = [];
     const decoder = new GoogleErrorDecoder();
 
-    const gRPCStatusDetailsObj = decoder.decodeGRPCStatusDetails(emptyBuffer);
+    const gRPCStatusDetailsObj = decoder.decodeGRPCStatusDetails(emptyArr);
 
     // nested error messages have different types so we can't use deepStrictEqual here
     assert.strictEqual(

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -111,7 +111,7 @@ describe('gRPC-google error decoding', () => {
 
     assert.strictEqual(
       JSON.stringify(decodedError),
-      '{"code":3,"message":"test","details":[]}'
+      '{"code":3,"message":"test","statusDetails":[]}'
     );
   });
 

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -313,9 +313,13 @@ describe('grpc-fallback', () => {
     );
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
-        assert(err instanceof Error);
+        assert(err instanceof GoogleError);
         assert.strictEqual(err.message, expectedMessage);
-        assert.strictEqual(JSON.stringify(err), JSON.stringify(expectedError));
+        assert.strictEqual(err.code, expectedError.code);
+        assert.strictEqual(
+          JSON.stringify(err.statusDetails),
+          JSON.stringify(expectedError.details)
+        );
         done();
       });
     });
@@ -371,6 +375,11 @@ describe('grpc-fallback', () => {
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         assert(err instanceof GoogleError);
+        assert.strictEqual(
+          JSON.stringify(err.statusDetails),
+          JSON.stringify(serverError['error']['details'])
+        );
+        assert.strictEqual(err.code, serverError['error']['code']);
         assert.strictEqual(err.message, serverError['error']['message']);
         assert.strictEqual(err.reason, errorInfo.reason);
         assert.strictEqual(err.domain, errorInfo.domain);

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -27,6 +27,7 @@ import * as protobuf from 'protobufjs';
 import * as sinon from 'sinon';
 import {echoProtoJson} from '../fixtures/echoProtoJson';
 import {GrpcClient} from '../../src/fallback';
+import {GoogleError} from '../../src';
 
 // @ts-ignore
 const hasAbortController = typeof AbortController !== 'undefined';
@@ -310,12 +311,73 @@ describe('grpc-fallback', () => {
         },
       })
     );
-
     gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
       echoStub.echo(requestObject, {}, {}, (err?: Error) => {
         assert(err instanceof Error);
         assert.strictEqual(err.message, expectedMessage);
         assert.strictEqual(JSON.stringify(err), JSON.stringify(expectedError));
+        done();
+      });
+    });
+  });
+
+  it('should promote ErrorInfo if exist in fallback-rest error', done => {
+    const requestObject = {content: 'test-content'};
+    // example of an actual google.rpc.Status error message returned by Translate API
+    const errorInfo = {
+      '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+      reason: 'SERVICE_DISABLED',
+      domain: 'googleapis.com',
+      metadata: {
+        service: 'translate.googleapis.com',
+        consumer: 'projects/123',
+      },
+    };
+    const serverError = {
+      error: {
+        code: 403,
+        message:
+          'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
+        status: 'PERMISSION_DENIED',
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.rpc.Help',
+            links: [
+              {
+                description: 'Google developers console API activation',
+                url: 'https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361',
+              },
+            ],
+          },
+          errorInfo,
+        ],
+      },
+    };
+    const opts = {
+      auth: authStub,
+      fallback: 'rest',
+    };
+    // @ts-ignore incomplete options
+    gaxGrpc = new GrpcClient(opts);
+    //@ts-ignore
+    sinon.stub(nodeFetch, 'Promise').returns(
+      Promise.resolve({
+        ok: false,
+        arrayBuffer: () => {
+          return Promise.resolve(Buffer.from(JSON.stringify(serverError)));
+        },
+      })
+    );
+    gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+      echoStub.echo(requestObject, {}, {}, (err?: Error) => {
+        assert(err instanceof GoogleError);
+        assert.strictEqual(err.message, serverError['error']['message']);
+        assert.strictEqual(err.reason, errorInfo.reason);
+        assert.strictEqual(err.domain, errorInfo.domain);
+        assert.strictEqual(
+          JSON.stringify(err.errorInfoMetadata),
+          JSON.stringify(errorInfo.metadata)
+        );
         done();
       });
     });


### PR DESCRIPTION
Keep debug experience consistency between GAPIC and REGAPIC.
Parse fallback error and promote the ErrorInfo field. Two type fallback decoder in gax:
- fallbackProto:: decodeReponse
- fallbackRest:: decodeReponse

Add integration test for Rest client

Open questions: Do we need to rename `details` field to `statusDetails` in Rest Client error object.
In GAPIC, the `details` fields has been occupized, so when decode `google.rpc.status` `details` field, we rename as `statusDetails`. 
Good to change the name is keep consistency with GAPIC.
Bad to change the name is that it is considered as break change.
@alexander-fenster @bcoe Can I have your opinion on this? Thank you.

Example call translate rest client with receiving http error:
before:
```
Error: Cloud Translation API has not been used in project ... 
{
  code: 403,
  status: 'PERMISSION_DENIED',
  details: [
    { '@type': 'type.googleapis.com/google.rpc.Help', links: [Array] },
    {
      '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
      reason: 'SERVICE_DISABLED',
      domain: 'googleapis.com',
      metadata: [Object]
    }
  ]
}
```
after
```
{
  code: 403,
  status: 'PERMISSION_DENIED',
  statusDetails: [
    { '@type': 'type.googleapis.com/google.rpc.Help', links: [Array] },
    {
      '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
      reason: 'SERVICE_DISABLED',
      domain: 'googleapis.com',
      metadata: [Object]
    }
  ]
  reason: 'SERVICE_DISABLED',
  domain: 'googleapis.com',
  errorInfoMetadata: {
      consumer: 'projects/...',
      service: 'translate.googleapis.com'
  }
}
```