### PR TITLE
fix: handle recursive proto messages in transcoding

### DIFF
--- a/src/fallbackRest.ts
+++ b/src/fallbackRest.ts
@@ -49,7 +49,7 @@ export function encodeRequest(
   const transcoded = transcode(
     json,
     rpc.parsedOptions,
-    rpc.resolvedRequestType!.fields
+    rpc.resolvedRequestType
   );
 
   if (!transcoded) {

--- a/test/fixtures/recursive.proto
+++ b/test/fixtures/recursive.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test;
+
+message Recursive {
+  Recursive value = 1;
+}


### PR DESCRIPTION
A part of the transcoding code (the code that converts gRPC request to HTTP request) fails if the protobuf type being transcoded is recursive. Fixing that.