### PR TITLE
chore: add actools as an owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/yoshi-nodejs @googleapis/actools
+
+# The yoshi-nodejs team is the default owner for nodejs repositories.
+*     @googleapis/yoshi-nodejs
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/actools
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-
-# The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/actools
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,6 @@
   "repo": "googleapis/gax-nodejs",
   "distribution_name": "google-gax",
   "api_id": "",
-  "requires_billing": false
+  "requires_billing": false,
+  "codeowner_team": "@googleapis/actools"
 }

--- a/owlbot.py
+++ b/owlbot.py
@@ -14,4 +14,4 @@
 
 import synthtool.languages.node as node
 
-node.owlbot_main(templates_excludes=["LICENSE", "README.md", ".github/sync-repo-settings.yaml", ".github/CODEOWNERS"])
+node.owlbot_main(templates_excludes=["LICENSE", "README.md", ".github/sync-repo-settings.yaml"])

--- a/owlbot.py
+++ b/owlbot.py
@@ -14,4 +14,4 @@
 
 import synthtool.languages.node as node
 
-node.owlbot_main(templates_excludes=["LICENSE", "README.md", ".github/sync-repo-settings.yaml"])
+node.owlbot_main(templates_excludes=["LICENSE", "README.md", ".github/sync-repo-settings.yaml", ".github/CODEOWNERS"])


### PR DESCRIPTION
Having generator-related features approved requires Client libraries team review rather than the JS-Team review.