### PR TITLE
fix: do not use typeof when comparing to undefined

### DIFF
--- a/src/transcoding.ts
+++ b/src/transcoding.ts
@@ -191,14 +191,14 @@ export function match(
     const [, before, field, pattern, after] = match;
     matchedFields.push(field);
     const fieldValue = getField(request, field);
-    if (typeof fieldValue === 'undefined') {
+    if (fieldValue === undefined) {
       return undefined;
     }
     const appliedPattern = applyPattern(
       pattern,
       fieldValue === null ? 'null' : fieldValue!.toString()
     );
-    if (typeof appliedPattern === 'undefined') {
+    if (appliedPattern === undefined) {
       return undefined;
     }
     url = before + appliedPattern + after;
@@ -210,7 +210,7 @@ export function match(
 export function flattenObject(request: JSONObject): JSONObject {
   const result: JSONObject = {};
   for (const key in request) {
-    if (typeof request[key] === 'undefined') {
+    if (request[key] === undefined) {
       continue;
     }
 
@@ -302,7 +302,7 @@ export function transcode(
     getFieldNameOnBehavior(requestFields);
   // all fields annotated as REQUIRED MUST be emitted in the body.
   for (const requiredField of requiredFields) {
-    if (!(requiredField in request) || request[requiredField] === 'undefined') {
+    if (!(requiredField in request) || request[requiredField] === undefined) {
       throw new Error(
         `Required field ${requiredField} is not present in the request.`
       );
@@ -336,7 +336,7 @@ export function transcode(
         httpMethod as keyof google.api.IHttpRule
       ] as string;
       const matchResult = match(snakeRequest, pathTemplate);
-      if (typeof matchResult === 'undefined') {
+      if (matchResult === undefined) {
         continue;
       }
       const {url, matchedFields} = matchResult;
@@ -351,7 +351,7 @@ export function transcode(
         for (const key in data) {
           if (
             optionalFields.has(snakeToCamelCase(key)) &&
-            (!(key in snakeRequest) || snakeRequest[key] === 'undefined')
+            (!(key in snakeRequest) || snakeRequest[key] === undefined)
           ) {
             delete data[key];
           }
@@ -372,7 +372,7 @@ export function transcode(
         deleteField(queryStringObject, snakeToCamelCase(body));
         // Unset optional field should not add in body request.
         data =
-          optionalFields.has(body) && snakeRequest[body] === 'undefined'
+          optionalFields.has(body) && snakeRequest[body] === undefined
             ? ''
             : (snakeRequest[body] as JSONObject);
       }
@@ -381,7 +381,7 @@ export function transcode(
       }
       // Unset proto3 optional field does not appear in the query params.
       for (const key in queryStringObject) {
-        if (optionalFields.has(key) && request[key] === 'undefined') {
+        if (optionalFields.has(key) && request[key] === undefined) {
           delete queryStringObject[key];
         }
       }

--- a/test/unit/transcoding.ts
+++ b/test/unit/transcoding.ts
@@ -588,9 +588,6 @@ describe('validate proto3 field with default value', () => {
           body: '*',
         },
       },
-      {
-        '(google.api.method_signature)': 'project_id, content',
-      },
     ];
     const transcoded = transcode(request, parsedOptions, badTestMessageFields);
     assert.deepStrictEqual(
@@ -598,16 +595,10 @@ describe('validate proto3 field with default value', () => {
       'projects/test-project/contents/test-content'
     );
   });
-  it('should throw error if required field has not been setted', () => {
-    const requests: RequestType[] = [
-      {
-        projectId: 'test-project',
-        content: 'undefined',
-      },
-      {
-        projectId: 'test-project',
-      },
-    ];
+  it('should throw error if required field has not been set', () => {
+    const request: RequestType = {
+      projectId: 'test-project',
+    };
     const parsedOptions: ParsedOptionsType = [
       {
         '(google.api.http)': {
@@ -615,16 +606,11 @@ describe('validate proto3 field with default value', () => {
           body: '*',
         },
       },
-      {
-        '(google.api.method_signature)': 'project_id, content',
-      },
     ];
-    for (const request of requests) {
-      assert.throws(
-        () => transcode(request, parsedOptions, testMessageFields),
-        Error
-      );
-    }
+    assert.throws(
+      () => transcode(request, parsedOptions, testMessageFields),
+      Error
+    );
   });
   it('when body="*", all required field should emitted in body', () => {
     const request: RequestType = {
@@ -644,17 +630,10 @@ describe('validate proto3 field with default value', () => {
     assert.deepStrictEqual(transcoded?.data, {content: 'test-content'});
   });
   it('when body="*", unset optional field should remove from body', () => {
-    const requests: RequestType[] = [
-      {
-        projectId: 'test-project',
-        content: 'test-content',
-        optionalValue: 'undefined',
-      },
-      {
-        projectId: 'test-project',
-        content: 'test-content',
-      },
-    ];
+    const request: RequestType = {
+      projectId: 'test-project',
+      content: 'test-content',
+    };
     const parsedOptions: ParsedOptionsType = [
       {
         '(google.api.http)': {
@@ -663,27 +642,18 @@ describe('validate proto3 field with default value', () => {
         },
       },
     ];
-    for (const request of requests) {
-      const transcoded = transcode(request, parsedOptions, testMessageFields);
-      assert.deepStrictEqual(
-        transcoded?.url,
-        'projects/test-project/contents/test-content'
-      );
-      assert.deepStrictEqual(transcoded?.data, {});
-    }
+    const transcoded = transcode(request, parsedOptions, testMessageFields);
+    assert.deepStrictEqual(
+      transcoded?.url,
+      'projects/test-project/contents/test-content'
+    );
+    assert.deepStrictEqual(transcoded?.data, {});
   });
   it('unset optional fields should not appear in query params', () => {
-    const requests: RequestType[] = [
-      {
-        projectId: 'test-project',
-        content: 'test-content',
-        optionalValue: 'undefined',
-      },
-      {
-        projectId: 'test-project',
-        content: 'test-content',
-      },
-    ];
+    const request: RequestType = {
+      projectId: 'test-project',
+      content: 'test-content',
+    };
     const parsedOptions: ParsedOptionsType = [
       {
         '(google.api.http)': {
@@ -695,12 +665,10 @@ describe('validate proto3 field with default value', () => {
         '(google.api.method_signature)': 'project_id, content',
       },
     ];
-    for (const request of requests) {
-      const transcoded = transcode(request, parsedOptions, testMessageFields);
-      assert.deepStrictEqual(transcoded?.url, 'projects/test-project');
-      assert.deepStrictEqual(transcoded?.data, 'test-content');
-      assert.deepStrictEqual(transcoded.queryString, '');
-    }
+    const transcoded = transcode(request, parsedOptions, testMessageFields);
+    assert.deepStrictEqual(transcoded?.url, 'projects/test-project');
+    assert.deepStrictEqual(transcoded?.data, 'test-content');
+    assert.strictEqual(transcoded.queryString, '');
   });
 });
 


### PR DESCRIPTION
Using `typeof something === 'undefined'` causes bugs (when instead the comparison goes as `something === 'undefined'`, as in several cases in this PR), and these bugs are very hard to find. In modern JS/TS, there is nothing wrong with directly comparing to `undefined` using `===`.