### PR TITLE
feat: allow passing --keep-case and --force-number to compileProtos

### DIFF
--- a/tools/test/compileProtos.ts
+++ b/tools/test/compileProtos.ts
@@ -315,4 +315,48 @@ describe('compileProtos tool', () => {
       assert.equal(js.toString().includes(link), false);
     }
   });
+
+  it('converts names to camelCase and uses Long by default', async function () {
+    this.timeout(20000);
+    const dirName = path.join(testDir, 'protoLists', 'parameters');
+    await compileProtos.main([dirName]);
+    const jsonBuf = await readFile(expectedJsonResultFile);
+    const json = JSON.parse(jsonBuf.toString());
+    const js = await readFile(expectedJSResultFile);
+    assert(json.nested.test.nested.Test.fields.snakeCaseField);
+    assert(js.includes('@property {number|Long|null} [checkForceNumber]'));
+  });
+
+  it('understands --keep-case', async function () {
+    this.timeout(20000);
+    const dirName = path.join(testDir, 'protoLists', 'parameters');
+    await compileProtos.main(['--keep-case', dirName]);
+    const jsonBuf = await readFile(expectedJsonResultFile);
+    const json = JSON.parse(jsonBuf.toString());
+    const js = await readFile(expectedJSResultFile);
+    assert(json.nested.test.nested.Test.fields.snake_case_field);
+    assert(js.includes('@property {number|Long|null} [check_force_number]'));
+  });
+
+  it('understands --force-number', async function () {
+    this.timeout(20000);
+    const dirName = path.join(testDir, 'protoLists', 'parameters');
+    await compileProtos.main(['--force-number', dirName]);
+    const jsonBuf = await readFile(expectedJsonResultFile);
+    const json = JSON.parse(jsonBuf.toString());
+    const js = await readFile(expectedJSResultFile);
+    assert(json.nested.test.nested.Test.fields.snakeCaseField);
+    assert(js.includes('@property {number|null} [checkForceNumber]'));
+  });
+
+  it('understands both --keep-case and --force-number', async function () {
+    this.timeout(20000);
+    const dirName = path.join(testDir, 'protoLists', 'parameters');
+    await compileProtos.main(['--keep-case', '--force-number', dirName]);
+    const jsonBuf = await readFile(expectedJsonResultFile);
+    const json = JSON.parse(jsonBuf.toString());
+    const js = await readFile(expectedJSResultFile);
+    assert(json.nested.test.nested.Test.fields.snake_case_field);
+    assert(js.includes('@property {number|null} [check_force_number]'));
+  });
 });

--- a/tools/test/fixtures/protoLists/parameters/parameters_proto_list.json
+++ b/tools/test/fixtures/protoLists/parameters/parameters_proto_list.json
@@ -1,0 +1,3 @@
+[
+  "../../protos/google/example/library/v1/parameters.proto"
+]

--- a/tools/test/fixtures/protos/google/example/library/v1/parameters.proto
+++ b/tools/test/fixtures/protos/google/example/library/v1/parameters.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package test;
+
+message Test {
+  string snake_case_field = 1;
+  uint64 check_force_number = 2;
+}


### PR DESCRIPTION
Making it possible to pass two extra flags to `pbjs` / `pbts`: `--keep-case` to use snake_case if needed, and `--force-number` to avoid using `Long`. Both flags are used in the Opteo fork [here](https://github.com/Opteo/gax-nodejs/blob/master/tools/src/compileProtos.ts), and making it configurable will make it easier for Opteo to stop maintaining the fork and use `google-gax` directly.