### PR TITLE
fix: support field name with period

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 15]
+        node: [12, 14, 15]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 15]
+        node: [10, 12, 14, 15]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,7 +40,7 @@ function capitalize(str: string) {
 export function snakeToCamelCase(str: string) {
   // split on spaces, non-alphanumeric, or capital letters
   const splitted = str
-    .split(/(?=[A-Z])|[\s\W_]+/)
+    .split(/(?=[A-Z])|(?:(?!\.)[\s\W_])+/)
     .filter(w => w.length > 0)
     // Keep the capitalization for the first split.
     .map((word, index) => (index === 0 ? word : word.toLowerCase()));

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -28,6 +28,7 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('iPProtocol'), 'i_p_protocol');
     assert.strictEqual(camelToSnakeCase('a.1'), 'a.1');
     assert.strictEqual(camelToSnakeCase('abc.1Foo'), 'abc.1_foo');
+    assert.strictEqual(camelToSnakeCase('abc.foo'), 'abc.foo');
   });
 
   it('snakeToCamelCase', () => {
@@ -38,5 +39,6 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('I_p_protocol'), 'IPProtocol');
     assert.strictEqual(snakeToCamelCase('a.1'), 'a.1');
     assert.strictEqual(snakeToCamelCase('abc.1_foo'), 'abc.1Foo');
+    assert.strictEqual(snakeToCamelCase('abc.foo'), 'abc.foo');
   });
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -26,6 +26,8 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('testAbcDef'), 'test_abc_def');
     assert.strictEqual(camelToSnakeCase('IPProtocol'), 'I_p_protocol');
     assert.strictEqual(camelToSnakeCase('iPProtocol'), 'i_p_protocol');
+    assert.strictEqual(camelToSnakeCase('a.1'), 'a.1');
+    assert.strictEqual(camelToSnakeCase('abc.1Foo'), 'abc.1_foo');
   });
 
   it('snakeToCamelCase', () => {
@@ -34,5 +36,7 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('test_abc'), 'testAbc');
     assert.strictEqual(snakeToCamelCase('test_abc_def'), 'testAbcDef');
     assert.strictEqual(snakeToCamelCase('I_p_protocol'), 'IPProtocol');
+    assert.strictEqual(snakeToCamelCase('a.1'), 'a.1');
+    assert.strictEqual(snakeToCamelCase('abc.1_foo'), 'abc.1Foo');
   });
 });


### PR DESCRIPTION
For REST mode, the period `.` value in the field has been stripped.
For example, the request
```
{'a.1': 'foo'}
```
after transcode, it becomes 
```
{'a1': 'foo'}
```

[System-test](https://github.com/googleapis/nodejs-firestore/blob/main/dev/system-test/firestore.ts#L662) in firestore