### PR TITLE
Use import = to match export =

### DIFF
--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
+++ b/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as Long from "long";
+import Long = require("long");
 import {protobuf as $protobuf} from "../../../../src";
 /** Namespace google. */
 export namespace google {

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long ='));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +114,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long ='));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -146,7 +146,7 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
 
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long ='));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -177,7 +177,7 @@ function fixDtsFile(dts: string): string {
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
   if (!dts.match(/import \* as Long/)) {
-    dts = 'import * as Long from "long";\n' + dts;
+    dts = 'import Long = require("long");\n' + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to


### PR DESCRIPTION
It seems like Firestore updated their version of google-gax which broke Cloud Functions for Firebase. As far as I can tell, the problem stems from using a standard `import` statement to import a module defined with `export =`.  Per [documentation](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require), the correct way to import code exported with `export =` is to use `import = require()`

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-node-core#317 🦕
