### PR TITLE
fix: add development dependency long

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "linkinator": "^2.0.0",
+    "long": "^5.2.0",
     "mkdirp": "^1.0.0",
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +114,7 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -145,8 +145,7 @@ describe('compileProtos tool', () => {
     ]);
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
-
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -177,7 +177,7 @@ function fixDtsFile(dts: string): string {
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
   if (!dts.match(/import \* as Long/)) {
-    dts = 'import * as Long from "long";\n' + dts;
+    dts = 'import Long = require("long");\n' + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to


### PR DESCRIPTION
Type `Long` is used in`protobufjs` generated file `.d.ts` in `gax/protos` and it also generated in client libraries.

Fix with ESM compatibility format.

updated grpc/proto-loader in #1245 