### PR TITLE
fix: revert gRPC stream change in #1226

### DIFF
--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -173,9 +173,9 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
     retryRequestOptions: RetryRequestOptions = {}
   ) {
     if (this.type === StreamType.SERVER_STREAMING) {
-      const stream = apiCall(argument, this._callback) as CancellableStream;
-      this.stream = stream;
       if (this.rest) {
+        const stream = apiCall(argument, this._callback) as CancellableStream;
+        this.stream = stream;
         this.setReadable(stream);
       } else {
         const retryStream = retryRequest(null, {
@@ -187,6 +187,8 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
               }
               return;
             }
+            const stream = apiCall(argument, this._callback) as CancellableStream;
+            this.stream = stream;
             this.forwardEvents(stream);
             return stream;
           },

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -187,7 +187,10 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
               }
               return;
             }
-            const stream = apiCall(argument, this._callback) as CancellableStream;
+            const stream = apiCall(
+              argument,
+              this._callback
+            ) as CancellableStream;
             this.stream = stream;
             this.forwardEvents(stream);
             return stream;

--- a/test/fixtures/google-gax-packaging-test-app/src/index.ts
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.ts
@@ -91,7 +91,6 @@ async function testShowcase() {
   await testEcho(grpcClient);
   await testEchoError(grpcClient);
   await testExpand(grpcClient);
-  await testExpandWithClosedClient(grpcClient);
   await testPagedExpand(grpcClient);
   await testPagedExpandAsync(grpcClient);
   await testCollect(grpcClient);
@@ -205,27 +204,6 @@ async function testExpand(client: EchoClient) {
     stream.on('end', () => {
       assert.deepStrictEqual(words, result);
     });
-}
-
-async function testExpandWithClosedClient(client: EchoClient) {
-  const words = ['nobody', 'ever', 'reads', 'test', 'input'];
-  const request = {
-    content: words.join(' '),
-  };
-  await client.close();
-  const stream = client.expand(request);
-  const expectedError = new Error('The client has already been closed.');
-  const promise = new Promise((resolve, reject) => {
-    stream.on(
-      'data', (response: any) => {
-        resolve(response);
-      }
-    );
-    stream.on('error', (err: Error) => {
-      reject(err);
-    });
-  });
-  await assert.rejects(promise, expectedError);
 }
 
 async function testPagedExpand(client: EchoClient) {

--- a/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
+++ b/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
@@ -680,6 +680,32 @@ describe('v1beta1.EchoClient', () => {
           .calledWith(request, expectedOptions)
       );
     });
+
+    it('invokes expand with closed client', async () => {
+      const client = new echoModule.v1beta1.EchoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.showcase.v1beta1.ExpandRequest()
+      );
+      const expectedError = new Error('The client has already been closed.');
+      client.close();
+      const stream = client.expand(request);
+      const promise = new Promise((resolve, reject) => {
+        stream.on(
+          'data',
+          (response: protos.google.showcase.v1beta1.EchoResponse) => {
+            resolve(response);
+          }
+        );
+        stream.on('error', (err: Error) => {
+          reject(err);
+        });
+      });
+      await assert.rejects(promise, expectedError);
+    });
   });
 
   describe('chat', () => {

--- a/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
+++ b/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
@@ -680,6 +680,33 @@ describe('v1beta1.EchoClient', () => {
           .calledWith(request, expectedOptions)
       );
     });
+
+    it('invoke expand with closed client', async () => {
+      const client = new echoModule.v1beta1.EchoClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.showcase.v1beta1.ExpandRequest()
+      );
+      const expectedError = new Error('The client has already been closed.');
+      client.close();
+      client.innerApiCalls.expand = stubServerStreamingCall();
+      const stream = client.expand(request);
+      const promise = new Promise((resolve, reject) => {
+        stream.on(
+          'data',
+          (response: protos.google.showcase.v1beta1.EchoResponse) => {
+            resolve(response);
+          }
+        );
+        stream.on('error', (err: Error) => {
+          reject(err);
+        });
+      });
+      await assert.rejects(promise, expectedError);
+    })
   });
 
   describe('chat', () => {

--- a/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
+++ b/test/fixtures/google-gax-packaging-test-app/test/gapic-v1beta1.ts
@@ -680,33 +680,6 @@ describe('v1beta1.EchoClient', () => {
           .calledWith(request, expectedOptions)
       );
     });
-
-    it('invoke expand with closed client', async () => {
-      const client = new echoModule.v1beta1.EchoClient({
-        credentials: {client_email: 'bogus', private_key: 'bogus'},
-        projectId: 'bogus',
-      });
-      client.initialize();
-      const request = generateSampleMessage(
-        new protos.google.showcase.v1beta1.ExpandRequest()
-      );
-      const expectedError = new Error('The client has already been closed.');
-      client.close();
-      client.innerApiCalls.expand = stubServerStreamingCall();
-      const stream = client.expand(request);
-      const promise = new Promise((resolve, reject) => {
-        stream.on(
-          'data',
-          (response: protos.google.showcase.v1beta1.EchoResponse) => {
-            resolve(response);
-          }
-        );
-        stream.on('error', (err: Error) => {
-          reject(err);
-        });
-      });
-      await assert.rejects(promise, expectedError);
-    })
   });
 
   describe('chat', () => {


### PR DESCRIPTION
Moving out lines from the `retryStream` cause failing to emit the closed client error.
```
const stream = apiCall(argument, this._callback) as CancellableStream;
this.stream = stream
```
