### PR TITLE
fix: add missing devDependency for compodoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "retry-request": "^5.0.0"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@compodoc/compodoc": "^1.1.21",
     "@types/mocha": "^9.0.0",
     "@types/ncp": "^2.0.1",
@@ -61,7 +60,7 @@
     "webpack-cli": "^4.0.0"
   },
   "scripts": {
-    "docs": "compodoc src/",
+    "docs": "npm install --save-dev @babel/plugin-proposal-private-methods && compodoc src/",
     "pretest": "npm run prepare",
     "test": "c8 mocha build/test/unit",
     "lint": "gts check src samples test",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "retry-request": "^5.0.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "^1.1.21",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@compodoc/compodoc": "1.1.19",
     "@types/mocha": "^9.0.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^18.0.0",
@@ -60,7 +61,7 @@
     "webpack-cli": "^4.0.0"
   },
   "scripts": {
-    "docs": "npm install --save-dev @babel/plugin-proposal-private-methods && compodoc src/",
+    "docs": "compodoc src/",
     "pretest": "npm run prepare",
     "test": "c8 mocha build/test/unit",
     "lint": "gts check src samples test",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "retry-request": "^5.0.0"
   },
   "devDependencies": {
-    "@compodoc/compodoc": "1.1.19",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@compodoc/compodoc": "^1.1.21",
     "@types/mocha": "^9.0.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^18.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": ".",
     "outDir": "build",
     "noImplicitAny": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "rootDir": ".",
     "outDir": "build",
     "noImplicitAny": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true
+    "resolveJsonModule": true
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
We might be dropping `compodoc` soon, but until we're on it, let's fix the failing `docs-test`. Looks like `compodoc` expects to have an extra `devDependency`. I think it's their bug, but let's just fix it here for now to unblock the CI.

Also here: adding `skipLibCheck` to `tsconfig.json` to stop being broken by random TS problems in dependencies.