### PR TITLE
fix: reserved word in path template params

### DIFF
--- a/src/pathTemplate.ts
+++ b/src/pathTemplate.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { isReservedWord } from "./util";
+
 /*
  * Path template utility.
  */
@@ -140,8 +142,11 @@ export class PathTemplate {
       );
     }
     let path = this.inspect();
-    for (const key of Object.keys(bindings)) {
+    for (let key of Object.keys(bindings)) {
       const b = bindings[key].toString();
+      if (extractReservedWord(key)) {
+        key = extractReservedWord(key) as string;
+      }
       if (!this.bindings[key]) {
         throw new TypeError(`render fails for not matching ${bindings[key]}`);
       }
@@ -262,4 +267,18 @@ function splitPathTemplate(data: string): string[] {
     right = right + 1;
   }
   return segments;
+}
+
+/**
+ * Extract the word that is end with 'Param'.
+ * Return extracted reserved word. Or return 'null' if it is not.
+ * For example: 'exportParam', 'packageParam' return 'export', 'package'.
+ * 'other', 'otherParam' return null.
+ */
+export function extractReservedWord(data: string): string | null {
+  const match = data.match(/\w+(?=Param)/);
+  if (match && isReservedWord(match[0])) {
+    return match[0];
+  }
+  return null;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,6 +13,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const STRICT_MODE_RESERVED_WORDS = new Set([
+  'as',
+  'implements',
+  'interface',
+  'let',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static',
+  'yield',
+]);
+
+const TYPESCRIPT_RESERVED_WORDS = new Set([
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'null',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+]);
 
 /**
  * Converts a given string from camelCase (used by protobuf.js and in JSON)
@@ -48,4 +99,13 @@ export function snakeToCamelCase(str: string) {
     return str;
   }
   return [splitted[0], ...splitted.slice(1).map(capitalize)].join('');
+}
+
+/**
+ * Check if the word is in reserved word list.
+ */
+export function isReservedWord(word: string) {
+  return (
+    STRICT_MODE_RESERVED_WORDS.has(word) || TYPESCRIPT_RESERVED_WORDS.has(word)
+  );
 }

--- a/test/unit/pathTemplate.ts
+++ b/test/unit/pathTemplate.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {PathTemplate} from '../../src/pathTemplate';
+import {extractReservedWord, PathTemplate} from '../../src/pathTemplate';
 
 describe('PathTemplate', () => {
   describe('constructor', () => {
@@ -226,6 +226,18 @@ describe('PathTemplate', () => {
       const want = 'user/foo/blurbs/legacy/bar.user2/project/pp';
       assert.strictEqual(template.render(params), want);
     });
+
+    it('should render param with reserved word', () => {
+      const template = new PathTemplate(
+        'projects/{project}/testExports/{export}'
+      );
+      const params = {
+        project: 'test',
+        exportParam: 'export_value',
+      };
+      const want = 'projects/test/testExports/export_value';
+      assert.strictEqual(template.render(params), want);
+    });
   });
 
   describe('method `inspect`', () => {
@@ -244,6 +256,24 @@ describe('PathTemplate', () => {
       it(`should render template ${template} ok`, () => {
         const t = new PathTemplate(template);
         assert.strictEqual(t.inspect(), want);
+      });
+    });
+  });
+
+  describe('method `extractReservedWord`', () => {
+    const matches = ['exportParam', 'packageParam', 'classParam'];
+    const notMatches = ['otherParam', 'other', '_Param'];
+
+    matches.forEach(word => {
+      const expect = word.replace('Param', '');
+      it(`should extract reserved word ${expect}`, () => {
+        assert.deepStrictEqual(extractReservedWord(word), expect);
+      });
+    });
+
+    notMatches.forEach(word => {
+      it(`can't extract reserved word from ${word}`, () => {
+        assert.deepStrictEqual(extractReservedWord(word), null);
       });
     });
   });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -16,7 +16,11 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {snakeToCamelCase, camelToSnakeCase} from '../../src/util';
+import {
+  snakeToCamelCase,
+  camelToSnakeCase,
+  isReservedWord,
+} from '../../src/util';
 
 describe('util.ts', () => {
   it('camelToSnakeCase', () => {
@@ -48,5 +52,12 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('!._\\`'), '!._\\`');
     assert.strictEqual(snakeToCamelCase('a!_b`'), 'a!B`');
     assert.strictEqual(snakeToCamelCase('a.1_b`'), 'a.1B`');
+  });
+
+  it('isReservedWord', () => {
+    assert.ok(isReservedWord('package'));
+    assert.ok(isReservedWord('export'));
+    assert.ok(isReservedWord('implements'));
+    assert.ok(isReservedWord('typeof'));
   });
 });


### PR DESCRIPTION
path template has param conflict with Typescript reserved words, like `export`, `package`, etc. [example](https://github.com/googleapis/nodejs-security-center/pull/467/files#diff-51b297a5dc93c426b269a1e5b713205bc67b49d3e2758e48d3d3b6fa38e220aeR35-R37)
`"organizations/{organization}/bigQueryExports/{export}"`

Generated library append `Param` with the reseved key word to avoid conflict. So, in `render` function, we need to extract the original word to match the pattern parameters.
