### PR TITLE
fix: handle stream has no metadata event

### DIFF
--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -129,9 +129,9 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
       stream.on(event, this.emit.bind(this, event));
     });
 
-    // gRPC guaranteed emit the 'status' event but not 'metadata'. And 'status' is the last event to be emit.
+    // gRPC is guaranteed emit the 'status' event but not 'metadata', and 'status' is the last event to emit.
     // Emit the 'response' event if stream has no 'metadata' event.
-    // This avoids stream swallow the other events, such as 'end'.
+    // This avoids the stream swallowing the other events, such as 'end'.
     stream.on('status', () => {
       if (!this._responseHasSent) {
         stream.emit('response', {

--- a/test/unit/streaming.ts
+++ b/test/unit/streaming.ts
@@ -257,71 +257,6 @@ describe('streaming', () => {
     }, 50);
   });
 
-  it('Not receive metadata event', done => {
-    const responseMetadata = {metadata: true};
-    const status = {code: 0, metadata: responseMetadata};
-    const expectedResponse = {
-      code: 200,
-      message: 'OK',
-      details: '',
-      metadata: responseMetadata,
-    };
-    function func() {
-      const s = new PassThrough({
-        objectMode: true,
-      });
-      s.on('finish', () => {
-        s.emit('status', status);
-      });
-      return s;
-    }
-    const apiCall = createApiCallStreaming(
-      //@ts-ignore
-      func,
-      streaming.StreamType.BIDI_STREAMING
-    );
-    const s = apiCall({}, undefined);
-    const metadataCallback = sinon.spy();
-    let receivedStatus: {};
-    let receivedResponse: {};
-    let finished = false;
-
-    function check() {
-      if (
-        typeof receivedStatus !== 'undefined' &&
-        typeof receivedResponse !== 'undefined' &&
-        finished
-      ) {
-        assert.deepStrictEqual(receivedStatus, status);
-        assert.deepStrictEqual(receivedResponse, expectedResponse);
-        done();
-      }
-    }
-
-    s.on('metadata', metadataCallback);
-    s.on('status', data => {
-      receivedStatus = data;
-      check();
-    });
-    s.on('response', data => {
-      receivedResponse = data;
-      check();
-    });
-    s.on('finish', () => {
-      finished = true;
-      check();
-    });
-    assert.strictEqual(s.readable, true);
-    assert.strictEqual(s.writable, true);
-    setTimeout(() => {
-      s.end(s);
-    }, 50);
-    s.on('end', () => {
-      assert.strictEqual(metadataCallback.callCount, 0);
-      done();
-    });
-  });
-
   it('cancels in the middle', done => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function schedulePush(s: any, c: number) {
@@ -369,6 +304,152 @@ describe('streaming', () => {
     s.on('error', err => {
       assert.strictEqual(err, cancelError);
       done();
+    });
+  });
+
+  it('emit response when stream received metadata event', done => {
+    const responseMetadata = {metadata: true};
+    const expectedStatus = {code: 0, metadata: responseMetadata};
+    const expectedResponse = {
+      code: 200,
+      message: 'OK',
+      details: '',
+      metadata: responseMetadata,
+    };
+    const spy = sinon.spy((...args: Array<{}>) => {
+      assert.strictEqual(args.length, 3);
+      const s = new PassThrough({
+        objectMode: true,
+      });
+      s.push(null);
+      setImmediate(() => {
+        s.emit('metadata', responseMetadata);
+      });
+      s.on('end', () => {
+        setTimeout(() => {
+          s.emit('status', expectedStatus);
+        }, 10);
+      });
+      return s;
+    });
+
+    const apiCall = createApiCallStreaming(
+      spy,
+      streaming.StreamType.SERVER_STREAMING
+    );
+    const s = apiCall({}, undefined);
+    let receivedMetadata: {};
+    let receivedStatus: {};
+    let receivedResponse: {};
+    let ended = false;
+
+    function check() {
+      if (
+        typeof receivedMetadata !== 'undefined' &&
+        typeof receivedStatus !== 'undefined' &&
+        typeof receivedResponse !== 'undefined' &&
+        ended
+      ) {
+        assert.deepStrictEqual(receivedMetadata, responseMetadata);
+        assert.deepStrictEqual(receivedStatus, expectedStatus);
+        assert.deepStrictEqual(receivedResponse, expectedResponse);
+        done();
+      }
+    }
+
+    const dataCallback = sinon.spy(data => {
+      assert.deepStrictEqual(data, undefined);
+    });
+    const responseCallback = sinon.spy();
+    assert.strictEqual(s.readable, true);
+    assert.strictEqual(s.writable, false);
+    s.on('data', dataCallback);
+    s.on('metadata', data => {
+      receivedMetadata = data;
+      check();
+    });
+    s.on('response', data => {
+      receivedResponse = data;
+      responseCallback();
+      check();
+    });
+    s.on('status', data => {
+      receivedStatus = data;
+      check();
+    });
+    s.on('end', () => {
+      ended = true;
+      check();
+      assert.strictEqual(dataCallback.callCount, 0);
+      assert.strictEqual(responseCallback.callCount, 1);
+    });
+  });
+
+  it('emit response when stream received no metadata event', done => {
+    const responseMetadata = {metadata: true};
+    const expectedStatus = {code: 0, metadata: responseMetadata};
+    const expectedResponse = {
+      code: 200,
+      message: 'OK',
+      details: '',
+    };
+    const spy = sinon.spy((...args: Array<{}>) => {
+      assert.strictEqual(args.length, 3);
+      const s = new PassThrough({
+        objectMode: true,
+      });
+      s.push(null);
+      s.on('end', () => {
+        setTimeout(() => {
+          console.log('emit status event')
+          s.emit('status', expectedStatus);
+        }, 10);
+      });
+      return s;
+    });
+
+    const apiCall = createApiCallStreaming(
+      spy,
+      streaming.StreamType.SERVER_STREAMING
+    );
+    const s = apiCall({}, undefined);
+    let receivedStatus: {};
+    let receivedResponse: {};
+    let ended = false;
+
+    function check() {
+      if (
+        typeof receivedStatus !== 'undefined' &&
+        typeof receivedResponse !== 'undefined' &&
+        ended
+      ) {
+        assert.deepStrictEqual(receivedStatus, expectedStatus);
+        assert.deepStrictEqual(receivedResponse, expectedResponse);
+        done();
+      }
+    }
+
+    const dataCallback = sinon.spy(data => {
+      assert.deepStrictEqual(data, undefined);
+    });
+    const responseCallback = sinon.spy();
+    assert.strictEqual(s.readable, true);
+    assert.strictEqual(s.writable, false);
+    s.on('data', dataCallback);
+    s.on('response', data => {
+      receivedResponse = data;
+      responseCallback();
+      check();
+    });
+    s.on('status', data => {
+      receivedStatus = data;
+      check();
+    });
+    s.on('end', () => {
+      ended = true;
+      check();
+      assert.strictEqual(dataCallback.callCount, 0);
+      assert.strictEqual(responseCallback.callCount, 1);
     });
   });
 });

--- a/test/unit/streaming.ts
+++ b/test/unit/streaming.ts
@@ -401,7 +401,7 @@ describe('streaming', () => {
       s.push(null);
       s.on('end', () => {
         setTimeout(() => {
-          console.log('emit status event')
+          console.log('emit status event');
           s.emit('status', expectedStatus);
         }, 10);
       });


### PR DESCRIPTION
When a user call `BigTable` server-stream API `readrows`, the `end` event get stuck when the BigTable is empty. This can be reproduce on local Java emulator, not on production and Node.js emulator.

The root cause is that `grpc` handle the proxy `metadata` differently, no `metadata` event emit for Java emulator. (https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/call-stream.ts#L527)
However, `gax` emit the `response` event once the grpc stream received the `metadata`, since the `metadata` has never been received in Java emulator case, stream seems swallow the `end` event.

Fix: grpc guaranteed `status` event, so we emit the response when received `status` event for no `metadata` event.

Sample code Java emulator
```
public class Main {
  public static void main(String[] args) throws Exception {
    Server server = ServerBuilder.forPort(1234)
        .addService(new BigtableImplBase() {
          @Override
          public void readRows(ReadRowsRequest request,
              StreamObserver<ReadRowsResponse> responseObserver) {
            System.out.println("readRows!, request:: " + request);
            responseObserver.onCompleted();
          }
        })
        .build();
    server.start();
    server.awaitTermination();
  }
}
``` 
Please reach out @summer-ji-eng if you need more detailed and internal information.