### PR TITLE
fix: errorInfoMetadata should be a string->string object

### DIFF
--- a/src/googleError.ts
+++ b/src/googleError.ts
@@ -28,7 +28,7 @@ export class GoogleError extends Error {
   statusDetails?: string | protobuf.Message<{}>[];
   reason?: string;
   domain?: string;
-  errorInfoMetadata?: {string: string};
+  errorInfoMetadata?: {[propName: string]: string};
 
   // Parse details field in google.rpc.status wire over gRPC medatadata.
   // Promote google.rpc.ErrorInfo if exist.


### PR DESCRIPTION
I'm pretty sure that's the case, anyhow. Right now it's just an object with one member named `string` of type `string`.
