### PR TITLE
feat: export protobuf separately, avoid loading gRPC unless needed

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -412,6 +412,7 @@ export * as protobufMinimal from 'protobufjs/minimal';
 
 export {warn} from './warnings';
 export {Operation, operation} from './longRunningCalls/longrunning';
+export {GoogleError} from './googleError';
 
 // Different environments or bundlers may or may not respect "browser" field
 // in package.json (e.g. Electron does not respect it, but if you run the code

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -42,6 +42,9 @@ import {generateServiceStub} from './fallbackServiceStub';
 import {StreamType} from './streamingCalls/streaming';
 import {toLowerCamelCase} from './util';
 import {google} from '../protos/http';
+import * as IamProtos from '../protos/iam_service';
+import * as LocationProtos from '../protos/locations';
+import * as operationsProtos from '../protos/operations';
 
 export {FallbackServiceError};
 export {PathTemplate} from './pathTemplate';
@@ -347,6 +350,7 @@ export function lro(options: GrpcClientOptions) {
   const gaxGrpc = new GrpcClient(options);
   return new OperationsClientBuilder(gaxGrpc, options.protoJson);
 }
+export {operationsProtos, IamProtos, LocationProtos};
 
 /**
  * gRPC-fallback version of createApiCall
@@ -405,6 +409,9 @@ export function createApiCall(
 
 export {protobuf};
 export * as protobufMinimal from 'protobufjs/minimal';
+
+export {warn} from './warnings';
+export {Operation, operation} from './longRunningCalls/longrunning';
 
 // Different environments or bundlers may or may not respect "browser" field
 // in package.json (e.g. Electron does not respect it, but if you run the code

--- a/src/iamService.ts
+++ b/src/iamService.ts
@@ -17,8 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 import * as gax from './gax';
-import {GrpcClient, ClientStubOptions} from './grpc';
-import {GrpcClient as FallbackGrpcClient} from './fallback';
+import type {GrpcClient, ClientStubOptions} from './grpc';
+import type {GrpcClient as FallbackGrpcClient} from './fallback';
 import {createApiCall} from './createApiCall';
 import {GoogleAuth, OAuth2Client} from 'google-auth-library';
 import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
@@ -26,7 +26,7 @@ import * as routingHeader from './routingHeader';
 import * as gapicConfig from './iam_policy_service_client_config.json';
 import * as protos from '../protos/iam_service';
 import * as fallback from './fallback';
-import {Descriptors, ClientOptions, Callback} from './clientInterface';
+import type {Descriptors, ClientOptions, Callback} from './clientInterface';
 let version = require('../../package.json').version;
 import jsonProtos = require('../protos/iam_service.json');
 
@@ -40,7 +40,6 @@ export class IamClient {
   private _defaults: {[method: string]: gax.CallSettings};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _protos: any;
-  private _gaxGrpc: GrpcClient | FallbackGrpcClient;
   auth?: GoogleAuth | OAuth2Client;
   descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
   innerApiCalls: {[name: string]: Function} = {};
@@ -65,9 +64,6 @@ export class IamClient {
       options
     ) as ClientOptions & ClientStubOptions;
     version = opts.fallback ? fallback.version : version;
-    this._gaxGrpc = opts.fallback
-      ? new FallbackGrpcClient(opts)
-      : new GrpcClient(opts);
     opts.scopes = (this.constructor as typeof IamClient).scopes;
     // Save options to use in initialize() method.
     this._opts = opts;
@@ -88,7 +84,7 @@ export class IamClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this.gaxGrpc.loadProtoJSON(jsonProtos);
     // Put together the default options sent with requests.
     this._defaults = gaxGrpc.constructSettings(
       'google.iam.v1.IAMPolicy',

--- a/src/locationService.ts
+++ b/src/locationService.ts
@@ -15,13 +15,13 @@
 /* global window */
 import * as gax from './gax';
 import {warn} from './warnings';
-import {GrpcClient} from './grpc';
-import {GrpcClient as FallbackGrpcClient} from './fallback';
+import type {GrpcClient} from './grpc';
+import type {GrpcClient as FallbackGrpcClient} from './fallback';
 import {createApiCall} from './createApiCall';
-import {GoogleAuth} from 'google-auth-library';
+import type {GoogleAuth} from 'google-auth-library';
 import * as routingHeader from './routingHeader';
 import * as protos from '../protos/locations';
