### PR TITLE
feat: support regapic LRO

### DIFF
--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -38,6 +38,7 @@ INCLUDE_DIRS.push(googleProtoFilesDir);
 // COMMON_PROTO_FILES logic is here for protobufjs loads (see
 // GoogleProtoFilesRoot below)
 import * as commonProtoFiles from './protosList.json';
+import {google} from '../protos/http';
 // use the correct path separator for the OS we are running on
 const COMMON_PROTO_FILES: string[] = commonProtoFiles.map(file =>
   file.replace(/[/\\]/g, path.sep)
@@ -46,6 +47,8 @@ const COMMON_PROTO_FILES: string[] = commonProtoFiles.map(file =>
 export interface GrpcClientOptions extends GoogleAuthOptions {
   auth?: GoogleAuth;
   grpc?: GrpcModule;
+  protoJson?: protobuf.Root;
+  httpRules?: Array<google.api.IHttpRule>;
 }
 
 export interface MetadataValue {
@@ -112,6 +115,7 @@ export class GrpcClient {
   grpcVersion: string;
   fallback: boolean | 'rest' | 'proto';
   private static protoCache = new Map<string, grpc.GrpcObject>();
+  httpRules?: Array<google.api.IHttpRule>;
 
   /**
    * Key for proto cache map. We are doing our best to make sure we respect

--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -576,10 +576,8 @@ export class OperationsClientBuilder {
       // overwrite the http rules if provide in service yaml.
       overrideHttpRules(gaxGrpc.httpRules, protoJson);
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const operationsProtos = protoJson
-      ? protoJson
-      : gaxGrpc.loadProtoJSON(operationProtoJson);
+    const operationsProtos =
+      protoJson ?? gaxGrpc.loadProtoJSON(operationProtoJson);
 
     /**
      * Build a new instance of {@link OperationsClient}.
@@ -591,10 +589,8 @@ export class OperationsClientBuilder {
      * @param {Object=} opts.clientConfig - The customized config to build the call settings. See {@link gax.constructSettings} for the format.
      */
     this.operationsClient = opts => {
-      if (gaxGrpc.fallback === 'rest') {
-        opts.fallback = 'rest';
-      } else if (gaxGrpc.fallback) {
-        opts.fallback = true;
+      if (gaxGrpc.fallback) {
+        opts.fallback = gaxGrpc.fallback;
       }
       return new OperationsClient(gaxGrpc, operationsProtos, opts);
     };

--- a/test/unit/streaming.ts
+++ b/test/unit/streaming.ts
@@ -32,7 +32,6 @@ import {StreamArrayParser} from '../../src/streamArrayParser';
 import path = require('path');
 import protobuf = require('protobufjs');
 import {GoogleError} from '../../src';
-import {CodeChallengeMethod} from 'google-auth-library';
 import {Metadata} from '@grpc/grpc-js';
 
 function createApiCallStreaming(

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -31,11 +31,14 @@ import {
   match,
   buildQueryStringComponents,
   requestChangeCaseAndCleanup,
+  overrideHttpRules,
 } from '../../src/transcoding';
 import * as assert from 'assert';
 import {camelToSnakeCase, snakeToCamelCase} from '../../src/util';
 import * as protobuf from 'protobufjs';
 import {testMessageJson} from '../fixtures/fallbackOptional';
+import {echoProtoJson} from '../fixtures/echoProtoJson';
+import {google} from '../../protos/http';
 
 describe('gRPC to HTTP transcoding', () => {
   const parsedOptions: ParsedOptionsType = [
@@ -694,6 +697,141 @@ describe('validate proto3 field with default value', () => {
       assert.deepStrictEqual(transcoded?.url, 'projects/test-project');
       assert.deepStrictEqual(transcoded?.data, 'test-content');
       assert.deepStrictEqual(transcoded.queryString, '');
+    }
+  });
+});
+
+describe('override the HTTP rules in protoJson', () => {
+  const httpOptionName = '(google.api.http)';
+
+  it('override multiple http rules', () => {
+    const httpRules: Array<google.api.IHttpRule> = [
+      {
+        selector: 'google.showcase.v1beta1.Messaging.GetRoom',
+        get: '/v1beta1/{name**}',
+      },
+      {
+        selector: 'google.showcase.v1beta1.Messaging.ListRooms',
+        get: '/fake/value',
+      },
+    ];
+    const root = protobuf.Root.fromJSON(echoProtoJson);
+    overrideHttpRules(httpRules, root);
+    for (const rule of httpRules) {
+      const modifiedRpc = root.lookup(rule.selector!) as protobuf.Method;
+      assert(modifiedRpc);
+      assert(modifiedRpc.parsedOptions);
+      for (const item of modifiedRpc!.parsedOptions) {
+        if (!(httpOptionName in item)) {
+          continue;
+        }
+        const httpOptions = item[httpOptionName];
+        assert.deepStrictEqual(httpOptions.get, rule.get);
+      }
+    }
+  });
+
+  it("override additional bindings for a rpc doesn't has additional bindings", () => {
+    const httpRules: Array<google.api.IHttpRule> = [
+      {
+        selector: 'google.showcase.v1beta1.Messaging.GetRoom',
+        get: 'v1beta1/room/{name=**}',
+        additional_bindings: [{get: 'v1beta1/room/{name}'}],
+      },
+    ];
+    const root = protobuf.Root.fromJSON(echoProtoJson);
+    overrideHttpRules(httpRules, root);
+    for (const rule of httpRules) {
+      const modifiedRpc = root.lookup(rule.selector!) as protobuf.Method;
+      assert(modifiedRpc);
+      assert(modifiedRpc.parsedOptions);
+      for (const item of modifiedRpc!.parsedOptions) {
+        if (!(httpOptionName in item)) {
+          continue;
+        }
+        const httpOptions = item[httpOptionName];
+        assert.deepStrictEqual(httpOptions.get, rule.get);
+        assert.deepStrictEqual(
+          httpOptions.additional_bindings,
+          rule.additional_bindings
+        );
+      }
+    }
+  });
+
+  it('append additional bindings for a rpc has additional bindings', () => {
+    const httpRules: Array<google.api.IHttpRule> = [
+      {
+        selector: 'google.showcase.v1beta1.Messaging.GetBlurb',
+        get: 'v1beta1/fake/value',
+        additional_bindings: [
+          {get: 'v1beta1/fake/value'},
+        ] as Array<google.api.IHttpRule>,
+      },
+    ];
+    const root = protobuf.Root.fromJSON(echoProtoJson);
+    const originRpc = root.lookup(httpRules[0].selector!) as protobuf.Method;
+    const originAdditionalBindings = () => {
+      for (const item of originRpc!.parsedOptions) {
+        if (!(httpOptionName in item)) {
+          continue;
+        }
+        const httpOptions = item[httpOptionName] as google.api.IHttpRule;
+        return [httpOptions.additional_bindings];
+      }
+      return null;
+    };
+    assert(originAdditionalBindings());
+    const expectedAditionalBindings = originAdditionalBindings()!.concat(
+      httpRules[0].additional_bindings
+    );
+    overrideHttpRules(httpRules, root);
+    for (const rule of httpRules) {
+      const modifiedRpc = root.lookup(rule.selector!) as protobuf.Method;
+      assert(modifiedRpc);
+      assert(modifiedRpc.parsedOptions);
+      for (const item of modifiedRpc!.parsedOptions) {
+        if (!(httpOptionName in item)) {
+          continue;
+        }
+        const httpOptions = item[httpOptionName];
+        assert.deepStrictEqual(httpOptions.get, rule.get);
+        assert.deepStrictEqual(
+          httpOptions.additional_bindings,
+          expectedAditionalBindings
+        );
+      }
+    }
+  });
+
+  it("can't override a non-exist rpc", () => {
+    const httpRules: Array<google.api.IHttpRule> = [
+      {
+        selector: 'not.a.valid.rpc',
+        get: 'v1/operations/{name=**}',
+      },
+    ];
+    const root = protobuf.Root.fromJSON(echoProtoJson);
+    overrideHttpRules(httpRules, root);
+    for (const rule of httpRules) {
+      const modifiedRpc = root.lookup(rule.selector!) as protobuf.Method;
+      assert.equal(modifiedRpc, null);
+    }
+  });
+
+  it('not support a rpc has no parsedOption', () => {
+    const httpRules: Array<google.api.IHttpRule> = [
+      {
+        selector: 'google.showcase.v1beta1.Messaging.Connect',
+        get: 'fake/url',
+      },
+    ];
+    const root = protobuf.Root.fromJSON(echoProtoJson);
+    overrideHttpRules(httpRules, root);
+    for (const rule of httpRules) {
+      const modifiedRpc = root.lookup(rule.selector!) as protobuf.Method;
+      assert(modifiedRpc);
+      assert.equal(modifiedRpc.parsedOptions, null);
     }
   });
 });


### PR DESCRIPTION
Enable using rest client to make long running operation call.

Example to use Rest SpeechClient to make LRO call, generator need to read `speech_v1.yaml` to construct `httpRules` which is array of `google.api.IHttpRules. Then we pass down the parameter to build OperationClient.

Here is an sample code in `speech_client.ts`

```
this.operationsClient = this._gaxModule
            .lro({
            auth: this.auth,
            grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
            protoJson: protoFilesRoot,
            httpRules: [
                {
                    selector: 'google.longrunning.Operations.GetOperation',
                    get: '/v1/operations/{name=**}'
                },
                {
                    selector: 'google.longrunning.Operations.ListOperations',
                    get: '/v1/operations',
                }
            ]

        })
            .operationsClient(opts);
```
            
