### PR TITLE
fix: protobufjs-compatible camel case

### DIFF
--- a/src/bundlingCalls/bundleDescriptor.ts
+++ b/src/bundlingCalls/bundleDescriptor.ts
@@ -20,7 +20,7 @@ import {NormalApiCaller} from '../normalCalls/normalApiCaller';
 
 import {BundleApiCaller} from './bundleApiCaller';
 import {BundleExecutor} from './bundleExecutor';
-import {snakeToCamelCase} from '../util';
+import {toCamelCase as snakeToCamelCase} from '../util';
 
 /**
  * A descriptor for calls that can be bundled into one call.

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import {OutgoingHttpHeaders} from 'http';
+import * as objectHash from 'object-hash';
 import * as protobuf from 'protobufjs';
 import * as gax from './gax';
 import * as routingHeader from './routingHeader';
 import {Status} from './status';
-import {OutgoingHttpHeaders} from 'http';
 import {
   GoogleAuth,
   OAuth2Client,
@@ -39,7 +40,7 @@ import * as fallbackRest from './fallbackRest';
 import {isNodeJS} from './featureDetection';
 import {generateServiceStub} from './fallbackServiceStub';
 import {StreamType} from './streamingCalls/streaming';
-import * as objectHash from 'object-hash';
+import {toLowerCamelCase} from './util';
 import {google} from '../protos/http';
 
 export {FallbackServiceError};
@@ -151,8 +152,7 @@ export class GrpcClient {
   private static getServiceMethods(service: protobuf.Service): ServiceMethods {
     const methods: {[name: string]: protobuf.Method} = {};
     for (const [methodName, methodObject] of Object.entries(service.methods)) {
-      const methodNameLowerCamelCase =
-        methodName[0].toLowerCase() + methodName.substring(1);
+      const methodNameLowerCamelCase = toLowerCamelCase(methodName);
       methods[methodNameLowerCamelCase] = methodObject;
     }
 

--- a/src/gax.ts
+++ b/src/gax.ts
@@ -19,6 +19,7 @@
  */
 
 import {BundleOptions} from './bundlingCalls/bundleExecutor';
+import {toLowerCamelCase} from './util';
 
 /**
  * Encapsulates the overridable settings for a particular API call.
@@ -657,7 +658,7 @@ export function constructSettings(
   const overridingMethods = overrides.methods || {};
   for (const methodName in methods) {
     const methodConfig = methods[methodName];
-    const jsName = methodName[0].toLowerCase() + methodName.slice(1);
+    const jsName = toLowerCamelCase(methodName);
 
     let retry = constructRetry(
       methodConfig,

--- a/src/transcoding.ts
+++ b/src/transcoding.ts
@@ -20,7 +20,7 @@
 import {JSONObject, JSONValue} from 'proto3-json-serializer';
 import {Field} from 'protobufjs';
 import {google} from '../protos/http';
-import {camelToSnakeCase, snakeToCamelCase} from './util';
+import {camelToSnakeCase, toCamelCase as snakeToCamelCase} from './util';
 
 export interface TranscodedRequest {
   httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete';

--- a/src/util.ts
+++ b/src/util.ts
@@ -72,7 +72,8 @@ function capitalize(str: string) {
 
 /**
  * Converts a given string from snake_case (normally used in proto definitions) or
- * PascalCase (also used in proto definitions) to camelCase (used by protobuf.js)
+ * PascalCase (also used in proto definitions) to camelCase (used by protobuf.js).
+ * Preserves capitalization of the first character.
  */
 export function toCamelCase(str: string) {
   const wordsList = words(str, /*normalize:*/ true);
@@ -89,4 +90,16 @@ export function toCamelCase(str: string) {
     })
   );
   return result.join('');
+}
+
+/**
+ * Converts a given string to lower camel case (forcing the first character to be
+ * in lower case).
+ */
+export function toLowerCamelCase(str: string) {
+  const camelCase = toCamelCase(str);
+  if (camelCase.length === 0) {
+    return camelCase;
+  }
+  return camelCase[0].toLowerCase() + camelCase.slice(1);
 }

--- a/test/fixtures/google-gax-packaging-test-app/src/index.ts
+++ b/test/fixtures/google-gax-packaging-test-app/src/index.ts
@@ -179,13 +179,13 @@ async function testEchoError(client: EchoClient) {
     Error);
   try {
       await client.echo(request);
-  } catch (err: any) {
+  } catch (err) {
       clearTimeout(timer);
-      assert.strictEqual(JSON.stringify(err.statusDetails), JSON.stringify(expectedDetails));
+      assert.strictEqual(JSON.stringify((err as typeof GoogleError).statusDetails), JSON.stringify(expectedDetails));
       assert.ok(errorInfo!)
-      assert.strictEqual(err.domain, errorInfo!.domain)
-      assert.strictEqual(err.reason, errorInfo!.reason)
-      assert.strictEqual(JSON.stringify(err.errorInfoMetadata), JSON.stringify(errorInfo!.metadata));
+      assert.strictEqual((err as typeof GoogleError).domain, errorInfo!.domain)
+      assert.strictEqual((err as typeof GoogleError).reason, errorInfo!.reason)
+      assert.strictEqual(JSON.stringify((err as typeof GoogleError).errorInfoMetadata), JSON.stringify(errorInfo!.metadata));
   }
 }
 

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -34,7 +34,10 @@ import {
   overrideHttpRules,
 } from '../../src/transcoding';
 import * as assert from 'assert';
