### PR TITLE
docs: describe fallback REST option

### DIFF
--- a/client-libraries.md
+++ b/client-libraries.md
@@ -97,17 +97,32 @@ binary tranport based on HTTP/2. It's Node.js implementation,
 [`@grpc/grpc-js`](https://www.npmjs.com/package/@grpc/grpc-js), uses Node.js
 `http2` module.
 
+#### HTTP/1.1 REST API mode
+
+- `options.fallback`: `true`, `"rest"`, or `false`, use HTTP fallback mode.
+  Default value is `false`, unless the `window` object is defined.
+
 If you need to use the client library in non-Node.js environment or when gRPC
-cannot be used for any reason, you can use the HTTP/1 fallback mode. In this
+cannot be used for any reason, you can use the HTTP/1.1 fallback mode. In this
 mode, a special browser-compatible transport implementation is used instead of
 gRPC transport.
+
+There are two supported gRPC fallback modes:
+
+- set `options.fallback` to `"rest"`: the library will send and receive JSON
+  payload, HTTP/1.1 REST API endpoints will be used. This mode is recommended
+  for fallback.
+  
+- set `options.fallback` to `true`: the library will send and receive serialized
+  protobuf payload to special endpoints accepting serialized protobufs over
+  HTTP/1.1.
 
 In browser context (if the `window` object is defined) the fallback mode is
 enabled automatically; set `options.fallback` to `false` if you need to override
 this behavior.
 
-- `options.fallback`: `true` or `false`, use HTTP fallback mode. Default value
-  is `false`, unless the `window` object is defined.
+Note that `options.fallback` accepts boolean values (`true` and `false`) for
+compatibility only. We recommend using `"rest"` to use HTTP/1.1 instead of gRPC.
 
 ## Calling API methods
 


### PR DESCRIPTION
We will reference this documentation from the generated client libraries.