### PR TITLE
fix: minify all common proto JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ package-lock.json
 .kitchen-sink/
 .showcase-server-dir/
 .compileProtos-test/
+.minify-test/
 __pycache__
 doc/
 dist/

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   "files": [
     "build/src",
     "build/tools/compileProtos.js",
+    "build/tools/minify.js",
     "build/protos/"
   ],
   "bin": {
-    "compileProtos": "build/tools/compileProtos.js"
+    "compileProtos": "build/tools/compileProtos.js",
+    "minifyProtoJson": "build/tools/minify.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "~1.6.0",
@@ -40,6 +42,7 @@
     "@types/pumpify": "^1.4.1",
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "^10.0.0",
+    "@types/uglify-js": "^3.17.0",
     "c8": "^7.0.0",
     "codecov": "^3.1.0",
     "execa": "^5.0.0",
@@ -59,6 +62,7 @@
     "stream-events": "^1.0.4",
     "ts-loader": "^8.0.0",
     "typescript": "^4.6.4",
+    "uglify-js": "^3.17.0",
     "walkdir": "^0.4.0",
     "webpack": "^4.0.0",
     "webpack-cli": "^4.0.0"
@@ -78,7 +82,7 @@
     "compile-http-protos": "pbjs -t static-module -r http_proto --keep-case google/api/http.proto -p ./protos > protos/http.js && pbts protos/http.js -o protos/http.d.ts",
     "compile-showcase-proto": "pbjs -t json google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/messaging.proto google/showcase/v1beta1/testing.proto -p ./protos > test/fixtures/google-gax-packaging-test-app/protos/protos.json && pbjs -t static-module -r showcase_protos google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/messaging.proto google/showcase/v1beta1/testing.proto -p ./protos > test/fixtures/google-gax-packaging-test-app/protos/protos.js && pbts test/fixtures/google-gax-packaging-test-app/protos/protos.js -o test/fixtures/google-gax-packaging-test-app/protos/protos.d.ts",
     "fix": "gts fix",
-    "prepare": "npm run compile && node ./build/tools/prepublish.js && mkdirp build/protos && cp -r protos/* build/protos/",
+    "prepare": "npm run compile && node ./build/tools/prepublish.js && mkdirp build/protos && cp -r protos/* build/protos/ && npm run minify-proto-json",
     "system-test": "c8 mocha build/test/system-test --timeout 600000 && npm run test-application",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "docs-test": "linkinator docs",
@@ -87,7 +91,8 @@
     "test-application": "cd test/test-application && npm run prefetch && npm install && npm start",
     "prelint": "cd samples; npm link ../; npm install",
     "precompile": "gts clean",
-    "update-protos": "node ./build/tools/listProtos.js"
+    "update-protos": "node ./build/tools/listProtos.js",
+    "minify-proto-json": "node ./build/tools/minify.js"
   },
   "repository": "googleapis/gax-nodejs",
   "keywords": [

--- a/test/unit/minify.ts
+++ b/test/unit/minify.ts
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, beforeEach} from 'mocha';
+import * as fs from 'fs';
+import {promises as fsp} from 'fs';
+import * as rimraf from 'rimraf';
+import * as path from 'path';
+import * as util from 'util';
+import * as minify from '../../tools/minify';
+
+const rmrf = util.promisify(rimraf);
+const testDir = path.join(process.cwd(), '.minify-test');
+const fixturesDir = path.join(__dirname, '..', 'fixtures');
+
+describe('minify tool', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(testDir)) {
+      await rmrf(testDir);
+    }
+    await fsp.mkdir(testDir);
+  });
+
+  it('minifies the proto JSON file', async () => {
+    const echoProtoJsonFixture = path.join(fixturesDir, 'echo.json');
+    const echoProtoJson = path.join(testDir, 'echo.json');
+    await fsp.copyFile(echoProtoJsonFixture, echoProtoJson);
+    const statBefore = await fsp.stat(echoProtoJson);
+    const objectBefore = require(echoProtoJson);
+    await minify.main(testDir);
+    const statAfter = await fsp.stat(echoProtoJson);
+    const objectAfter = require(echoProtoJson);
+    const contentAfter = (await fsp.readFile(echoProtoJson)).toString();
+    const parsedObjectAfter = JSON.parse(contentAfter);
+    assert(statBefore.size > statAfter.size);
+    assert.deepEqual(objectBefore, objectAfter);
+    assert.deepEqual(objectBefore, parsedObjectAfter);
+  });
+});

--- a/tools/minify.ts
+++ b/tools/minify.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Minifies proto JSON files under `build/`.
+
+import {promises as fsp} from 'fs';
+import * as path from 'path';
+import * as uglify from 'uglify-js';
+
+async function minifyFile(filename: string) {
+  const content = (await fsp.readFile(filename)).toString();
+  const output = uglify.minify(content, {
+    expression: true,
+    compress: false, // we need to keep it valid JSON
+    output: {quote_keys: true},
+  });
+  if (output.error) {
+    throw output.error;
+  }
+  await fsp.writeFile(filename, output.code);
+}
+
+export async function main(directory?: string) {
+  const buildDir = directory ?? path.join(process.cwd(), 'build', 'protos');
+  const files = await fsp.readdir(buildDir);
+  const jsonFiles = files.filter(file => file.match(/\.json$/));
+  for (const jsonFile of jsonFiles) {
+    console.log(`Minifying ${jsonFile}...`);
+    await minifyFile(path.join(buildDir, jsonFile));
+  }
+  console.log('Minified all proto JSON files successfully.');
+}
+
+function usage() {
+  console.log(`Usage: node ${process.argv[1]} [directory]`);
+  console.log(
+    'Minifies all JSON files in-place in the given directory (non-recursively).'
+  );
+  console.log(
+    'If no directory is given, minifies JSON files in ./build/protos.'
+  );
+}
+
+if (require.main === module) {
+  // argv[0] is node.js binary, argv[1] is script path
+
+  if (process.argv[2] === '--help') {
+    usage();
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+
+  main(process.argv[2]);
+}


### PR DESCRIPTION
We ship several proto JSON files by copying them to the `build/` folder before packing the package. These files are loaded into `protobufjs` and are not supposed to be read by a human (we ship `.d.ts` for humans). Since some libraries would benefit from having faster cold start time, and the size of the loaded files directly affects cold start time, let's minify these proto JSONs.

I'm exporting this small script because we can do the same in the libraries.

Size comparison:

Original files (in `protos/` folder):

```
$ ls -lh protos/*.json
-rw-r--r--  1 fenster  primarygroup    94K Oct 19  2021 protos/compute_operations.json
-rw-r--r--  1 fenster  primarygroup    41K Jul 21  2021 protos/iam_service.json
-rw-r--r--  1 fenster  primarygroup    33K Aug  3  2021 protos/locations.json
-rw-r--r--  1 fenster  primarygroup    37K Jul 21  2021 protos/operations.json
-rw-r--r--  1 fenster  primarygroup   6.3K Aug  3  2021 protos/status.json
```

Minified files (in `build/protos`):

```
$ ls -lh build/protos/*.json
-rw-r--r--  1 fenster  primarygroup    32K Sep  4 01:52 build/protos/compute_operations.json
-rw-r--r--  1 fenster  primarygroup    15K Sep  4 01:52 build/protos/iam_service.json
-rw-r--r--  1 fenster  primarygroup    12K Sep  4 01:52 build/protos/locations.json
-rw-r--r--  1 fenster  primarygroup    14K Sep  4 01:52 build/protos/operations.json
-rw-r--r--  1 fenster  primarygroup   2.1K Sep  4 01:52 build/protos/status.json
```
