### PR TITLE
fix: reduce duplicate code in streaming retries and add a test

### DIFF
--- a/gax/test/test-application/src/index.ts
+++ b/gax/test/test-application/src/index.ts
@@ -1238,6 +1238,7 @@ async function testServerStreamingRetriesImmediatelywithRetryOptions(
     10000
   );
 
+  // allow the two codes we are going to send as errors
   const retryOptions = new RetryOptions([14, 4], backoffSettings);
 
   const settings = {
@@ -1246,6 +1247,7 @@ async function testServerStreamingRetriesImmediatelywithRetryOptions(
 
   client.initialize();
 
+  // errors immediately, then again after sending "This is"
   const request = createStreamingSequenceRequestFactory(
     [Status.UNAVAILABLE, Status.DEADLINE_EXCEEDED, Status.OK],
     [0.1, 0.1, 0.1],

--- a/gax/test/test-application/src/index.ts
+++ b/gax/test/test-application/src/index.ts
@@ -151,6 +151,10 @@ async function testShowcase() {
   );
 
   await testErrorMaxRetries0(grpcSequenceClientWithServerStreamingRetries);
+  await testServerStreamingRetriesImmediatelywithRetryOptions(
+    grpcSequenceClientWithServerStreamingRetries
+  );
+
   // ensure legacy tests pass with streaming retries client
   await testEcho(grpcClientWithServerStreamingRetries);
   await testEchoError(grpcClientWithServerStreamingRetries);
@@ -1217,6 +1221,66 @@ async function testErrorMaxRetries0(client: SequenceServiceClient) {
         new GoogleError('The stream should not end before it receives an error')
       );
     });
+  });
+}
+// a streaming call that retries two times and finishes successfully
+async function testServerStreamingRetriesImmediatelywithRetryOptions(
+  client: SequenceServiceClient
+) {
+  const finalData: string[] = [];
+  const backoffSettings = createBackoffSettings(
+    100,
+    1.2,
+    1000,
+    null,
+    1.5,
+    3000,
+    10000
+  );
+
+  const retryOptions = new RetryOptions([14, 4], backoffSettings);
+
+  const settings = {
+    retry: retryOptions,
+  };
+
+  client.initialize();
+
+  const request = createStreamingSequenceRequestFactory(
+    [Status.UNAVAILABLE, Status.DEADLINE_EXCEEDED, Status.OK],
+    [0.1, 0.1, 0.1],
+    [0, 2, 11],
+    'This is testing the brand new and shiny StreamingSequence server 3'
+  );
+
+  const response = await client.createStreamingSequence(request);
+  await new Promise<void>((resolve, reject) => {
+    const sequence = response[0];
+
+    const attemptRequest =
+      new protos.google.showcase.v1beta1.AttemptStreamingSequenceRequest();
+    attemptRequest.name = sequence.name!;
+
+    const attemptStream = client.attemptStreamingSequence(
+      attemptRequest,
+      settings
+    );
+    attemptStream.on('data', (response: {content: string}) => {
+      finalData.push(response.content);
+    });
+    attemptStream.on('error', error => {
+      reject(error);
+    });
+    attemptStream.on('end', () => {
+      attemptStream.end();
+
+      resolve();
+    });
+  }).then(() => {
+    assert.equal(
+      finalData.join(' '),
+      'This is This is testing the brand new and shiny StreamingSequence server 3'
+    );
   });
 }
 


### PR DESCRIPTION
This is part of some larger cleanup work and adds a scenario we weren't checking for before in the test application and reduces some duplicate code in the server streaming retries implementation
