### PR TITLE
chore: regenerate showcase client

### DIFF
--- a/gax/test/showcase-echo-client/protos/google/showcase/v1beta1/echo.proto
+++ b/gax/test/showcase-echo-client/protos/google/showcase/v1beta1/echo.proto
@@ -43,6 +43,8 @@ service Echo {
   // This service is meant to only run locally on the port 7469 (keypad digits
   // for "show").
   option (google.api.default_host) = "localhost:7469";
+  // See https://github.com/aip-dev/google.aip.dev/pull/1331
+  option (google.api.api_version) = "v1_20240408";
 
   // This method simply echoes the request. This method showcases unary RPCs.
   rpc Echo(EchoRequest) returns (EchoResponse) {

--- a/gax/test/showcase-echo-client/src/v1beta1/echo_client.ts
+++ b/gax/test/showcase-echo-client/src/v1beta1/echo_client.ts
@@ -252,8 +252,7 @@ export class EchoClient {
       ),
       collect: new this._gaxModule.StreamDescriptor(
         this._gaxModule.StreamType.CLIENT_STREAMING,
-        !!opts.fallback,
-        !!opts.gaxServerStreamingRetries
+        !!opts.fallback
       ),
       chat: new this._gaxModule.StreamDescriptor(
         this._gaxModule.StreamType.BIDI_STREAMING,


### PR DESCRIPTION
Regenerate showcase with more fine grained template changes changes from https://github.com/googleapis/gapic-generator-typescript/pull/1575