-import {camelToSnakeCase, snakeToCamelCase} from '../../src/util';
+import {
+  camelToSnakeCase,
+  toCamelCase as snakeToCamelCase,
+} from '../../src/util';
 import * as protobuf from 'protobufjs';
 import {testMessageJson} from '../fixtures/fallbackOptional';
 import {echoProtoJson} from '../fixtures/echoProtoJson';

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -19,6 +19,7 @@ import {describe, it} from 'mocha';
 import {
   toCamelCase as snakeToCamelCase,
   camelToSnakeCase,
+  toLowerCamelCase,
 } from '../../src/util';
 
 describe('util.ts', () => {
@@ -53,5 +54,23 @@ describe('util.ts', () => {
       snakeToCamelCase('something_abcde_value'),
       'somethingAbcdeValue'
     );
+  });
+
+  it('toLowerCamelCase', () => {
+    assert.strictEqual(toLowerCamelCase('test'), 'test');
+    assert.strictEqual(toLowerCamelCase('test123'), 'test123');
+    assert.strictEqual(toLowerCamelCase('test_abc'), 'testAbc');
+    assert.strictEqual(toLowerCamelCase('test_abc_def'), 'testAbcDef');
+    assert.strictEqual(toLowerCamelCase('I_p_protocol'), 'iPProtocol');
+    assert.strictEqual(toLowerCamelCase('a.1'), 'a.1');
+    assert.strictEqual(toLowerCamelCase('abc.1_foo'), 'abc.1Foo');
+    assert.strictEqual(toLowerCamelCase('abc.foo'), 'abc.foo');
+    assert.strictEqual(toLowerCamelCase('a.1_b'), 'a.1B');
+    assert.strictEqual(
+      toLowerCamelCase('something_abcde_value'),
+      'somethingAbcdeValue'
+    );
+    assert.strictEqual(toLowerCamelCase('PascalCaseString'), 'pascalCaseString');
+    assert.strictEqual(toLowerCamelCase('PascalCASEString'), 'pascalCaseString');
   });
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -70,7 +70,13 @@ describe('util.ts', () => {
       toLowerCamelCase('something_abcde_value'),
       'somethingAbcdeValue'
     );
-    assert.strictEqual(toLowerCamelCase('PascalCaseString'), 'pascalCaseString');
-    assert.strictEqual(toLowerCamelCase('PascalCASEString'), 'pascalCaseString');
+    assert.strictEqual(
+      toLowerCamelCase('PascalCaseString'),
+      'pascalCaseString'
+    );
+    assert.strictEqual(
+      toLowerCamelCase('PascalCASEString'),
+      'pascalCaseString'
+    );
   });
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -16,7 +16,10 @@
 
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
-import {snakeToCamelCase, camelToSnakeCase} from '../../src/util';
+import {
+  toCamelCase as snakeToCamelCase,
+  camelToSnakeCase,
+} from '../../src/util';
 
 describe('util.ts', () => {
   it('camelToSnakeCase', () => {
@@ -29,10 +32,11 @@ describe('util.ts', () => {
     assert.strictEqual(camelToSnakeCase('a.1'), 'a.1');
     assert.strictEqual(camelToSnakeCase('abc.1Foo'), 'abc.1_foo');
     assert.strictEqual(camelToSnakeCase('abc.foo'), 'abc.foo');
-    assert.strictEqual(camelToSnakeCase('a!.\\'), 'a!.\\');
-    assert.strictEqual(camelToSnakeCase('!._\\`'), '!._\\`');
-    assert.strictEqual(camelToSnakeCase('a!B`'), 'a!_b`');
-    assert.strictEqual(camelToSnakeCase('a.1B`'), 'a.1_b`');
+    assert.strictEqual(camelToSnakeCase('a.1B'), 'a.1_b');
+    assert.strictEqual(
+      camelToSnakeCase('somethingABCDEValue`'),
+      'something_a_b_c_d_e_value'
+    );
   });
 
   it('snakeToCamelCase', () => {
@@ -44,9 +48,10 @@ describe('util.ts', () => {
     assert.strictEqual(snakeToCamelCase('a.1'), 'a.1');
     assert.strictEqual(snakeToCamelCase('abc.1_foo'), 'abc.1Foo');
     assert.strictEqual(snakeToCamelCase('abc.foo'), 'abc.foo');
-    assert.strictEqual(snakeToCamelCase('a!.\\`'), 'a!.\\`');
-    assert.strictEqual(snakeToCamelCase('!._\\`'), '!._\\`');
-    assert.strictEqual(snakeToCamelCase('a!_b`'), 'a!B`');
-    assert.strictEqual(snakeToCamelCase('a.1_b`'), 'a.1B`');
+    assert.strictEqual(snakeToCamelCase('a.1_b'), 'a.1B');
+    assert.strictEqual(
+      snakeToCamelCase('something_abcde_value'),
+      'somethingAbcdeValue'
+    );
   });
 });


### PR DESCRIPTION
This PR brings camel case implementation in gax on the same page with the implementation in gapic-generator-typescript and in protobuf.js. The only affected use cases are strings that have multiple capital letters, e.g. `GetOSPolicySomething`, which protobuf.js wants to see as `getOsPolicySomething`; I believe these names do not work now, so this is a fix rather than a breaking change in behavior.

Tested locally that OSConfig API works with this change (and the generator change in https://github.com/googleapis/gapic-generator-typescript/pull/1157).

I removed some unit tests that did not make sense (contained characters that never occur in names but prevented this refactor).