### PR TITLE
fix: pin @grpc/proto-loader to v0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "^0.6.1",
+    "@grpc/proto-loader": "0.6.9",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#321, googleapis/google-cloud-node-core#320.

The compilation is broken by https://github.com/grpc/grpc-node/pull/2110, pinning proto loader to the previous version.