### PR TITLE
feat: publish protos.js using es6 and amd, if needed

### DIFF
--- a/tools/src/compileProtos.ts
+++ b/tools/src/compileProtos.ts
@@ -157,6 +157,13 @@ function updateDtsTypes(dts: string, enums: Set<string>): string {
 }
 
 function fixJsFile(js: string): string {
+  // 1. fix protobufjs import: we don't want the libraries to
+  // depend on protobufjs, so we re-export it from google-gax
+  js = js.replace(
+    'import * as $protobuf from "protobufjs/minimal"',
+    'import * as $protobuf from "google-gax/build/src/protobufjs/protobufMinimal.js"'
+  );
+
   // 1. fix protobufjs require: we don't want the libraries to
   // depend on protobufjs, so we re-export it from google-gax
   js = js.replace(
@@ -230,7 +237,8 @@ async function buildListOfProtos(protoJsonFiles: string[]): Promise<string[]> {
 async function compileProtos(
   rootName: string,
   protos: string[],
-  skipJson = false
+  skipJson = false,
+  amd = false
 ): Promise<void> {
   if (!skipJson) {
     // generate protos.json file from proto list
@@ -267,6 +275,8 @@ async function compileProtos(
     path.join(__dirname, '..', '..', '..', 'google-gax', 'build', 'protos'),
     '-o',
     jsOutput,
+    '-w',
+    'es6',
   ];
   pbjsArgs4js.push(...protos);
   await pbjsMain(pbjsArgs4js);
@@ -274,6 +284,28 @@ async function compileProtos(
   let jsResult = (await readFile(jsOutput)).toString();
   jsResult = fixJsFile(jsResult);
   await writeFile(jsOutput, jsResult);
+
+  if (amd) {
+    const jsOutputAmd = path.join('protos', 'protos.cjs');
+    const pbjsArgs4jsAmd = [
+      '-r',
+      rootName,
+      '--target',
+      'static-module',
+      '-p',
+      'protos',
+      '-p',
+      path.join(__dirname, '..', '..', '..', 'google-gax', 'build', 'protos'),
+      '-o',
+      jsOutputAmd,
+    ];
+    pbjsArgs4jsAmd.push(...protos);
+    await pbjsMain(pbjsArgs4jsAmd);
+
+    let jsResult = (await readFile(jsOutputAmd)).toString();
+    jsResult = fixJsFile(jsResult);
+    await writeFile(jsOutputAmd, jsResult);
+  }
 
   // generate protos/protos.d.ts
   const tsOutput = path.join('protos', 'protos.d.ts');
@@ -324,10 +356,15 @@ export async function generateRootName(directories: string[]): Promise<string> {
 export async function main(parameters: string[]): Promise<void> {
   const protoJsonFiles: string[] = [];
   let skipJson = false;
+  let amd = false;
   const directories: string[] = [];
   for (const parameter of parameters) {
     if (parameter === '--skip-json') {
       skipJson = true;
+      continue;
+    }
+    if (parameter === '--amd') {
+      amd = true;
       continue;
     }
     // it's not an option so it's a directory
@@ -337,14 +374,16 @@ export async function main(parameters: string[]): Promise<void> {
   }
   const rootName = await generateRootName(directories);
   const protos = await buildListOfProtos(protoJsonFiles);
-  await compileProtos(rootName, protos, skipJson);
+  await compileProtos(rootName, protos, skipJson, amd);
 }
 
 /**
  * Shows the usage information.
  */
 function usage() {
-  console.log(`Usage: node ${process.argv[1]} [--skip-json] directory ...`);
+  console.log(
+    `Usage: node ${process.argv[1]} [--skip-json] [--amd] directory ...`
+  );
   console.log(
     `Finds all files matching ${PROTO_LIST_REGEX} in the given directories.`
   );

--- a/tools/test/compileProtos.ts
+++ b/tools/test/compileProtos.ts
@@ -33,6 +33,7 @@ const cwd = process.cwd();
 
 const expectedJsonResultFile = path.join(resultDir, 'protos.json');
 const expectedJSResultFile = path.join(resultDir, 'protos.js');
+const expectedCommonJSResultFile = path.join(resultDir, 'protos.cjs');
 const expectedTSResultFile = path.join(resultDir, 'protos.d.ts');
 
 describe('compileProtos tool', () => {
@@ -73,9 +74,65 @@ describe('compileProtos tool', () => {
     assert(
       js
         .toString()
+        .includes(
+          'import * as $protobuf from "google-gax/build/src/protobufjs/protobufMinimal.js"'
+        )
+    );
+    assert(!js.toString().includes('require("protobufjs/minimal")'));
+    assert(
+      !js.toString().includes('import * as $protobuf from "protobufjs/minimal"')
+    );
+
+    // check that it uses proper root object; it's taken from fixtures/package.json
+    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+
+    const ts = await readFile(expectedTSResultFile);
+    assert(ts.toString().includes('TestMessage'));
+    assert(ts.toString().includes('LibraryService'));
+    assert(ts.toString().includes('import Long = require'));
+    assert(!ts.toString().includes('import * as Long'));
+    assert(
+      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+    );
+    assert(
+      ts
+        .toString()
+        .includes('import type {protobuf as $protobuf} from "google-gax"')
+    );
+    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
+  });
+
+  it('compiles protos to JSON, common JS, TS', async function () {
+    this.timeout(20000);
+    await compileProtos.main([
+      '--amd',
+      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+    ]);
+    assert(fs.existsSync(expectedJsonResultFile));
+    assert(fs.existsSync(expectedJSResultFile));
+    assert(fs.existsSync(expectedTSResultFile));
+    assert(fs.existsSync(expectedCommonJSResultFile));
+
+    const json = await readFile(expectedJsonResultFile);
+    const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
+    assert(root.lookup('TestMessage'));
+    assert(root.lookup('LibraryService'));
+
+    const js = await readFile(expectedCommonJSResultFile);
+    assert(js.toString().includes('TestMessage'));
+    assert(js.toString().includes('LibraryService'));
+    assert(
+      js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+    );
+    assert(
+      js
+        .toString()
         .includes('require("google-gax/build/src/protobuf").protobufMinimal')
     );
     assert(!js.toString().includes('require("protobufjs/minimal")'));
+    assert(
+      !js.toString().includes('import * as $protobuf from "protobufjs/minimal"')
+    );
 
     // check that it uses proper root object; it's taken from fixtures/package.json
     assert(js.toString().includes('$protobuf.roots._org_fake_package'));
@@ -115,9 +172,14 @@ describe('compileProtos tool', () => {
     assert(
       js
         .toString()
-        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+        .includes(
+          'import * as $protobuf from "google-gax/build/src/protobufjs/protobufMinimal.js"'
+        )
     );
     assert(!js.toString().includes('require("protobufjs/minimal")'));
+    assert(
+      !js.toString().includes('import * as $protobuf from "protobufjs/minimal"')
+    );
 
     // check that it uses proper root object; it's taken from fixtures/package.json
     assert(js.toString().includes('$protobuf.roots._org_fake_package'));


### PR DESCRIPTION
See: https://github.com/googleapis/google-cloud-node/pull/4189 and doc `Migrate to Node 14 + ESM`

We'll likely need to publish protos.js in ESM format, instead of commonJS. However, this adds an option to also publish in cjs if needed.