### PR TITLE
fix: better error handling for REST transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "1.1.19",
-    "@types/mkdirp": "^1.0.2",
     "@types/mocha": "^9.0.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^18.0.0",

--- a/src/fallbackServiceStub.ts
+++ b/src/fallbackServiceStub.ts
@@ -175,12 +175,7 @@ export function generateServiceStub(
             ])
               .then(([ok, buffer]: [boolean, Buffer | ArrayBuffer]) => {
                 const response = responseDecoder(rpc, ok, buffer);
-                if (!callback) {
-                  throw new Error(
-                    'Internal error: callback is not provided for non-streaming call.'
-                  );
-                }
-                callback(null, response);
+                callback!(null, response);
               })
               .catch((err: Error) => {
                 if (!cancelRequested || err.name !== 'AbortError') {

--- a/src/fallbackServiceStub.ts
+++ b/src/fallbackServiceStub.ts
@@ -34,9 +34,9 @@ export interface FallbackServiceStub {
   // Compatible with gRPC service stub
   [method: string]: (
     request: {},
-    options: {},
-    metadata: {},
-    callback: (err?: Error, response?: {} | undefined) => void
+    options?: {},
+    metadata?: {},
+    callback?: (err?: Error, response?: {} | undefined) => void
   ) => StreamArrayParser | {cancel: () => void};
 }
 
@@ -83,10 +83,12 @@ export function generateServiceStub(
   for (const [rpcName, rpc] of Object.entries(rpcs)) {
     serviceStub[rpcName] = (
       request: {},
-      options: {[name: string]: string},
-      _metadata: {},
-      callback: Function
+      options?: {[name: string]: string},
+      _metadata?: {} | Function,
+      callback?: Function
     ) => {
+      options ??= {};
+
       // We cannot use async-await in this function because we need to return the canceller object as soon as possible.
       // Using plain old promises instead.
 
@@ -103,7 +105,9 @@ export function generateServiceStub(
       } catch (err) {
         // we could not encode parameters; pass error to the callback
         // and return a no-op canceler object.
-        callback(err);
+        if (callback) {
+          callback(err);
+        }
         return {
           cancel() {},
         };
@@ -171,6 +175,11 @@ export function generateServiceStub(
             ])
               .then(([ok, buffer]: [boolean, Buffer | ArrayBuffer]) => {
                 const response = responseDecoder(rpc, ok, buffer);
+                if (!callback) {
+                  throw new Error(
+                    'Internal error: callback is not provided for non-streaming call.'
+                  );
+                }
                 callback(null, response);
               })
               .catch((err: Error) => {
@@ -180,14 +189,27 @@ export function generateServiceStub(
                       callback(err);
                     }
                     streamArrayParser.emit('error', err);
-                  } else {
+                  } else if (callback) {
                     callback(err);
+                  } else {
+                    throw err;
                   }
                 }
               });
           }
         })
-        .catch((err: unknown) => callback(err));
+        .catch((err: unknown) => {
+          if (rpc.responseStream) {
+            if (callback) {
+              callback(err);
+            }
+            streamArrayParser.emit('error', err);
+          } else if (callback) {
+            callback(err);
+          } else {
+            throw err;
+          }
+        });
 
       if (rpc.responseStream) {
         return streamArrayParser;

--- a/test/unit/streamArrayParser.ts
+++ b/test/unit/streamArrayParser.ts
@@ -132,7 +132,7 @@ describe('Parse REST stream array', () => {
     });
   });
 
-  it('should assign defaul value if the service response is not valid protobuf specific JSON', done => {
+  it('should assign default value if the service response is not valid protobuf specific JSON', done => {
     const expectedResults = [
       {
         name: 'Not Valid Name Message',

--- a/tools/prepublish.ts
+++ b/tools/prepublish.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 // Note: the following three imports will be all gone when we support Node.js 16+.
 // But until then, we'll use these modules.
 import * as rimraf from 'rimraf';
-import * as mkdirp from 'mkdirp';
+import mkdirp from 'mkdirp';
 import * as ncp from 'ncp';
 import {promisify} from 'util';
 


### PR DESCRIPTION
Fixes googleapis/google-cloud-node-core#252.

In REST streaming use case, `callback` is not provided. Instead, the caller expects to see `error` events in the returned stream. If, for whatever reason, an error occurs in the streaming call, the caller would get `TypeError: callback is not a function`.

Make sure we only call `callback` if it's provided, and use the stream emitter to report errors in other cases.

Note: the unrelated change to `mkdirp` import is just because they are apparently making ESM related changes. It just makes our code compile again.