### PR TITLE
chore: release new version of gapic-tools

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gapic-tools",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "compiles, updates, and minifies protos",
   "main": "build/src/compileProtos.js",
   "files": [


### PR DESCRIPTION
Need to do this until I set up the release-please process properly.
