### PR TITLE
fix: update some pnpm deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "google-auth-library": "^9.0.0",
     "node-fetch": "^2.6.1",
     "object-hash": "^3.0.0",
-    "proto3-json-serializer": "^1.0.0",
+    "proto3-json-serializer": "^1.1.1",
     "protobufjs": "7.2.4",
     "retry-request": "^6.0.0"
   },
@@ -38,7 +38,7 @@
     "codecov": "^3.1.0",
     "execa": "^5.0.0",
     "gapic-tools": "^0.1.7",
-    "google-proto-files": "^3.0.0",
+    "google-proto-files": "^3.0.3",
     "gts": "^3.1.0",
     "linkinator": "^4.0.0",
     "long": "^4.0.0",

--- a/tools/package.json
+++ b/tools/package.json
@@ -28,7 +28,7 @@
   "author": "Google API Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "google-proto-files": "^3.0.0",
+    "google-proto-files": "^3.0.3",
     "protobufjs-cli": "1.1.1",
     "rimraf": "^5.0.1",
     "uglify-js": "^3.17.0",


### PR DESCRIPTION
Due to this weird bug: https://github.com/pnpm/pnpm/issues/6463, this causes us to not be able to build this package using pnpm. This causes different versions of protobufjs to be installed.
