### PR TITLE
fix: require long instead of import

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "0.7.0",
+    "@grpc/proto-loader": "^0.7.1",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "^0.7.0",
+    "@grpc/proto-loader": "0.7.0",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
-    "@grpc/proto-loader": "^0.7.1",
+    "@grpc/proto-loader": "^0.7.0",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -79,7 +79,8 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
+    assert(!ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -114,7 +115,8 @@ describe('compileProtos tool', () => {
     const ts = await readFile(expectedTSResultFile);
     assert(ts.toString().includes('TestMessage'));
     assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
+    assert(!ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
@@ -146,7 +148,8 @@ describe('compileProtos tool', () => {
     assert(fs.existsSync(expectedTSResultFile));
     const ts = await readFile(expectedTSResultFile);
 
-    assert(ts.toString().includes('import * as Long'));
+    assert(ts.toString().includes('import Long = require'));
+    assert(!ts.toString().includes('import * as Long'));
     assert(
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -176,8 +176,12 @@ function fixDtsFile(dts: string): string {
   // 1. fix for pbts output: the corresponding protobufjs PR
   // https://github.com/protobufjs/protobuf.js/pull/1166
   // is merged but not yet released.
-  if (!dts.match(/import \* as Long/)) {
-    dts = 'import * as Long from "long";\n' + dts;
+  dts = dts.replace(
+    'import * as Long from "long";',
+    'import Long = require("long");'
+  );
+  if (!dts.match(/import Long = require/)) {
+    dts = 'import Long = require("long");' + dts;
   }
 
   // 2. fix protobufjs import: we don't want the libraries to


### PR DESCRIPTION
We'll need to figure out the `Long` stuff once and forever. Pin the dependency for now.