### PR TITLE
fix: match http error with grpc error pattern

### DIFF
--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -71,7 +71,7 @@ export class GoogleError extends Error {
         Status[rpcCode] !== json['error']['status']
       ) {
         console.warn(
-          `Internal Error: Recieved HTTP error status ${json['error']['status']} doesn't match gRPC status ${Status[rpcCode]}.`
+          `Internal Error: Received HTTP error status ${json['error']['status']} doesn't match gRPC status ${Status[rpcCode]}.`
         );
       }
       const rpcErrMsg = `${rpcCode} ${Status[rpcCode]}: ${json['error']['message']}`;

--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -65,7 +65,18 @@ export class GoogleError extends Error {
     );
     // Map Http Status Code to gRPC Status Code
     if (json['error']['code']) {
-      error.code = rpcCodeFromHttpStatusCode(json['error']['code']);
+      const rpcCode = rpcCodeFromHttpStatusCode(json['error']['code']);
+      if (
+        !json['error']['status'] ||
+        Status[rpcCode] !== json['error']['status']
+      ) {
+        console.warn(
+          `Internal Error: Recieved HTTP error status ${json['error']['status']} doesn't match gRPC status ${Status[rpcCode]}.`
+        );
+      }
+      const rpcErrMsg = `${rpcCode} ${Status[rpcCode]}: ${json['error']['message']}`;
+      error.message = rpcErrMsg;
+      error.code = rpcCode;
     }
 
     // Keep consistency with gRPC statusDetails fields. gRPC details has been occupied before.


### PR DESCRIPTION
Firestore error message test fails on REST client : https://github.com/googleapis/nodejs-firestore/blob/main/dev/system-test/firestore.ts#L744

grpc error message pattern: `${grpcCode} ${grpcStatus}: ${error message}`.

To provide same debugging experience between HTTP/JSON and grpc, we should compose HTTP error message using the same pattern with grpc error message.