### PR TITLE
feat: add specified outputdir

### DIFF
--- a/tools/test/compileProtos.ts
+++ b/tools/test/compileProtos.ts
@@ -26,317 +26,477 @@ import * as compileProtos from '../src/compileProtos';
 const readFile = util.promisify(fs.readFile);
 const mkdir = util.promisify(fs.mkdir);
 
-const testDir = path.join(process.cwd(), '.compileProtos-test');
-const resultDir = path.join(testDir, 'protos');
-const cwd = process.cwd();
-
-const expectedJsonResultFile = path.join(resultDir, 'protos.json');
-const expectedJSResultFile = path.join(resultDir, 'protos.js');
-const expectedTSResultFile = path.join(resultDir, 'protos.d.ts');
-const expectedCommonJSResultFile = path.join(resultDir, 'protos.cjs');
-
 describe('compileProtos tool', () => {
-  beforeEach(async () => {
-    if (fs.existsSync(testDir)) {
-      await rimraf(testDir);
-    }
-    await mkdir(testDir);
-    await mkdir(resultDir);
+  describe('in same directory', () => {
+    const testDir = path.join(process.cwd(), '.compileProtos-test');
+    const resultDir = path.join(testDir, 'protos');
+    const cwd = process.cwd();
 
-    process.chdir(testDir);
+    const expectedJsonResultFile = path.join(resultDir, 'protos.json');
+    const expectedJSResultFile = path.join(resultDir, 'protos.js');
+    const expectedTSResultFile = path.join(resultDir, 'protos.d.ts');
+    const expectedCommonJSResultFile = path.join(resultDir, 'protos.cjs');
+    beforeEach(async () => {
+      if (fs.existsSync(testDir)) {
+        await rimraf(testDir);
+      }
+      await mkdir(testDir);
+      await mkdir(resultDir);
+
+      process.chdir(testDir);
+    });
+
+    afterEach(() => {
+      process.chdir(cwd);
+    });
+
+    it('fetches gax from the appropriate place', async () => {
+      assert.deepStrictEqual(fs.readdirSync(compileProtos.gaxProtos), [
+        'compute_operations.d.ts',
+        'compute_operations.js',
+        'compute_operations.json',
+        'google',
+        'http.d.ts',
+        'http.js',
+        'iam_service.d.ts',
+        'iam_service.js',
+        'iam_service.json',
+        'locations.d.ts',
+        'locations.js',
+        'locations.json',
+        'operations.d.ts',
+        'operations.js',
+        'operations.json',
+        'status.json',
+      ]);
+    });
+    it('compiles protos to JSON, JS, TS', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+      ]);
+      assert(fs.existsSync(expectedJsonResultFile));
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
+
+      const json = await readFile(expectedJsonResultFile);
+      const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
+      assert(root.lookup('TestMessage'));
+      assert(root.lookup('LibraryService'));
+
+      const js = await readFile(expectedJSResultFile);
+      assert(js.toString().includes('TestMessage'));
+      assert(js.toString().includes('LibraryService'));
+      assert(
+        js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        js
+          .toString()
+          .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+      );
+      assert(!js.toString().includes('require("protobufjs/minimal")'));
+
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+
+      const ts = await readFile(expectedTSResultFile);
+      assert(ts.toString().includes('TestMessage'));
+      assert(ts.toString().includes('LibraryService'));
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        ts
+          .toString()
+          .includes('import type {protobuf as $protobuf} from "google-gax"')
+      );
+      assert(
+        !ts.toString().includes('import * as $protobuf from "protobufjs"')
+      );
+    });
+
+    it('compiles protos to CJS and ES6 if --esm is specified', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        '--esm',
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'esm'),
+      ]);
+      assert(fs.existsSync(expectedJsonResultFile));
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
+      assert(fs.existsSync(expectedCommonJSResultFile));
+
+      const json = await readFile(expectedJsonResultFile);
+      const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
+      assert(root.lookup('TestMessage'));
+      assert(root.lookup('LibraryService'));
+
+      const cjs = await readFile(expectedCommonJSResultFile);
+      assert(cjs.toString().includes('TestMessage'));
+      assert(cjs.toString().includes('LibraryService'));
+      assert(
+        cjs.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        cjs
+          .toString()
+          .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+      );
+      assert(!cjs.toString().includes('require("protobufjs/minimal")'));
+
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(cjs.toString().includes('$protobuf.roots._org_fake_package'));
+
+      const js = await readFile(expectedJSResultFile);
+      assert(js.toString().includes('TestMessage'));
+      assert(js.toString().includes('LibraryService'));
+      assert(
+        js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        js
+          .toString()
+          .includes(
+            'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf.js"'
+          )
+      );
+      assert(!js.toString().includes('require("protobufjs/minimal")'));
+      assert(
+        !js
+          .toString()
+          .includes('import * as $protobuf from "protobufjs/minimal"')
+      );
+
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+
+      const ts = await readFile(expectedTSResultFile);
+      assert(ts.toString().includes('TestMessage'));
+      assert(ts.toString().includes('LibraryService'));
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        ts
+          .toString()
+          .includes('import type {protobuf as $protobuf} from "google-gax"')
+      );
+      assert(
+        !ts.toString().includes('import * as $protobuf from "protobufjs"')
+      );
+    });
+
+    it('compiles protos to JS, TS, skips JSON if asked', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        '--skip-json',
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+      ]);
+      assert(!fs.existsSync(expectedJsonResultFile));
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
+
+      const js = await readFile(expectedJSResultFile);
+      assert(js.toString().includes('TestMessage'));
+      assert(js.toString().includes('LibraryService'));
+      assert(
+        js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        js
+          .toString()
+          .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+      );
+      assert(!js.toString().includes('require("protobufjs/minimal")'));
+
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+
+      const ts = await readFile(expectedTSResultFile);
+      assert(ts.toString().includes('TestMessage'));
+      assert(ts.toString().includes('LibraryService'));
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        ts
+          .toString()
+          .includes('import type {protobuf as $protobuf} from "google-gax"')
+      );
+      assert(
+        !ts.toString().includes('import * as $protobuf from "protobufjs"')
+      );
+    });
+
+    it('writes an empty object if no protos are given', async () => {
+      await compileProtos.main([
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          'test',
+          'fixtures',
+          'protoLists',
+          'empty'
+        ),
+      ]);
+      assert(fs.existsSync(expectedJsonResultFile));
+    });
+
+    it('fixes types in the TS file', async () => {
+      await compileProtos.main([
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'dts-update'),
+      ]);
+      assert(fs.existsSync(expectedTSResultFile));
+      const ts = await readFile(expectedTSResultFile);
+
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(ts.toString().includes('longField?: (number|Long|string|null);'));
+      assert(ts.toString().includes('bytesField?: (Uint8Array|string|null);'));
+      assert(
+        ts
+          .toString()
+          .includes(
+            'enumField?: (google.TestEnum|keyof typeof google.TestEnum|null);'
+          )
+      );
+      assert(
+        ts
+          .toString()
+          .includes(
+            '"case"?: (google.TestEnum|keyof typeof google.TestEnum|null);'
+          )
+      );
+      assert(ts.toString().includes('public longField: (number|Long|string);'));
+      assert(ts.toString().includes('public bytesField: (Uint8Array|string);'));
+      assert(
+        ts
+          .toString()
+          .includes(
+            'public enumField: (google.TestEnum|keyof typeof google.TestEnum);'
+          )
+      );
+      assert(
+        ts
+          .toString()
+          .includes(
+            'public case: (google.TestEnum|keyof typeof google.TestEnum);'
+          )
+      );
+    });
+
+    it('proposes the name for protobuf root', async () => {
+      const rootName = await compileProtos.generateRootName([
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'dts-update'),
+      ]);
+      assert.strictEqual(rootName, '_org_fake_package_protos');
+    });
+
+    it('falls back to the default name for protobuf root if unable to guess', async () => {
+      const rootName = await compileProtos.generateRootName([
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          'test',
+          'fixtures',
+          'protoLists',
+          'empty'
+        ),
+      ]);
+      assert.strictEqual(rootName, 'default');
+    });
+
+    it('reformat the JSDOC link in the JS and TS file', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+      ]);
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
+      const js = await readFile(expectedJSResultFile);
+      const ts = await readFile(expectedTSResultFile);
+      const links = [
+        '{@link google.example.library.v1.LibraryService#createShelf}',
+        '{@link google.example.library.v1.LibraryService#getShelf}',
+        '{@link google.example.library.v1.LibraryService#listShelves}',
+        '{@link google.example.library.v1.LibraryService#deleteShelf}',
+        '{@link google.example.library.v1.LibraryService#mergeShelves}',
+        '{@link google.example.library.v1.LibraryService#createBook}',
+        '{@link google.example.library.v1.LibraryService#getBook}',
+        '{@link google.example.library.v1.LibraryService#listBooks}',
+        '{@link google.example.library.v1.LibraryService#deleteBook}',
+        '{@link google.example.library.v1.LibraryService#updateBook}',
+        '{@link google.example.library.v1.LibraryService#moveBook}',
+      ];
+      for (const link of links) {
+        const reformate = link.replace('#', '|');
+        assert(js.toString().includes(reformate));
+        assert(ts.toString().includes(reformate));
+        assert.equal(js.toString().includes(link), false);
+      }
+    });
   });
