### PR TITLE
fix: handle undefined stream callback 

### DIFF
--- a/src/fallbackServiceStub.ts
+++ b/src/fallbackServiceStub.ts
@@ -137,7 +137,10 @@ export function generateServiceStub(
                   (!cancelRequested ||
                     (err instanceof Error && err.name !== 'AbortError'))
                 ) {
-                  callback(err);
+                  if (callback) {
+                    callback(err);
+                  }
+                  streamArrayParser.emit('error', err);
                 }
               }
             );


### PR DESCRIPTION
If a callback is undefined, rest stream call throw error `Uncaught TypeError: callback is not a function`.