### PR TITLE
fix: compilation error in fallback.ts

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -277,7 +277,7 @@ export class GrpcClient {
   ) {
     if (!this.authClient) {
       if (this.auth && 'getClient' in this.auth) {
-        this.authClient = await this.auth.getClient();
+        this.authClient = (await this.auth.getClient()) as AuthClient;
       } else if (this.auth && 'getRequestHeaders' in this.auth) {
         this.authClient = this.auth;
       }


### PR DESCRIPTION
The compilation failed for me on a clean install, possibly because of some auth library update. We don't really care about the real type of the returned auth client, so a simple type cast should be good.