+  describe('in different output directory', () => {
+    const testDir = path.join(process.cwd(), '.compileProtos-test');
+    const outputDir = path.join(testDir, 'anotherLevel');
+    const resultDir = path.join(outputDir, 'protos');
+    const cwd = process.cwd();
 
-  afterEach(() => {
-    process.chdir(cwd);
-  });
+    const expectedJsonResultFile = path.join(resultDir, 'protos.json');
+    const expectedJSResultFile = path.join(resultDir, 'protos.js');
+    const expectedTSResultFile = path.join(resultDir, 'protos.d.ts');
+    const expectedCommonJSResultFile = path.join(resultDir, 'protos.cjs');
+    beforeEach(async () => {
+      if (fs.existsSync(testDir)) {
+        await rimraf(testDir);
+      }
+      await mkdir(testDir);
+      await mkdir(outputDir);
+      await mkdir(resultDir);
 
-  it('fetches gax from the appropriate place', async () => {
-    assert.deepStrictEqual(fs.readdirSync(compileProtos.gaxProtos), [
-      'compute_operations.d.ts',
-      'compute_operations.js',
-      'compute_operations.json',
-      'google',
-      'http.d.ts',
-      'http.js',
-      'iam_service.d.ts',
-      'iam_service.js',
-      'iam_service.json',
-      'locations.d.ts',
-      'locations.js',
-      'locations.json',
-      'operations.d.ts',
-      'operations.js',
-      'operations.json',
-      'status.json',
-    ]);
-  });
-  it('compiles protos to JSON, JS, TS', async function () {
-    this.timeout(20000);
-    await compileProtos.main([
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
-    ]);
-    assert(fs.existsSync(expectedJsonResultFile));
-    assert(fs.existsSync(expectedJSResultFile));
-    assert(fs.existsSync(expectedTSResultFile));
+      process.chdir(testDir);
+    });
 
-    const json = await readFile(expectedJsonResultFile);
-    const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
-    assert(root.lookup('TestMessage'));
-    assert(root.lookup('LibraryService'));
+    afterEach(() => {
+      process.chdir(cwd);
+    });
 
-    const js = await readFile(expectedJSResultFile);
-    assert(js.toString().includes('TestMessage'));
-    assert(js.toString().includes('LibraryService'));
-    assert(
-      js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      js
-        .toString()
-        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
-    );
-    assert(!js.toString().includes('require("protobufjs/minimal")'));
+    it('compiles protos to CJS and ES6 and outputs it in a specified directory', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        '--out-dir',
+        outputDir,
+        '--esm',
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'esm'),
+      ]);
 
-    // check that it uses proper root object; it's taken from fixtures/package.json
-    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+      assert(fs.existsSync(expectedJsonResultFile));
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
+      assert(fs.existsSync(expectedCommonJSResultFile));
 
-    const ts = await readFile(expectedTSResultFile);
-    assert(ts.toString().includes('TestMessage'));
-    assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import Long = require'));
-    assert(!ts.toString().includes('import * as Long'));
-    assert(
-      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      ts
-        .toString()
-        .includes('import type {protobuf as $protobuf} from "google-gax"')
-    );
-    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
-  });
+      const json = await readFile(expectedJsonResultFile);
+      const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
+      assert(root.lookup('TestMessage'));
+      assert(root.lookup('LibraryService'));
 
