### PR TITLE
use --keep-case in pbjs arguments

### DIFF
--- a/tools/src/compileProtos.ts
+++ b/tools/src/compileProtos.ts
@@ -249,6 +249,7 @@ async function compileProtos(
     const pbjsArgs4JSON = [
       '--target',
       'json',
+      '--keep-case',
       '-p',
       'protos',
       '-p',
@@ -267,6 +268,7 @@ async function compileProtos(
     rootName,
     '--target',
     'static-module',
+    '--keep-case',
     '-p',
     'protos',
     '-p',


### PR DESCRIPTION
Should generate TS files from protos with everything in snake case, as god intended.