### PR TITLE
fix: refactor the showcase stream method collect

### DIFF
--- a/test/fixtures/google-gax-packaging-test-app/src/index.ts
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.ts
@@ -195,7 +195,7 @@ async function testExpand(client: EchoClient) {
   const request = {
     content: words.join(' '),
   };
-  const stream = await client.expand(request);
+  const stream = client.expand(request);
   const result: string[] = [];
     stream.on('data', (response: {content: string}) => {
       result.push(response.content);
@@ -242,13 +242,14 @@ async function testPagedExpandAsync(client: EchoClient) {
 
 async function testCollect(client: EchoClient) {
   const words = ['nobody', 'ever', 'reads', 'test', 'input'];
-  const stream = await client.collect((err: Error, result: {content: string}) => {
-    assert.deepStrictEqual(result.content, words.join(' '));
-  });
+  const stream = await client.collect();
   for (const word of words) {
       const request = { content: word };
       stream.write(request);
-    }
+  }
+  stream.on('data', (result: { content: String; }) => {
+    assert.deepStrictEqual(result.content, words.join(' '))
+  })
   stream.end();
 }
 

--- a/test/fixtures/google-gax-packaging-test-app/src/index.ts
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.ts
@@ -242,7 +242,7 @@ async function testPagedExpandAsync(client: EchoClient) {
 
 async function testCollect(client: EchoClient) {
   const words = ['nobody', 'ever', 'reads', 'test', 'input'];
-  const stream = await client.collect();
+  const stream = client.collect();
   for (const word of words) {
       const request = { content: word };
       stream.write(request);


### PR DESCRIPTION
The compiler complains the augment type error for showcase test on stream method `collect`
```
test/fixtures/google-gax-packaging-test-app/src/index.ts:245:39 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(options?: CallOptions | undefined, callback?: Callback<IEchoResponse, IEchoRequest | null | undefined, {} | null | undefined> | undefined): CancellableStream', gave the following error.
    Type '(err: Error, result: { content: string; }) => void' has no properties in common with type 'CallOptions'.
  Overload 2 of 2, '(callback?: Callback<IEchoResponse, IEchoRequest | null | undefined, {} | null | undefined> | undefined): CancellableStream', gave the following error.
    Argument of type '(err: Error, result: {    content: string;}) => void' is not assignable to parameter of type 'Callback<IEchoResponse, IEchoRequest | null | undefined, {} | null | undefined>'.
      Types of parameters 'err' and 'err' are incompatible.
        Type 'Error | null | undefined' is not assignable to type 'Error'.
          Type 'undefined' is not assignable to type 'Error'.

245   const stream = await client.collect((err: Error, result: {content: string}) => {
```