-  it('compiles protos to CJS and ES6 if --esm is specified', async function () {
-    this.timeout(20000);
-    await compileProtos.main([
-      '--esm',
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'esm'),
-    ]);
-    assert(fs.existsSync(expectedJsonResultFile));
-    assert(fs.existsSync(expectedJSResultFile));
-    assert(fs.existsSync(expectedTSResultFile));
-    assert(fs.existsSync(expectedCommonJSResultFile));
+      const cjs = await readFile(expectedCommonJSResultFile);
+      assert(cjs.toString().includes('TestMessage'));
+      assert(cjs.toString().includes('LibraryService'));
+      assert(
+        cjs.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        cjs
+          .toString()
+          .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+      );
+      assert(!cjs.toString().includes('require("protobufjs/minimal")'));
 
-    const json = await readFile(expectedJsonResultFile);
-    const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
-    assert(root.lookup('TestMessage'));
-    assert(root.lookup('LibraryService'));
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(cjs.toString().includes('$protobuf.roots._org_fake_package'));
 
-    const cjs = await readFile(expectedCommonJSResultFile);
-    assert(cjs.toString().includes('TestMessage'));
-    assert(cjs.toString().includes('LibraryService'));
-    assert(
-      cjs.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      cjs
-        .toString()
-        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
-    );
-    assert(!cjs.toString().includes('require("protobufjs/minimal")'));
+      const js = await readFile(expectedJSResultFile);
+      assert(js.toString().includes('TestMessage'));
+      assert(js.toString().includes('LibraryService'));
+      assert(
+        js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        js
+          .toString()
+          .includes(
+            'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf.js"'
+          )
+      );
+      assert(!js.toString().includes('require("protobufjs/minimal")'));
+      assert(
+        !js
+          .toString()
+          .includes('import * as $protobuf from "protobufjs/minimal"')
+      );
 
-    // check that it uses proper root object; it's taken from fixtures/package.json
-    assert(cjs.toString().includes('$protobuf.roots._org_fake_package'));
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(js.toString().includes('$protobuf.roots._org_fake_package'));
 
-    const js = await readFile(expectedJSResultFile);
-    assert(js.toString().includes('TestMessage'));
-    assert(js.toString().includes('LibraryService'));
-    assert(
-      js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      js
-        .toString()
-        .includes(
-          'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf.js"'
-        )
-    );
-    assert(!js.toString().includes('require("protobufjs/minimal")'));
-    assert(
-      !js.toString().includes('import * as $protobuf from "protobufjs/minimal"')
-    );
+      const ts = await readFile(expectedTSResultFile);
+      assert(ts.toString().includes('TestMessage'));
+      assert(ts.toString().includes('LibraryService'));
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        ts
+          .toString()
+          .includes('import type {protobuf as $protobuf} from "google-gax"')
+      );
+      assert(
+        !ts.toString().includes('import * as $protobuf from "protobufjs"')
+      );
+    });
 
