### PR TITLE
fix: isolate Rest Stream from retry logic to avoid backpressure

### DIFF
--- a/src/streamingCalls/streamDescriptor.ts
+++ b/src/streamingCalls/streamDescriptor.ts
@@ -27,10 +27,12 @@ import {StreamingApiCaller} from './streamingApiCaller';
 export class StreamDescriptor implements Descriptor {
   type: StreamType;
   streaming: boolean; // needed for browser support
+  rest?: boolean;
 
-  constructor(streamType: StreamType) {
+  constructor(streamType: StreamType, rest?: boolean) {
     this.type = streamType;
     this.streaming = true;
+    this.rest = rest;
   }
 
   getApiCaller(settings: CallSettings): APICaller {

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -26,7 +26,7 @@ import {
   SimpleCallbackFunction,
 } from '../apitypes';
 import {RetryRequestOptions} from '../gax';
-import {StreamArrayParser} from '../streamArrayParser';
+import { StreamingApiCaller } from './streamingApiCaller';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const duplexify: DuplexifyConstructor = require('duplexify');
@@ -175,6 +175,7 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
   ) {
     if (this.type === StreamType.SERVER_STREAMING) {
       const stream = apiCall(argument, this._callback) as CancellableStream;
+      this.stream = stream;
       if (this.rest) {
         this.setReadable(stream);
       } else {
@@ -187,7 +188,6 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
               }
               return;
             }
-            this.stream = stream;
             this.forwardEvents(stream);
             return stream;
           },

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -26,7 +26,6 @@ import {
   SimpleCallbackFunction,
 } from '../apitypes';
 import {RetryRequestOptions} from '../gax';
-import { StreamingApiCaller } from './streamingApiCaller';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const duplexify: DuplexifyConstructor = require('duplexify');

--- a/src/streamingCalls/streamingApiCaller.ts
+++ b/src/streamingCalls/streamingApiCaller.ts
@@ -44,7 +44,11 @@ export class StreamingApiCaller implements APICaller {
   }
 
   init(callback: APICallback): StreamProxy {
-    return new StreamProxy(this.descriptor.type, callback);
+    return new StreamProxy(
+      this.descriptor.type,
+      callback,
+      this.descriptor.rest
+    );
   }
 
   wrap(func: GRPCCall): GRPCCall {

--- a/test/unit/streaming.ts
+++ b/test/unit/streaming.ts
@@ -36,14 +36,15 @@ function createApiCallStreaming(
   func:
     | Promise<GRPCCall>
     | sinon.SinonSpy<Array<{}>, internal.Transform | StreamArrayParser>,
-  type: streaming.StreamType
+  type: streaming.StreamType,
+  rest?: boolean
 ) {
   const settings = new gax.CallSettings();
   return createApiCall(
     //@ts-ignore
     Promise.resolve(func),
     settings,
-    new StreamDescriptor(type)
+    new StreamDescriptor(type, rest)
   ) as GaxCallStream;
 }
 
@@ -459,7 +460,7 @@ describe('streaming', () => {
   });
 });
 
-describe('apiCall return StreamArrayParser', () => {
+describe('REST streaming apiCall return StreamArrayParser', () => {
   const protos_path = path.resolve(__dirname, '..', 'fixtures', 'user.proto');
   const root = protobuf.loadSync(protos_path);
   const UserService = root.lookupService('UserService');
@@ -476,7 +477,8 @@ describe('apiCall return StreamArrayParser', () => {
     });
     const apiCall = createApiCallStreaming(
       spy,
-      streaming.StreamType.SERVER_STREAMING
+      streaming.StreamType.SERVER_STREAMING,
+      true
     );
     const s = apiCall({}, undefined);
     assert.strictEqual(s.readable, true);
@@ -505,7 +507,8 @@ describe('apiCall return StreamArrayParser', () => {
     });
     const apiCall = createApiCallStreaming(
       spy,
-      streaming.StreamType.SERVER_STREAMING
+      streaming.StreamType.SERVER_STREAMING,
+      true
     );
     const s = apiCall({}, undefined);
     assert.strictEqual(s.readable, true);
@@ -536,7 +539,8 @@ describe('apiCall return StreamArrayParser', () => {
     const apiCall = createApiCallStreaming(
       //@ts-ignore
       spy,
-      streaming.StreamType.SERVER_STREAMING
+      streaming.StreamType.SERVER_STREAMING,
+      true
     );
     const s = apiCall({}, undefined);
     let counter = 0;


### PR DESCRIPTION
Get rid of `retry-request` for rest server-stream.

`retry-request` cause problem:
gax returns the `StreamProxy` that a customer can read the data. This proxy stream sets `RetryStream`(A wrapper of `StreamArrayPaser` with retry logic) as `ReadableStream`.  In the retry-request implementation, the [stream listens on](https://github.com/googleapis/retry-request/blob/main/index.js#L159) a response event where it is not the event that would be emitted by HTTP response.body or StreamArrayPaser. It somehow causes a miss forward data event when [pipe to the next stream](https://github.com/googleapis/retry-request/blob/main/index.js#L169). That’s also the reason we [need to forward](https://github.com/googleapis/gax-nodejs/blob/main/src/streamingCalls/streaming.ts#L128-L130) data, end, error events in stream.ts before.

Reason to remove `retry-request`:
1. retry-request is  not supposed to be used with REST streams because there were no REST streams when retry-request was implemented a few years ago. And REST streams are a very rare use case.
2. Long-term goal is to get rid of retry-request dependency.