### PR TITLE
build: correct repository for publication failures

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -89,6 +89,11 @@
   "keywords": [
     "grpc"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/gax-nodejs.git",
+    "directory": "gax"
+  },
   "author": "Google API Authors",
   "license": "Apache-2.0",
   "bugs": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -40,7 +40,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/googleapis/gax-nodejs.git",
-    "directory": "packages/gapic-tools"
+    "directory": "gapic-tools"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.5",

--- a/tools/package.json
+++ b/tools/package.json
@@ -37,7 +37,11 @@
     "uglify-js": "^3.17.0",
     "walkdir": "^0.4.0"
   },
-  "repository": "googleapis/gax-nodejs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleapis/gax-nodejs.git",
+    "directory": "packages/gapic-tools"
+  },
   "devDependencies": {
     "@babel/cli": "^7.22.5",
     "@babel/types": "^7.22.5",


### PR DESCRIPTION
Should fix: 
```
npm ERR! code E400
npm ERR! 400 Bad Request - PUT [https://wombat-dressing-room.appspot.com/gapic-tools](https://www.google.com/url?q=https://wombat-dressing-room.appspot.com/gapic-tools&sa=D) - 
npm ERR!   ===============================
npm ERR!   Publish service error
npm ERR!   -------------------------------
npm ERR!   matching release v0.2.0 not found for googleapis/gax-nodejs. Did not find any tags matching: v0.2.0
npm ERR!   ===============================
npm ERR!
```