-    // check that it uses proper root object; it's taken from fixtures/package.json
-    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
+    it('compiles protos to JSON, JS, TS and outputs it to a specified directory', async function () {
+      this.timeout(20000);
+      await compileProtos.main([
+        '--out-dir',
+        outputDir,
+        path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
+      ]);
+      assert(fs.existsSync(expectedJsonResultFile));
+      assert(fs.existsSync(expectedJSResultFile));
+      assert(fs.existsSync(expectedTSResultFile));
 
-    const ts = await readFile(expectedTSResultFile);
-    assert(ts.toString().includes('TestMessage'));
-    assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import Long = require'));
-    assert(!ts.toString().includes('import * as Long'));
-    assert(
-      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      ts
-        .toString()
-        .includes('import type {protobuf as $protobuf} from "google-gax"')
-    );
-    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
-  });
+      const json = await readFile(expectedJsonResultFile);
+      const root = protobuf.Root.fromJSON(JSON.parse(json.toString()));
+      assert(root.lookup('TestMessage'));
+      assert(root.lookup('LibraryService'));
 
-  it('compiles protos to JS, TS, skips JSON if asked', async function () {
-    this.timeout(20000);
-    await compileProtos.main([
-      '--skip-json',
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
-    ]);
-    assert(!fs.existsSync(expectedJsonResultFile));
-    assert(fs.existsSync(expectedJSResultFile));
-    assert(fs.existsSync(expectedTSResultFile));
+      const js = await readFile(expectedJSResultFile);
+      assert(js.toString().includes('TestMessage'));
+      assert(js.toString().includes('LibraryService'));
+      assert(
+        js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        js
+          .toString()
+          .includes('require("google-gax/build/src/protobuf").protobufMinimal')
+      );
+      assert(!js.toString().includes('require("protobufjs/minimal")'));
 
-    const js = await readFile(expectedJSResultFile);
-    assert(js.toString().includes('TestMessage'));
-    assert(js.toString().includes('LibraryService'));
-    assert(
-      js.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      js
-        .toString()
-        .includes('require("google-gax/build/src/protobuf").protobufMinimal')
-    );
-    assert(!js.toString().includes('require("protobufjs/minimal")'));
+      // check that it uses proper root object; it's taken from fixtures/package.json
+      assert(js.toString().includes('$protobuf.roots._org_fake_package'));
 
-    // check that it uses proper root object; it's taken from fixtures/package.json
-    assert(js.toString().includes('$protobuf.roots._org_fake_package'));
-
-    const ts = await readFile(expectedTSResultFile);
-    assert(ts.toString().includes('TestMessage'));
-    assert(ts.toString().includes('LibraryService'));
-    assert(ts.toString().includes('import Long = require'));
-    assert(!ts.toString().includes('import * as Long'));
-    assert(
-      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(
-      ts
-        .toString()
-        .includes('import type {protobuf as $protobuf} from "google-gax"')
-    );
-    assert(!ts.toString().includes('import * as $protobuf from "protobufjs"'));
-  });
-
-  it('writes an empty object if no protos are given', async () => {
-    await compileProtos.main([
-      path.join(
-        __dirname,
-        '..',
-        '..',
-        'test',
-        'fixtures',
-        'protoLists',
-        'empty'
-      ),
-    ]);
-    assert(fs.existsSync(expectedJsonResultFile));
-  });
-
-  it('fixes types in the TS file', async () => {
-    await compileProtos.main([
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'dts-update'),
-    ]);
-    assert(fs.existsSync(expectedTSResultFile));
-    const ts = await readFile(expectedTSResultFile);
-
-    assert(ts.toString().includes('import Long = require'));
-    assert(!ts.toString().includes('import * as Long'));
-    assert(
-      ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
-    );
-    assert(ts.toString().includes('longField?: (number|Long|string|null);'));
-    assert(ts.toString().includes('bytesField?: (Uint8Array|string|null);'));
-    assert(
-      ts
-        .toString()
-        .includes(
-          'enumField?: (google.TestEnum|keyof typeof google.TestEnum|null);'
-        )
-    );
-    assert(
-      ts
-        .toString()
-        .includes(
-          '"case"?: (google.TestEnum|keyof typeof google.TestEnum|null);'
-        )
-    );
-    assert(ts.toString().includes('public longField: (number|Long|string);'));
-    assert(ts.toString().includes('public bytesField: (Uint8Array|string);'));
-    assert(
-      ts
-        .toString()
-        .includes(
-          'public enumField: (google.TestEnum|keyof typeof google.TestEnum);'
-        )
-    );
-    assert(
-      ts
-        .toString()
-        .includes(
-          'public case: (google.TestEnum|keyof typeof google.TestEnum);'
-        )
-    );
-  });
-
-  it('proposes the name for protobuf root', async () => {
-    const rootName = await compileProtos.generateRootName([
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'dts-update'),
-    ]);
-    assert.strictEqual(rootName, '_org_fake_package_protos');
-  });
-
-  it('falls back to the default name for protobuf root if unable to guess', async () => {
-    const rootName = await compileProtos.generateRootName([
-      path.join(
-        __dirname,
-        '..',
-        '..',
-        'test',
-        'fixtures',
-        'protoLists',
-        'empty'
-      ),
-    ]);
-    assert.strictEqual(rootName, 'default');
-  });
-
-  it('reformat the JSDOC link in the JS and TS file', async function () {
-    this.timeout(20000);
-    await compileProtos.main([
-      path.join(__dirname, '..', '..', 'test', 'fixtures', 'protoLists'),
-    ]);
-    assert(fs.existsSync(expectedJSResultFile));
-    assert(fs.existsSync(expectedTSResultFile));
-    const js = await readFile(expectedJSResultFile);
-    const ts = await readFile(expectedTSResultFile);
-    const links = [
-      '{@link google.example.library.v1.LibraryService#createShelf}',
-      '{@link google.example.library.v1.LibraryService#getShelf}',
-      '{@link google.example.library.v1.LibraryService#listShelves}',
-      '{@link google.example.library.v1.LibraryService#deleteShelf}',
-      '{@link google.example.library.v1.LibraryService#mergeShelves}',
-      '{@link google.example.library.v1.LibraryService#createBook}',
-      '{@link google.example.library.v1.LibraryService#getBook}',
-      '{@link google.example.library.v1.LibraryService#listBooks}',
-      '{@link google.example.library.v1.LibraryService#deleteBook}',
-      '{@link google.example.library.v1.LibraryService#updateBook}',
-      '{@link google.example.library.v1.LibraryService#moveBook}',
-    ];
-    for (const link of links) {
-      const reformate = link.replace('#', '|');
-      assert(js.toString().includes(reformate));
-      assert(ts.toString().includes(reformate));
-      assert.equal(js.toString().includes(link), false);
-    }
+      const ts = await readFile(expectedTSResultFile);
+      assert(ts.toString().includes('TestMessage'));
+      assert(ts.toString().includes('LibraryService'));
+      assert(ts.toString().includes('import Long = require'));
+      assert(!ts.toString().includes('import * as Long'));
+      assert(
+        ts.toString().includes('http://www.apache.org/licenses/LICENSE-2.0')
+      );
+      assert(
+        ts
+          .toString()
+          .includes('import type {protobuf as $protobuf} from "google-gax"')
+      );
+      assert(
+        !ts.toString().includes('import * as $protobuf from "protobufjs"')
+      );
+    });
   });
 });


### PR DESCRIPTION
This allows compileProtos to run with a directory as an argument and another specified directory as another argument.

Specifically for: https://github.com/googleapis/gapic-generator-typescript/pull/1484