### PR TITLE
fix: parse error from stream call

### DIFF
--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -62,6 +62,12 @@ export class GoogleError extends Error {
   // Parse http JSON error and promote google.rpc.ErrorInfo if exist.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static parseHttpError(json: any): GoogleError {
+    if (Array.isArray(json)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      json = json.find((obj: any) => {
+        return 'error' in obj;
+      });
+    }
     const decoder = new GoogleErrorDecoder();
     const proto3Error = decoder.decodeHTTPError(json['error']);
     const error = Object.assign(

--- a/src/streamingCalls/streaming.ts
+++ b/src/streamingCalls/streaming.ts
@@ -25,6 +25,7 @@ import {
   SimpleCallbackFunction,
 } from '../apitypes';
 import {RetryRequestOptions} from '../gax';
+import {GoogleError} from '../googleError';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const duplexify: DuplexifyConstructor = require('duplexify');
@@ -151,6 +152,9 @@ export class StreamProxy extends duplexify implements GRPCCallResult {
         metadata,
       });
       this._responseHasSent = true;
+    });
+    stream.on('error', error => {
+      GoogleError.parseGRPCStatusDetails(error);
     });
   }
 

--- a/test/unit/googleError.ts
+++ b/test/unit/googleError.ts
@@ -305,35 +305,51 @@ describe('map http status code to gRPC status code', () => {
 });
 
 describe('http error decoding', () => {
+  const errorInfo = {
+    '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+    reason: 'SERVICE_DISABLED',
+    domain: 'googleapis.com',
+    metadata: {
+      service: 'translate.googleapis.com',
+      consumer: 'projects/123',
+    },
+  };
+  const help = {
+    '@type': 'type.googleapis.com/google.rpc.Help',
+    links: [
+      {
+        description: 'Google developers console API activation',
+        url: 'https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361',
+      },
+    ],
+  };
+  const json = {
+    error: {
+      code: 403,
+      message:
+        'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
+      status: 'PERMISSION_DENIED',
+      details: [help, errorInfo],
+    },
+  };
   it('should promote ErrorInfo if exist in http error', () => {
-    const errorInfo = {
-      '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
-      reason: 'SERVICE_DISABLED',
-      domain: 'googleapis.com',
-      metadata: {
-        service: 'translate.googleapis.com',
-        consumer: 'projects/123',
-      },
-    };
-    const help = {
-      '@type': 'type.googleapis.com/google.rpc.Help',
-      links: [
-        {
-          description: 'Google developers console API activation',
-          url: 'https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361',
-        },
-      ],
-    };
-    const json = {
-      error: {
-        code: 403,
-        message:
-          'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
-        status: 'PERMISSION_DENIED',
-        details: [help, errorInfo],
-      },
-    };
     const error = GoogleError.parseHttpError(json);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length
+    );
+    assert.deepStrictEqual(error.message, json['error']['message']);
+    assert.deepStrictEqual(error.reason, errorInfo.reason);
+    assert.deepStrictEqual(error.domain, errorInfo.domain);
+    assert.deepStrictEqual(
+      JSON.stringify(error.errorInfoMetadata),
+      JSON.stringify(errorInfo.metadata)
+    );
+  });
+
+  it('should support http error in array', () => {
+    const error = GoogleError.parseHttpError([json]);
     assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
     assert.deepStrictEqual(
       error.statusDetails?.length,


### PR DESCRIPTION
- grpc stream call should parse the `Status` and promote `ErrorInfo`. Address #1270 

- parse Http error in an array. Bigtable error example
```
[
  {
    error: {
       code: 405,
       message: "not found",
       details:  [..]
    }
  }
]
```
