### PR TITLE
chore(deps)!: update proto-loader to 0.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "linkinator": "^2.0.0",
-    "long": "^5.2.0",
     "mkdirp": "^1.0.0",
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "0.6.9",
+    "@grpc/proto-loader": "^0.6.11",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "linkinator": "^2.0.0",
+    "long": "^5.2.0",
     "mkdirp": "^1.0.0",
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",

--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+ import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
+++ b/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as Long from "long";
+import Long = require('long');
 import {protobuf as $protobuf} from "../../../../src";
 /** Namespace google. */
 export namespace google {

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +114,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -145,8 +145,7 @@ describe('compileProtos tool', () => {
     ]);
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
-
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +114,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -146,7 +146,7 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
 
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import Long = require'));
+    assert(ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +114,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import Long = require'));
+    assert(ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -146,7 +146,7 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
 
-    assert(ts.toString().includes('import Long = require'));
+    assert(ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -177,7 +177,7 @@ function fixDtsFile(dts: string): string {
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
   if (!dts.match(/import \* as Long/)) {
-    dts = 'import * as Long from "long";\n' + dts;
+    dts = "import Long = require('long');\n" + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -177,7 +177,7 @@ function fixDtsFile(dts: string): string {
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
   if (!dts.match(/import \* as Long/)) {
-    dts = "import Long = require('long');\n" + dts;
+    dts = 'import * as Long from "long";\n' + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -177,7 +177,7 @@ function fixDtsFile(dts: string): string {
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
   if (!dts.match(/import \* as Long/)) {
-    dts = 'import * as Long from "long";\n' + dts;
+    dts = 'import Long = require("long");\n' + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to


### PR DESCRIPTION
gax generated code in `/protos` import `long`. With upgrade to`long v5`, it cause compiling error similar in https://github.com/grpc/grpc-node/issues/2111.

Thanks to @murgatroid99 fixed in https://github.com/grpc/grpc-node/pull/2112.

Now library could compile with version 0.6.11


