### PR TITLE
fix: post-process JSDoc link format in proto.d.ts

### DIFF
--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -214,9 +214,10 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const js = await readFile(expectedJSResultFile);
     const ts = await readFile(expectedTSResultFile);
+    // TODO: use assert.match and assert.doesnotmatch after node version > 13
     assert.ok(/{@link (.*?)|(.*?)}/.test(js.toString()));
-    assert.doesNotMatch(js.toString(), /{@link (.*?)#(.*?)}/);
+    assert.equal(/{@link (.*?)#(.*?)}/.test(js.toString()), false);
     assert.ok(/{@link (.*?)|(.*?)}/.test(ts.toString()));
-    assert.doesNotMatch(ts.toString(), /{@link (.*?)#(.*?)}/);
+    assert.equal(/{@link (.*?)#(.*?)}/.test(ts.toString()), false);
   });
 });

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -214,10 +214,24 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const js = await readFile(expectedJSResultFile);
     const ts = await readFile(expectedTSResultFile);
-    // TODO: use assert.match and assert.doesnotmatch after node version > 13
-    assert.ok(/{@link (.*?)|(.*?)}/.test(js.toString()));
-    assert.equal(/{@link (.*?)#(.*?)}/.test(js.toString()), false);
-    assert.ok(/{@link (.*?)|(.*?)}/.test(ts.toString()));
-    assert.equal(/{@link (.*?)#(.*?)}/.test(ts.toString()), false);
+    const links = [
+      '{@link google.example.library.v1.LibraryService#createShelf}',
+      '{@link google.example.library.v1.LibraryService#getShelf}',
+      '{@link google.example.library.v1.LibraryService#listShelves}',
+      '{@link google.example.library.v1.LibraryService#deleteShelf}',
+      '{@link google.example.library.v1.LibraryService#mergeShelves}',
+      '{@link google.example.library.v1.LibraryService#createBook}',
+      '{@link google.example.library.v1.LibraryService#getBook}',
+      '{@link google.example.library.v1.LibraryService#listBooks}',
+      '{@link google.example.library.v1.LibraryService#deleteBook}',
+      '{@link google.example.library.v1.LibraryService#updateBook}',
+      '{@link google.example.library.v1.LibraryService#moveBook}',
+    ];
+    for (const link of links) {
+      const reformate = link.replace('#', '|');
+      assert(js.toString().includes(reformate));
+      assert(ts.toString().includes(reformate));
+      assert.equal(js.toString().includes(link), false);
+    }
   });
 });

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -214,9 +214,9 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const js = await readFile(expectedJSResultFile);
     const ts = await readFile(expectedTSResultFile);
-    assert.match(js.toString(), /{@link (.*?)|(.*?)}/);
+    assert.ok(/{@link (.*?)|(.*?)}/.test(js.toString()));
     assert.doesNotMatch(js.toString(), /{@link (.*?)#(.*?)}/);
-    assert.match(ts.toString(), /{@link (.*?)|(.*?)}/);
+    assert.ok(/{@link (.*?)|(.*?)}/.test(ts.toString()));
     assert.doesNotMatch(ts.toString(), /{@link (.*?)#(.*?)}/);
   });
 });

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -205,4 +205,18 @@ describe('compileProtos tool', () => {
     ]);
     assert.strictEqual(rootName, 'default');
   });
+
+  it('reformat the JSDOC link in the JS and TS file', async () => {
+    await compileProtos.main([
+      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+    ]);
+    assert(fs.existsSync(expectedJSResultFile));
+    assert(fs.existsSync(expectedTSResultFile));
+    const js = await readFile(expectedJSResultFile);
+    const ts = await readFile(expectedTSResultFile);
+    assert.match(js.toString(), /{@link (.*?)|(.*?)}/);
+    assert.doesNotMatch(js.toString(), /{@link (.*?)#(.*?)}/);
+    assert.match(ts.toString(), /{@link (.*?)|(.*?)}/);
+    assert.doesNotMatch(ts.toString(), /{@link (.*?)#(.*?)}/);
+  });
 });

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -166,6 +166,9 @@ function fixJsFile(js: string): string {
 
   // 2. add Apache license to the generated .js file
   js = apacheLicense + js;
+
+  // 3. reformat JSDoc reference link in the comments
+  js = js.replace(/{@link (.*?)#(.*?)}/g, '{@link $1|$2}');
   return js;
 }
 


### PR DESCRIPTION
`protobufjs` generate JSDoC links in comment is format of `{@link $1#$2}`. It fails on rendering generated JSDOC link.

Reformat the `protobufjs`generated js file, format as `{@ $1|$2}`. 
