### PR TITLE
feat: numeric enums for REST transport

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -30,7 +30,7 @@ import {
   BaseExternalAccountClient,
 } from 'google-auth-library';
 import {OperationsClientBuilder} from './operationsClient';
-import {GrpcClientOptions, ClientStubOptions} from './grpc';
+import type {GrpcClientOptions, ClientStubOptions} from './grpc';
 import {GaxCall, GRPCCall} from './apitypes';
 import {Descriptor, StreamDescriptor} from './descriptor';
 import {createApiCall as _createApiCall} from './createApiCall';
@@ -98,6 +98,7 @@ export class GrpcClient {
   grpcVersion: string;
   private static protoCache = new Map<string, protobuf.Root>();
   httpRules?: Array<google.api.IHttpRule>;
+  numericEnums: boolean;
 
   /**
    * In rare cases users might need to deallocate all memory consumed by loaded protos.
@@ -137,6 +138,7 @@ export class GrpcClient {
     this.fallback = options.fallback !== 'rest' ? 'proto' : 'rest';
     this.grpcVersion = require('../../package.json').version;
     this.httpRules = (options as GrpcClientOptions).httpRules;
+    this.numericEnums = (options as GrpcClientOptions).numericEnums ?? false;
   }
 
   /**
@@ -329,7 +331,8 @@ export class GrpcClient {
       servicePort,
       this.authClient,
       encoder,
-      decoder
+      decoder,
+      this.numericEnums
     );
 
     return serviceStub;

--- a/src/fallbackRest.ts
+++ b/src/fallbackRest.ts
@@ -32,13 +32,16 @@ export function encodeRequest(
   protocol: string,
   servicePath: string,
   servicePort: number,
-  request: {}
+  request: {},
+  numericEnums: boolean
 ): FetchParameters {
   const headers: {[key: string]: string} = {
     'Content-Type': 'application/json',
   };
   const message = rpc.resolvedRequestType!.fromObject(request);
-  const json = serializer.toProto3JSON(message);
+  const json = serializer.toProto3JSON(message, {
+    numericEnums,
+  });
   if (!json) {
     throw new Error(`Cannot send null request to RPC ${rpc.name}.`);
   }
@@ -55,6 +58,13 @@ export function encodeRequest(
       }`
     );
   }
+
+  // If numeric enums feature is requested, add extra parameter to the query string
+  if (numericEnums) {
+    transcoded.queryString =
+      (transcoded.queryString ? '&' : '') + '$alt=json%3Benum-encoding=int';
+  }
+
   // Converts httpMethod to method that permitted in standard Fetch API spec
   // https://fetch.spec.whatwg.org/#methods
   const method = transcoded.httpMethod.toUpperCase() as FetchParametersMethod;

--- a/src/fallbackServiceStub.ts
+++ b/src/fallbackServiceStub.ts
@@ -60,13 +60,15 @@ export function generateServiceStub(
     protocol: string,
     servicePath: string,
     servicePort: number,
-    request: {}
+    request: {},
+    numericEnums: boolean
   ) => FetchParameters,
   responseDecoder: (
     rpc: protobuf.Method,
     ok: boolean,
     response: Buffer | ArrayBuffer
-  ) => {}
+  ) => {},
+  numericEnums: boolean
 ) {
   const fetch = hasWindowFetch()
     ? window.fetch
@@ -95,7 +97,8 @@ export function generateServiceStub(
           protocol,
           servicePath,
           servicePort,
-          request
+          request,
+          numericEnums
         );
       } catch (err) {
         // we could not encode parameters; pass error to the callback

--- a/src/grpc.ts
+++ b/src/grpc.ts
@@ -49,6 +49,7 @@ export interface GrpcClientOptions extends GoogleAuthOptions {
   grpc?: GrpcModule;
   protoJson?: protobuf.Root;
   httpRules?: Array<google.api.IHttpRule>;
+  numericEnums?: boolean;
 }
 
 export interface MetadataValue {


### PR DESCRIPTION
Adding an option to send `enum` values as integers for HTTP transport.

Accoding to the design, in this case the HTTP request query string must contain `$alt=json%3Benum-encoding=int`, which will ask the backend to send `enum` values back as integers. `proto3-json-serializer` already supports that (and an option to serializer `enum` values as integers) as of version 1.1.0.

The GAPIC generator will enable this new option if the `BUILD.bazel` file has the corresponding flag (this will be implemented in my next PR to the generator).