### PR TITLE
feat: implement support for Trusted Partner Cloud

### DIFF
--- a/gax/src/clientInterface.ts
+++ b/gax/src/clientInterface.ts
@@ -38,6 +38,10 @@ export interface ClientOptions
   fallback?: boolean | 'rest' | 'proto';
   apiEndpoint?: string;
   gaxServerStreamingRetries?: boolean;
+  // We support both camelCase and snake_case for the universe domain.
+  // No preference; exception will be thrown if both are set to different values.
+  universeDomain?: string;
+  universe_domain?: string;
 }
 
 export interface Descriptors {

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -290,6 +290,18 @@ export class GrpcClient {
     if (!this.authClient) {
       throw new Error('No authentication was provided');
     }
+    if (!opts.universeDomain) {
+      opts.universeDomain = 'googleapis.com';
+    }
+    if (opts.universeDomain) {
+      const universeFromAuth = this.authClient.universeDomain;
+      if (opts.universeDomain !== universeFromAuth) {
+        throw new Error(
+          `The configured universe domain (${opts.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}. ` +
+            "If you haven't configured the universe domain explicitly, googleapis.com is the default."
+        );
+      }
+    }
     service.resolveAll();
     const methods = GrpcClient.getServiceMethods(service);
 

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -297,7 +297,7 @@ export class GrpcClient {
       const universeFromAuth = this.authClient.universeDomain;
       if (universeFromAuth && opts.universeDomain !== universeFromAuth) {
         throw new Error(
-          `The configured universe domain (${opts.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}. ` +
+          `The configured universe domain (${opts.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}). ` +
             "If you haven't configured the universe domain explicitly, googleapis.com is the default."
         );
       }

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -295,7 +295,7 @@ export class GrpcClient {
     }
     if (opts.universeDomain) {
       const universeFromAuth = this.authClient.universeDomain;
-      if (opts.universeDomain !== universeFromAuth) {
+      if (universeFromAuth && opts.universeDomain !== universeFromAuth) {
         throw new Error(
           `The configured universe domain (${opts.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}. ` +
             "If you haven't configured the universe domain explicitly, googleapis.com is the default."

--- a/gax/src/grpc.ts
+++ b/gax/src/grpc.ts
@@ -418,7 +418,7 @@ export class GrpcClient {
       const universeFromAuth = await this.auth.getUniverseDomain();
       if (universeFromAuth && options.universeDomain !== universeFromAuth) {
         throw new Error(
-          `The configured universe domain (${options.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}. ` +
+          `The configured universe domain (${options.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}). ` +
             "If you haven't configured the universe domain explicitly, googleapis.com is the default."
         );
       }

--- a/gax/src/grpc.ts
+++ b/gax/src/grpc.ts
@@ -416,7 +416,7 @@ export class GrpcClient {
     }
     if (options.universeDomain) {
       const universeFromAuth = await this.auth.getUniverseDomain();
-      if (options.universeDomain !== universeFromAuth) {
+      if (universeFromAuth && options.universeDomain !== universeFromAuth) {
         throw new Error(
           `The configured universe domain (${options.universeDomain}) does not match the universe domain found in the credentials (${universeFromAuth}. ` +
             "If you haven't configured the universe domain explicitly, googleapis.com is the default."

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -31,6 +31,7 @@ import {GoogleError} from '../../src';
 const hasAbortController = typeof AbortController !== 'undefined';
 
 const authClient = {
+  universeDomain: 'googleapis.com',
   async getRequestHeaders() {
     return {Authorization: 'Bearer SOME_TOKEN'};
   },
@@ -133,6 +134,18 @@ describe('createStub', () => {
 
     // Each of the service methods should take 4 arguments (so that it works with createApiCall)
     assert.strictEqual(echoStub.echo.length, 4);
+  });
+
+  it('validates universe domain if set', async () => {
+    const opts = {...stubOptions, universeDomain: 'example.com'};
+    assert.rejects(gaxGrpc.createStub(echoService, opts), /configured universe domain/);
+  });
+
+  it('validates universe domain if unset', async () => {
+    authClient.universeDomain = 'example.com';
+    assert.rejects(gaxGrpc.createStub(echoService, stubOptions), /configured universe domain/);
+    // reset to default value
+    authClient.universeDomain = 'googleapis.com';
   });
 
   it('should support optional parameters', async () => {

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -138,12 +138,18 @@ describe('createStub', () => {
 
   it('validates universe domain if set', async () => {
     const opts = {...stubOptions, universeDomain: 'example.com'};
-    assert.rejects(gaxGrpc.createStub(echoService, opts), /configured universe domain/);
+    assert.rejects(
+      gaxGrpc.createStub(echoService, opts),
+      /configured universe domain/
+    );
   });
 
   it('validates universe domain if unset', async () => {
     authClient.universeDomain = 'example.com';
-    assert.rejects(gaxGrpc.createStub(echoService, stubOptions), /configured universe domain/);
+    assert.rejects(
+      gaxGrpc.createStub(echoService, stubOptions),
+      /configured universe domain/
+    );
     // reset to default value
     authClient.universeDomain = 'googleapis.com';
   });

--- a/gax/test/unit/grpc.ts
+++ b/gax/test/unit/grpc.ts
@@ -184,8 +184,8 @@ describe('grpc', () => {
         port: 443,
         universeDomain: 'example.com',
       };
-      // @ts-ignore
       assert.rejects(
+        // @ts-ignore
         grpcClient.createStub(DummyStub, opts),
         /configured universe domain/
       );
@@ -195,8 +195,8 @@ describe('grpc', () => {
       const opts = {servicePath: 'foo.example.com', port: 443};
       stubAuth.getUniverseDomain.reset();
       stubAuth.getUniverseDomain.resolves('example.com');
-      // @ts-ignore
       assert.rejects(
+        // @ts-ignore
         grpcClient.createStub(DummyStub, opts),
         /configured universe domain/
       );
@@ -697,8 +697,8 @@ dvorak
       // Create a client and test the certificate detection flow:
       process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'true';
       const client = gaxGrpc();
-      // @ts-ignore
       assert.rejects(
+        // @ts-ignore
         client.createStub(DummyStub, {universeDomain: 'example.com'}),
         /configured universe domain/
       );

--- a/gax/test/unit/grpc.ts
+++ b/gax/test/unit/grpc.ts
@@ -179,9 +179,16 @@ describe('grpc', () => {
     });
 
     it('validates universe domain if set', async () => {
-      const opts = {servicePath: 'foo.example.com', port: 443, universeDomain: 'example.com'};
+      const opts = {
+        servicePath: 'foo.example.com',
+        port: 443,
+        universeDomain: 'example.com',
+      };
       // @ts-ignore
-      assert.rejects(grpcClient.createStub(DummyStub, opts), /configured universe domain/);
+      assert.rejects(
+        grpcClient.createStub(DummyStub, opts),
+        /configured universe domain/
+      );
     });
 
     it('validates universe domain if unset', async () => {
@@ -189,7 +196,10 @@ describe('grpc', () => {
       stubAuth.getUniverseDomain.reset();
       stubAuth.getUniverseDomain.resolves('example.com');
       // @ts-ignore
-      assert.rejects(grpcClient.createStub(DummyStub, opts), /configured universe domain/);
+      assert.rejects(
+        grpcClient.createStub(DummyStub, opts),
+        /configured universe domain/
+      );
     });
 
     it('supports optional parameters', () => {
@@ -688,7 +698,10 @@ dvorak
       process.env.GOOGLE_API_USE_CLIENT_CERTIFICATE = 'true';
       const client = gaxGrpc();
       // @ts-ignore
-      assert.rejects(client.createStub(DummyStub, {universeDomain: 'example.com'}), /configured universe domain/);
+      assert.rejects(
+        client.createStub(DummyStub, {universeDomain: 'example.com'}),
+        /configured universe domain/
+      );
       rimrafSync(tmpFolder); // Cleanup.
     });
   });


### PR DESCRIPTION
Client libraries will start passing `universeDomain` to `createStub` method for both gRPC and REST transports. Perform some validation as required.

Related: https://github.com/googleapis/google-auth-library-nodejs/pull/1732