### PR TITLE
fix: support non-alphanumeric field name

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -40,8 +40,8 @@ function capitalize(str: string) {
 export function snakeToCamelCase(str: string) {
   // split on spaces, non-alphanumeric, or capital letters
   const splitted = str
-    .split(/(?=[A-Z])|(?:(?!\.)[\s\W_])+/)
-    .filter(w => w.length > 0)
+    .split(/(?=[A-Z])|(?:(?!(_(\W+)))[\s_])+/)
+    .filter(w => w && w.length > 0)
     // Keep the capitalization for the first split.
     .map((word, index) => (index === 0 ? word : word.toLowerCase()));
   if (splitted.length === 0) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,7 +38,7 @@ function capitalize(str: string) {
  * camelCase (used by protobuf.js)
  */
 export function snakeToCamelCase(str: string) {
-  // split on spaces, non-alphanumeric, or capital letters
+  // split on spaces, underscore, or capital letters
   const splitted = str
     .split(/(?=[A-Z])|(?:(?!(_(\W+)))[\s_])+/)
     .filter(w => w && w.length > 0)

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -29,6 +29,10 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('a.1'), 'a.1');
     assert.strictEqual(camelToSnakeCase('abc.1Foo'), 'abc.1_foo');
     assert.strictEqual(camelToSnakeCase('abc.foo'), 'abc.foo');
+    assert.strictEqual(camelToSnakeCase('a!.\\'), 'a!.\\');
+    assert.strictEqual(camelToSnakeCase('!._\\`'), '!._\\`');
+    assert.strictEqual(camelToSnakeCase('a!B`'), 'a!_b`');
+    assert.strictEqual(camelToSnakeCase('a.1B`'), 'a.1_b`');
   });
 
   it('snakeToCamelCase', () => {
@@ -40,5 +44,9 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('a.1'), 'a.1');
     assert.strictEqual(snakeToCamelCase('abc.1_foo'), 'abc.1Foo');
     assert.strictEqual(snakeToCamelCase('abc.foo'), 'abc.foo');
+    assert.strictEqual(snakeToCamelCase('a!.\\`'), 'a!.\\`');
+    assert.strictEqual(snakeToCamelCase('!._\\`'), '!._\\`');
+    assert.strictEqual(snakeToCamelCase('a!_b`'), 'a!B`');
+    assert.strictEqual(snakeToCamelCase('a.1_b`'), 'a.1B`');
   });
 });


### PR DESCRIPTION
Currently REST mode transcode doesn't support non-alphanumeric in the field name, and it cause [firestore test](https://github.com/googleapis/nodejs-firestore/blob/main/dev/system-test/firestore.ts#L754-L771) fails.

code sample:
```
test() {
    const ref = randomCol.doc('doc');
    return ref
      .set({'!.\\`': {'!.\\`': 'value'}})
      .then(() => {
        return ref.get();
      })
      .then(doc => {
        // SEE ERROR ON THIS LINE
        expect(doc.data()).to.deep.equal({'!.\\`': {'!.\\`': 'value'}});
        return ref.update(new 
FieldPath('!.\\`', '!.\\`'), 'new-value');
      })
      .then(() => {
        return ref.get();
      })
      .then(doc => {
        expect(doc.data()).to.deep.equal({'!.\\`': {'!.\\`': 'new-value'}});
      });
}
```

Error
```
AssertionError: expected { '.': { '.': 'value' } } to deeply equal { '!.\\`': { '!.\\`': 'value' } }
```