### PR TITLE
fix(deps): change grpc-js dependency to major

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "!build/src/**/*.map"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "~1.9.0",
+    "@grpc/grpc-js": "^1.9.0",
     "@grpc/proto-loader": "^0.7.0",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
Minor versions should not break BC, and every time grpc-js has a new minor release, the dependency must be updated to allow its usage.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-node-core#240.
