### PR TITLE
chore(deps): proto-loader to 0.7.13

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "@grpc/grpc-js": "~1.10.3",
-    "@grpc/proto-loader": "^0.7.0",
+    "@grpc/proto-loader": "^0.7.13",
     "@types/long": "^4.0.0",
     "abort-controller": "^3.0.0",
     "duplexify": "^4.0.0",


### PR DESCRIPTION
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)


While protobufjs itself was updated to avoid the issue in >7.2.6 , proto-loader was not, which itself requires a version of protobufjs with the vulnerability still present.

This PR aims to fix that by upgrading proto-loader to latest where the requirement for the vulnerable version of protobufjs has been updated. 
Ideally renovate-bot would have done this by itself, but I couldn't find a PR for it.

Fixes googleapis/google-cloud-node-core#216  🦕
