### PR TITLE
fix: upgrade proto-loader and add long dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "0.6.9",
+    "@grpc/proto-loader": "^0.6.12",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",
@@ -60,6 +60,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^5.0.0",
     "linkinator": "^2.0.0",
+    "long": "^4.0.0",
     "mkdirp": "^1.0.0",
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",
@@ -73,7 +74,7 @@
     "ts-loader": "^9.0.0",
     "typescript": "^3.8.3",
     "walkdir": "^0.4.0",
-    "webpack": "^4.34.0",
+    "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0"
   },
   "scripts": {

--- a/protos/iam_service.d.ts
+++ b/protos/iam_service.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/protos/operations.d.ts
+++ b/protos/operations.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Long from 'long';
+import Long = require('long');
 import * as $protobuf from "protobufjs";
 /** Namespace google. */
 export namespace google {

--- a/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
+++ b/test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as Long from "long";
+import Long = require('long');
 import {protobuf as $protobuf} from "../../../../src";
 /** Namespace google. */
 export namespace google {


### PR DESCRIPTION
Gax dependency `grpc/proto-loader` switch long dependency back to 4.x https://github.com/grpc/grpc-node/pull/2114

It address https://github.com/googleapis/google-cloud-node-core/issues/317