-import {
+import type {
   Descriptors,
   ClientOptions,
   Callback,

--- a/src/operationsClient.ts
+++ b/src/operationsClient.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {GoogleAuth, OAuth2Client} from 'google-auth-library';
+import type {GoogleAuth, OAuth2Client} from 'google-auth-library';
 import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
-import {ClientOptions, Callback} from './clientInterface';
+import type {ClientOptions, Callback} from './clientInterface';
 
 import {GaxCall, ResultTuple, RequestType} from './apitypes';
 import {createApiCall} from './createApiCall';
 import {PageDescriptor} from './descriptor';
 import * as gax from './gax';
-import {ClientStubOptions, GrpcClient} from './grpc';
-import {GrpcClient as FallbackGrpcClient} from './fallback';
+import type {ClientStubOptions, GrpcClient} from './grpc';
+import type {GrpcClient as FallbackGrpcClient} from './fallback';
 import * as protos from '../protos/operations';
 import configData = require('./operations_client_config.json');
 import {Transform} from 'stream';

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is here to re-export protobuf.js so that the proto.js files
+// produced by tools/compileProtos.ts did not depend on protobuf.js
+// directly.
+// Usage:
+//   const {protobufMinimal} = require('google-gax/build/src/protobuf');
+
+export * as protobufMinimal from 'protobufjs/minimal';

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -70,7 +70,7 @@ describe('compileProtos tool', () => {
     assert(
       js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
-    assert(js.toString().includes('require("google-gax").protobufMinimal'));
+    assert(js.toString().includes('require("google-gax/build/src/protobuf").protobufMinimal'));
     assert(!js.toString().includes('require("protobufjs/minimal")'));
 
     // check that it uses proper root object; it's taken from fixtures/package.json
@@ -85,7 +85,7 @@ describe('compileProtos tool', () => {
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
     assert(
-      ts.toString().includes('import {protobuf as $protobuf} from "google-gax"')
+      ts.toString().includes('import type {protobuf as $protobuf} from "google-gax"')
     );
     assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });
@@ -106,7 +106,7 @@ describe('compileProtos tool', () => {
     assert(
       js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
-    assert(js.toString().includes('require("google-gax").protobufMinimal'));
+    assert(js.toString().includes('require("google-gax/build/src/protobuf").protobufMinimal'));
     assert(!js.toString().includes('require("protobufjs/minimal")'));
 
     // check that it uses proper root object; it's taken from fixtures/package.json
@@ -121,7 +121,7 @@ describe('compileProtos tool', () => {
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
     assert(
-      ts.toString().includes('import {protobuf as $protobuf} from "google-gax"')
+      ts.toString().includes('import type {protobuf as $protobuf} from "google-gax"')
     );
     assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });

--- a/test/unit/compileProtos.ts
+++ b/test/unit/compileProtos.ts
@@ -70,7 +70,11 @@ describe('compileProtos tool', () => {
     assert(
       js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
-    assert(js.toString().includes('require("google-gax/build/src/protobuf").protobufMinimal'));
+    assert(
+      js
+        .toString()
+        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+    );
     assert(!js.toString().includes('require("protobufjs/minimal")'));
 
     // check that it uses proper root object; it's taken from fixtures/package.json
@@ -85,7 +89,9 @@ describe('compileProtos tool', () => {
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
     assert(
-      ts.toString().includes('import type {protobuf as $protobuf} from "google-gax"')
+      ts
+        .toString()
+        .includes('import type {protobuf as $protobuf} from "google-gax"')
     );
     assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });
@@ -106,7 +112,11 @@ describe('compileProtos tool', () => {
     assert(
       js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
-    assert(js.toString().includes('require("google-gax/build/src/protobuf").protobufMinimal'));
+    assert(
+      js
+        .toString()
+        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+    );
     assert(!js.toString().includes('require("protobufjs/minimal")'));
 
     // check that it uses proper root object; it's taken from fixtures/package.json
@@ -121,7 +131,9 @@ describe('compileProtos tool', () => {
       ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
     );
     assert(
-      ts.toString().includes('import type {protobuf as $protobuf} from "google-gax"')
+      ts
+        .toString()
+        .includes('import type {protobuf as $protobuf} from "google-gax"')
     );
     assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
   });

--- a/tools/compileProtos.ts
+++ b/tools/compileProtos.ts
@@ -161,7 +161,7 @@ function fixJsFile(js: string): string {
   // depend on protobufjs, so we re-export it from google-gax
   js = js.replace(
     'require("protobufjs/minimal")',
-    'require("google-gax").protobufMinimal'
+    'require("google-gax/build/src/protobuf").protobufMinimal'
   );
 
   // 2. add Apache license to the generated .js file
@@ -173,9 +173,7 @@ function fixJsFile(js: string): string {
 }
 
 function fixDtsFile(dts: string): string {
-  // 1. fix for pbts output: the corresponding protobufjs PR
-  // https://github.com/protobufjs/protobuf.js/pull/1166
-  // is merged but not yet released.
+  // 1. fix for pbts output to make sure we import Long properly
   dts = dts.replace(
     'import * as Long from "long";',
     'import Long = require("long");'
@@ -188,7 +186,7 @@ function fixDtsFile(dts: string): string {
   // depend on protobufjs, so we re-export it from google-gax
   dts = dts.replace(
     'import * as $protobuf from "protobufjs"',
-    'import {protobuf as $protobuf} from "google-gax"'
+    'import type {protobuf as $protobuf} from "google-gax"'
   );
 
   // 3. add Apache license to the generated .d.ts file


### PR DESCRIPTION
This PR contains a set of small fixes and new exports that will allow client libraries load just the REST version of `google-gax`, without auto-loading gRPC. The first library that will immediately benefit from this is Firestore.