### PR TITLE
chore(deps): remove @types/download from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "1.1.19",
-    "@types/download": "^8.0.0",
     "@types/fs-extra": "^9.0.0",
     "@types/mocha": "^9.0.0",
     "@types/ncp": "^2.0.1",

--- a/test/showcase-server/package.json
+++ b/test/showcase-server/package.json
@@ -17,12 +17,13 @@
     "start": "node build/src/index.js"
   },
   "dependencies": {
-    "execa": "^5.0.0",
     "download": "^8.0.0",
+    "execa": "^5.0.0",
     "rimraf": "^3.0.0"
   },
   "devDependencies": {
-    "typescript": "^4.0.3",
-    "@types/node": "^14.11.2"
+    "@types/download": "^8.0.1",
+    "@types/node": "^14.11.2",
+    "typescript": "^4.0.3"
   }
 }


### PR DESCRIPTION
It's not needed now but breaks `yarn install` for some weird reason.