### PR TITLE
fix: do not depend on index.ts from fallback code

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -38,7 +38,7 @@ import * as fallbackProto from './fallbackProto';
 import * as fallbackRest from './fallbackRest';
 import {isNodeJS} from './featureDetection';
 import {generateServiceStub} from './fallbackServiceStub';
-import {StreamType} from '.';
+import {StreamType} from './streamingCalls/streaming';
 import * as objectHash from 'object-hash';
 
 export {FallbackServiceError};


### PR DESCRIPTION
Otherwise, `fallback.ts` will pull the whole gRPC code which it is not supposed to do.