### PR TITLE
feat: map http status code to grpc status code

### DIFF
--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Status} from './status';
+import {Status, rpcCodeFromHttpStatusCode} from './status';
 import * as protobuf from 'protobufjs';
 import {Metadata} from './grpc';
 
@@ -63,6 +63,11 @@ export class GoogleError extends Error {
       new GoogleError(json['error']['message']),
       json.error
     );
+    // Map Http Status Code to gRPC Status Code
+    if (json['error']['code']) {
+      error.code = rpcCodeFromHttpStatusCode(json['error']['code']);
+    }
+
     // Keep consistency with gRPC statusDetails fields. gRPC details has been occupied before.
     // Rename "detials" to "statusDetails".
     error.statusDetails = json['error']['details'];

--- a/src/status.ts
+++ b/src/status.ts
@@ -38,3 +38,38 @@ export enum Status {
   DATA_LOSS,
   UNAUTHENTICATED,
 }
+
+export const HttpCodeToRpcCodeMap = new Map([
+  [400, Status.INVALID_ARGUMENT],
+  [401, Status.UNAUTHENTICATED],
+  [403, Status.PERMISSION_DENIED],
+  [404, Status.NOT_FOUND],
+  [409, Status.ABORTED],
+  [416, Status.OUT_OF_RANGE],
+  [429, Status.RESOURCE_EXHAUSTED],
+  [499, Status.CANCELLED],
+  [501, Status.UNIMPLEMENTED],
+  [503, Status.UNAVAILABLE],
+  [504, Status.DEADLINE_EXCEEDED],
+]);
+
+// Maps HTTP status codes to gRPC status codes above.
+export function rpcCodeFromHttpStatusCode(httpStatusCode: number): number {
+  if (HttpCodeToRpcCodeMap.has(httpStatusCode)) {
+    return HttpCodeToRpcCodeMap.get(httpStatusCode)!;
+  }
+  // All 2xx
+  if (httpStatusCode >= 200 && httpStatusCode < 300) {
+    return Status.OK;
+  }
+  // All other 4xx
+  if (httpStatusCode >= 400 && httpStatusCode < 500) {
+    return Status.FAILED_PRECONDITION;
+  }
+  // All other 5xx
+  if (httpStatusCode >= 500 && httpStatusCode < 600) {
+    return Status.INTERNAL;
+  }
+  // Everything else
+  return Status.UNKNOWN;
+}

--- a/test/unit/grpc-fallback.ts
+++ b/test/unit/grpc-fallback.ts
@@ -379,7 +379,7 @@ describe('grpc-fallback', () => {
           JSON.stringify(err.statusDetails),
           JSON.stringify(serverError['error']['details'])
         );
-        assert.strictEqual(err.code, serverError['error']['code']);
+        assert.strictEqual(err.code, 7);
         assert.strictEqual(err.message, serverError['error']['message']);
         assert.strictEqual(err.reason, errorInfo.reason);
         assert.strictEqual(err.domain, errorInfo.domain);

--- a/test/unit/status.ts
+++ b/test/unit/status.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/status.ts
+++ b/test/unit/status.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {describe, it} from 'mocha';
+import {rpcCodeFromHttpStatusCode} from '../../src/status';
+
+describe('status.ts', () => {
+  it('rpcCodeFromHttpStatusCode', () => {
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(200), 0);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(206), 0);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(300), 2);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(307), 2);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(400), 3);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(401), 16);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(403), 7);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(404), 5);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(409), 10);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(416), 11);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(429), 8);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(499), 1);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(451), 9);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(411), 9);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(501), 12);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(503), 14);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(504), 4);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(505), 13);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(510), 13);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(100), 2);
+  });
+});

--- a/test/unit/status.ts
+++ b/test/unit/status.ts
@@ -16,29 +16,53 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {rpcCodeFromHttpStatusCode} from '../../src/status';
+import {rpcCodeFromHttpStatusCode, Status} from '../../src/status';
 
 describe('status.ts', () => {
   it('rpcCodeFromHttpStatusCode', () => {
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(200), 0);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(206), 0);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(300), 2);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(307), 2);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(400), 3);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(401), 16);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(403), 7);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(404), 5);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(409), 10);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(416), 11);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(429), 8);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(499), 1);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(451), 9);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(411), 9);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(501), 12);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(503), 14);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(504), 4);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(505), 13);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(510), 13);
-    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(100), 2);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(200), Status.OK);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(206), Status.OK);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(300), Status.UNKNOWN);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(307), Status.UNKNOWN);
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(400),
+      Status.INVALID_ARGUMENT
+    );
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(401),
+      Status.UNAUTHENTICATED
+    );
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(403),
+      Status.PERMISSION_DENIED
+    );
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(404), Status.NOT_FOUND);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(409), Status.ABORTED);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(416), Status.OUT_OF_RANGE);
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(429),
+      Status.RESOURCE_EXHAUSTED
+    );
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(499), Status.CANCELLED);
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(451),
+      Status.FAILED_PRECONDITION
+    );
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(411),
+      Status.FAILED_PRECONDITION
+    );
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(501),
+      Status.UNIMPLEMENTED
+    );
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(503), Status.UNAVAILABLE);
+    assert.deepStrictEqual(
+      rpcCodeFromHttpStatusCode(504),
+      Status.DEADLINE_EXCEEDED
+    );
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(505), Status.INTERNAL);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(510), Status.INTERNAL);
+    assert.deepStrictEqual(rpcCodeFromHttpStatusCode(100), Status.UNKNOWN);
   });
 });


### PR DESCRIPTION
Implement Canonical error code / HTTP mapping googleapis/google-cloud-node-core#356

HTTP | Canonical
-- | --
2xx | OK (0)
3xx | UNKNOWN (2)
400 Bad request | INVALID_ARGUMENT (3)
401 Unauthorized | UNAUTHENTICATED (16)
403 Forbidden | PERMISSION_DENIED (7)
404 Not found | NOT_FOUND (5)
409 Conflict | ABORTED (10)
416 Requested range not satisfiable | OUT_OF_RANGE (11)
429 Too many requests | RESOURCE_EXHAUSTED (8)
499 Client closed request | CANCELLED (1)
Other 4xx | FAILED_PRECONDITION (9)
501 Not implemented | UNIMPLEMENTED (12)
503 Service unavailable | UNAVAILABLE (14)
504 Gateway Time-out | DEADLINE_EXCEEDED (4)
Other 5xx | INTERNAL (13)
All others (includes 100s) | UNKNOWN (2)
