### PR TITLE
fix: improve package.json lookup for root name

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -28,13 +28,14 @@
   "author": "Google API Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "@babel/core": "^7.22.5",
+    "@babel/traverse": "^7.22.5",
     "google-gax": "^4.1.0",
     "google-proto-files": "^4.1.0",
     "protobufjs-cli": "1.1.2",
     "rimraf": "^5.0.1",
-    "@babel/core": "^7.22.5",
-    "@babel/traverse": "^7.22.5",
     "uglify-js": "^3.17.0",
+    "walk-up-path": "^3.0.1",
     "walkdir": "^0.4.0"
   },
   "repository": {

--- a/tools/test/compileProtos.ts
+++ b/tools/test/compileProtos.ts
@@ -281,9 +281,16 @@ describe('compileProtos tool', () => {
     assert.strictEqual(rootName, '_org_fake_package_protos');
   });
 
-  it('falls back to the default name for protobuf root if unable to guess', async () => {
+  it('uses the nearest package.json to guess the root name', async () => {
     const rootName = await compileProtos.generateRootName([
       path.join(__dirname, 'protoLists', 'empty'),
+    ]);
+    assert.strictEqual(rootName, 'gapic_tools_protos');
+  });
+
+  it('falls back to the default name for protobuf root if unable to guess', async () => {
+    const rootName = await compileProtos.generateRootName([
+      '/nonexistent/empty',
     ]);
     assert.strictEqual(rootName, 'default');
   });


### PR DESCRIPTION
compileProtos seeks for package.json one directory above the one it accepts as input (typically src).

Running gapic-generator-typescript with --format=esm, generates the the sources in esm/src, then compileProtos can't find package.json.

When package.json is not found, the root name falls back to default and all the packages have the same root.

Use walk-up-path, which is also used by npm[1].

Fixes googleapis/google-cloud-node-core#233.

[1] https://github.com/npm/config/blob/77a48dbe22/lib/index.js#L632

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
