### PR TITLE
fix: update gax protos long import

### DIFF
--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+ import Long = require("long");
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require("long");
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
+++ b/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as Long from "long";
+import Long = require("long");
 import {protobuf as $protobuf} from "../../../../src";
 /** Namespace google. */
 export namespace google {


### PR DESCRIPTION
This is a template fix to unblock issue in https://github.com/googleapis/google-cloud-node-core/issues/317.

The complete fix should be in googleapis/gax-nodejs#1250 and with mass update on client libraries surface. 
