### PR TITLE
fix: catch rejected promise from closed client

### DIFF
--- a/src/call.ts
+++ b/src/call.ts
@@ -90,6 +90,11 @@ export class OngoingCall {
         setImmediate(this.callback!, err, response, next, rawResponse);
       }
     );
+    if (canceller instanceof Promise) {
+      canceller.catch(err => {
+        setImmediate(this.callback!, new GoogleError(err), null, null, null);
+      });
+    }
     this.cancelFunc = () => canceller.cancel();
   }
 }

--- a/src/normalCalls/retries.ts
+++ b/src/normalCalls/retries.ts
@@ -126,6 +126,11 @@ export function retryable(
           }, toSleep);
         }
       });
+      if (canceller instanceof Promise) {
+        canceller.catch(err => {
+          callback(new GoogleError(err));
+        });
+      }
     }
 
     if (maxRetries && deadline!) {

--- a/test/fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client.ts
+++ b/test/fixtures/google-gax-packaging-test-app/src/v1beta1/echo_client.ts
@@ -1133,8 +1133,7 @@ export class EchoClient {
    * @returns {Promise} A promise that resolves when the client is closed.
    */
   close(): Promise<void> {
-    this.initialize();
-    if (!this._terminated) {
+    if (this.echoStub && !this._terminated) {
       return this.echoStub!.then(stub => {
         this._terminated = true;
         stub.close();

--- a/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
+++ b/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
@@ -357,7 +357,7 @@ describe('v1beta1.EchoClient', () => {
       );
     });
 
-    it('invokes echo with closed client', async () => {
+    it.only('invokes echo with closed client', async () => {
       const client = new echoModule.v1beta1.EchoClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',

--- a/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
+++ b/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
@@ -356,6 +356,20 @@ describe('v1beta1.EchoClient', () => {
           .calledWith(request, expectedOptions, undefined)
       );
     });
+
+    it('invokes echo with closed client', async () => {
+      const client = new echoModule.v1beta1.EchoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.showcase.v1beta1.EchoRequest()
+      );
+      const expectedError = new Error('The client has already been closed.');
+      client.close();
+      await assert.rejects(client.echo(request), expectedError);
+    });
   });
 
   describe('block', () => {

--- a/test/unit/apiCallable.ts
+++ b/test/unit/apiCallable.ts
@@ -238,6 +238,15 @@ describe('Promise', () => {
       .catch(done);
   });
 
+  it('emits error on rejected promise', async () => {
+    const reason = 'reject reason';
+    function func() {
+      return Promise.reject(reason);
+    }
+    const apiCall = createApiCall(func);
+    await assert.rejects(apiCall({}, undefined), new Error(reason));
+  });
+
   it('emits error on failure', async () => {
     const apiCall = createApiCall(fail);
     await assert.rejects(apiCall({}, undefined));

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -57,7 +57,12 @@ export function createApiCall(func: Function, opts?: Options) {
           },
         };
       }
-      func(argument, metadata, options, callback);
+      const conceller = func(argument, metadata, options, callback);
+      if (conceller instanceof Promise) {
+        conceller.catch((err: string) => {
+          callback(new GoogleError(err));
+        });
+      }
       return {
         cancel:
           (opts && opts.cancel) ||


### PR DESCRIPTION
When I was writing a unit test of a unary call on closed client in generator, I find that the error hanging out until the timeout.  The root cause is the rejected promise has not been catch either in 
1. retryable
2. call

Unit Tests add in generator: [PR](https://github.com/googleapis/gapic-generator-typescript/pull/1105/files) 