### PR TITLE
fix: reduce duplicate code, remove old unused dependency

### DIFF
--- a/gax/src/streamingRetryRequest.ts
+++ b/gax/src/streamingRetryRequest.ts
@@ -40,8 +40,8 @@ interface streamingRetryRequestOptions {
  */
 export function streamingRetryRequest(opts: streamingRetryRequestOptions) {
   opts = Object.assign({}, DEFAULTS, opts);
-  if (opts.request === undefined){
-    throw new Error('A request function must be provided')
+  if (opts.request === undefined) {
+    throw new Error('A request function must be provided');
   }
 
   let numNoResponseAttempts = 0;

--- a/gax/src/streamingRetryRequest.ts
+++ b/gax/src/streamingRetryRequest.ts
@@ -42,12 +42,7 @@ export function streamingRetryRequest(opts: streamingRetryRequestOptions) {
   opts = Object.assign({}, DEFAULTS, opts);
 
   if (opts.request === undefined) {
-    try {
-      // eslint-disable-next-line node/no-unpublished-require
-      opts.request = require('request');
-    } catch (e) {
-      throw new Error('A request library must be provided to retry-request.');
-    }
+      throw new Error('A request function must be provided');
   }
 
   let numNoResponseAttempts = 0;

--- a/gax/src/streamingRetryRequest.ts
+++ b/gax/src/streamingRetryRequest.ts
@@ -42,7 +42,7 @@ export function streamingRetryRequest(opts: streamingRetryRequestOptions) {
   opts = Object.assign({}, DEFAULTS, opts);
 
   if (opts.request === undefined) {
-      throw new Error('A request function must be provided');
+    throw new Error('A request function must be provided');
   }
 
   let numNoResponseAttempts = 0;

--- a/gax/src/streamingRetryRequest.ts
+++ b/gax/src/streamingRetryRequest.ts
@@ -40,6 +40,9 @@ interface streamingRetryRequestOptions {
  */
 export function streamingRetryRequest(opts: streamingRetryRequestOptions) {
   opts = Object.assign({}, DEFAULTS, opts);
+  if (opts.request === undefined){
+    throw new Error('A request function must be provided')
+  }
 
   let numNoResponseAttempts = 0;
   let streamResponseHandled = false;

--- a/gax/src/streamingRetryRequest.ts
+++ b/gax/src/streamingRetryRequest.ts
@@ -30,7 +30,7 @@ const requestOps = null;
 const objectMode = true; // we don't support objectMode being false
 
 interface streamingRetryRequestOptions {
-  request?: Function;
+  request: Function;
   maxRetries?: number;
 }
 /**
@@ -40,10 +40,6 @@ interface streamingRetryRequestOptions {
  */
 export function streamingRetryRequest(opts: streamingRetryRequestOptions) {
   opts = Object.assign({}, DEFAULTS, opts);
-
-  if (opts.request === undefined) {
-    throw new Error('A request function must be provided');
-  }
 
   let numNoResponseAttempts = 0;
   let streamResponseHandled = false;

--- a/gax/test/unit/streamingRetryRequest.ts
+++ b/gax/test/unit/streamingRetryRequest.ts
@@ -96,16 +96,5 @@ describe('retry-request', () => {
         });
       assert.strictEqual(retryStream._readableState.objectMode, true);
     });
-
-    it('throws request error', done => {
-      try {
-        const opts = {};
-        streamingRetryRequest(opts);
-      } catch (err) {
-        assert(err instanceof Error);
-        assert.match(err.message, /A request function must be provided/);
-        done();
-      }
-    });
   });
 });

--- a/gax/test/unit/streamingRetryRequest.ts
+++ b/gax/test/unit/streamingRetryRequest.ts
@@ -103,7 +103,7 @@ describe('retry-request', () => {
         streamingRetryRequest(opts);
       } catch (err) {
         assert(err instanceof Error);
-        assert.match(err.message, /A request library must be provided/);
+        assert.match(err.message, /A request function must be provided/);
         done();
       }
     });

--- a/gax/test/unit/streamingRetryRequest.ts
+++ b/gax/test/unit/streamingRetryRequest.ts
@@ -96,5 +96,16 @@ describe('retry-request', () => {
         });
       assert.strictEqual(retryStream._readableState.objectMode, true);
     });
+    it('throws request error', done => {
+      try {
+        const opts = {};
+        //@ts-expect-error
+        streamingRetryRequest(opts);
+      } catch (err) {
+        assert(err instanceof Error);
+        assert.match(err.message, /A request function must be provided/);
+        done();
+      }
+    });
   });
 });


### PR DESCRIPTION
1. Moves some duplicated event handling code into helper functions 
2. Removes unused dependency on deprecated `request` library that wasn't actually being used and was causing security issues for some, fixes googleapis/google-cloud-node-core#217, fixes googleapis/google-cloud-node-core#212

Partially helps with b/342418572
