### PR TITLE
feat: Improve `AuthClient` Compatibility

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -37,6 +37,7 @@
     "@types/sinon": "^17.0.0",
     "@types/uglify-js": "^3.17.0",
     "c8": "^9.0.0",
+    "cheerio": "1.0.0-rc.12",
     "codecov": "^3.1.0",
     "execa": "^5.0.0",
     "glob": "10.4.5",

--- a/gax/src/clientInterface.ts
+++ b/gax/src/clientInterface.ts
@@ -18,7 +18,7 @@
 
 import {GrpcClientOptions, ClientStubOptions} from './grpc';
 import * as gax from './gax';
-import {GoogleAuthOptions} from 'google-auth-library';
+import {AuthClient, GoogleAuthOptions} from 'google-auth-library';
 import {
   BundleDescriptor,
   LongrunningDescriptor,
@@ -30,7 +30,7 @@ import * as operationProtos from '../protos/operations';
 
 export interface ClientOptions
   extends GrpcClientOptions,
-    GoogleAuthOptions,
+    GoogleAuthOptions<AuthClient>,
     ClientStubOptions {
   libName?: string;
   libVersion?: string;

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -20,7 +20,12 @@ import * as protobuf from 'protobufjs';
 import * as gax from './gax';
 import * as routingHeader from './routingHeader';
 import {Status} from './status';
-import {GoogleAuth, GoogleAuthOptions, AuthClient} from 'google-auth-library';
+import {
+  GoogleAuth,
+  GoogleAuthOptions,
+  AuthClient,
+  AnyAuthClient,
+} from 'google-auth-library';
 import {OperationsClientBuilder} from './operationsClient';
 import type {GrpcClientOptions, ClientStubOptions} from './grpc';
 import {GaxCall, GRPCCall} from './apitypes';
@@ -37,7 +42,7 @@ import * as IamProtos from '../protos/iam_service';
 import * as LocationProtos from '../protos/locations';
 import * as operationsProtos from '../protos/operations';
 
-export {AuthClient};
+export {AnyAuthClient as AuthClient};
 export {FallbackServiceError};
 export {PathTemplate} from './pathTemplate';
 export {routingHeader};

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -20,12 +20,7 @@ import * as protobuf from 'protobufjs';
 import * as gax from './gax';
 import * as routingHeader from './routingHeader';
 import {Status} from './status';
-import {
-  GoogleAuth,
-  GoogleAuthOptions,
-  AuthClient,
-  AnyAuthClient,
-} from 'google-auth-library';
+import {GoogleAuth, AuthClient, AnyAuthClient} from 'google-auth-library';
 import {OperationsClientBuilder} from './operationsClient';
 import type {GrpcClientOptions, ClientStubOptions} from './grpc';
 import {GaxCall, GRPCCall} from './apitypes';
@@ -118,17 +113,19 @@ export class GrpcClient {
       fallback?: boolean | string;
     } = {}
   ) {
-    if (!isNodeJS()) {
-      if (!options.auth) {
-        throw new Error(
-          JSON.stringify(options) +
-            'You need to pass auth instance to use gRPC-fallback client in browser or other non-Node.js environments. Provide a `GoogleAuth` or `AuthClient` instance from `google-auth-library`.'
-        );
-      }
+    if (options.auth) {
       this.auth = options.auth;
+    } else if ('authClient' in options) {
+      this.auth = options.authClient;
+    } else if (!isNodeJS()) {
+      throw new Error(
+        JSON.stringify(options) +
+          'You need to pass auth instance to use gRPC-fallback client in browser or other non-Node.js environments. Provide a `GoogleAuth` or `AuthClient` instance from `google-auth-library`.'
+      );
     } else {
-      this.auth = options.auth || new GoogleAuth(options as GoogleAuthOptions);
+      this.auth = new GoogleAuth(options as GrpcClientOptions);
     }
+
     this.fallback = options.fallback ? true : false;
     this.grpcVersion = require('../../package.json').version;
     this.httpRules = (options as GrpcClientOptions).httpRules;

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -84,7 +84,7 @@ export interface ServiceMethods {
 }
 
 export class GrpcClient {
-  auth?: AuthClient | GoogleAuth;
+  auth?: AuthClient | GoogleAuth<AuthClient>;
   authClient?: AuthClient;
   fallback: boolean;
   grpcVersion: string;

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -37,6 +37,7 @@ import * as IamProtos from '../protos/iam_service';
 import * as LocationProtos from '../protos/locations';
 import * as operationsProtos from '../protos/operations';
 
+export {AuthClient};
 export {FallbackServiceError};
 export {PathTemplate} from './pathTemplate';
 export {routingHeader};

--- a/gax/src/grpc.ts
+++ b/gax/src/grpc.ts
@@ -17,7 +17,7 @@
 import * as grpcProtoLoader from '@grpc/proto-loader';
 import {execFile} from 'child_process';
 import * as fs from 'fs';
-import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
+import {GoogleAuth, GoogleAuthOptions, AuthClient} from 'google-auth-library';
 import * as grpc from '@grpc/grpc-js';
 import * as os from 'os';
 import {join} from 'path';
@@ -45,7 +45,7 @@ const COMMON_PROTO_FILES: string[] = commonProtoFiles.map(file =>
 );
 
 export interface GrpcClientOptions extends GoogleAuthOptions {
-  auth?: GoogleAuth;
+  auth?: GoogleAuth<AuthClient>;
   grpc?: GrpcModule;
   protoJson?: protobuf.Root;
   httpRules?: Array<google.api.IHttpRule>;
@@ -113,7 +113,7 @@ export class ClientStub extends grpc.Client {
 }
 
 export class GrpcClient {
-  auth: GoogleAuth;
+  auth: GoogleAuth<AuthClient>;
   grpc: GrpcModule;
   grpcVersion: string;
   fallback: boolean | 'rest' | 'proto';

--- a/gax/src/grpc.ts
+++ b/gax/src/grpc.ts
@@ -44,7 +44,7 @@ const COMMON_PROTO_FILES: string[] = commonProtoFiles.map(file =>
   file.replace(/[/\\]/g, path.sep)
 );
 
-export interface GrpcClientOptions extends GoogleAuthOptions {
+export interface GrpcClientOptions extends GoogleAuthOptions<AuthClient> {
   auth?: GoogleAuth<AuthClient>;
   grpc?: GrpcModule;
   protoJson?: protobuf.Root;

--- a/gax/src/iamService.ts
+++ b/gax/src/iamService.ts
@@ -20,7 +20,7 @@ import * as gax from './gax';
 import type {GrpcClient, ClientStubOptions} from './grpc';
 import type {GrpcClient as FallbackGrpcClient} from './fallback';
 import {createApiCall} from './createApiCall';
-import {GoogleAuth, OAuth2Client} from 'google-auth-library';
+import {GoogleAuth, AuthClient} from 'google-auth-library';
 import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
 import * as routingHeader from './routingHeader';
 import * as gapicConfig from './iam_policy_service_client_config.json';
@@ -40,7 +40,7 @@ export class IamClient {
   private _defaults: {[method: string]: gax.CallSettings};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _protos: any;
-  auth?: GoogleAuth | OAuth2Client;
+  auth?: GoogleAuth | AuthClient;
   descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
   innerApiCalls: {[name: string]: Function} = {};
   iamPolicyStub?: Promise<{[name: string]: Function}>;

--- a/gax/src/iamService.ts
+++ b/gax/src/iamService.ts
@@ -40,7 +40,7 @@ export class IamClient {
   private _defaults: {[method: string]: gax.CallSettings};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _protos: any;
-  auth?: GoogleAuth | AuthClient;
+  auth?: GoogleAuth<AuthClient> | AuthClient;
   descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
   innerApiCalls: {[name: string]: Function} = {};
   iamPolicyStub?: Promise<{[name: string]: Function}>;

--- a/gax/src/operationsClient.ts
+++ b/gax/src/operationsClient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type {GoogleAuth, OAuth2Client} from 'google-auth-library';
+import {GoogleAuth, AuthClient} from 'google-auth-library';
 import {ProjectIdCallback} from 'google-auth-library/build/src/auth/googleauth';
 import type {ClientOptions, Callback} from './clientInterface';
 
@@ -62,7 +62,7 @@ export const ALL_SCOPES: string[] = [];
  * @class
  */
 export class OperationsClient {
-  auth?: GoogleAuth | OAuth2Client;
+  auth?: GoogleAuth | AuthClient;
   innerApiCalls: {[name: string]: Function};
   descriptor: {[method: string]: PageDescriptor};
   operationsStub: Promise<{[method: string]: Function}>;

--- a/gax/src/operationsClient.ts
+++ b/gax/src/operationsClient.ts
@@ -62,7 +62,7 @@ export const ALL_SCOPES: string[] = [];
  * @class
  */
 export class OperationsClient {
-  auth?: GoogleAuth | AuthClient;
+  auth?: GoogleAuth<AuthClient> | AuthClient;
   innerApiCalls: {[name: string]: Function};
   descriptor: {[method: string]: PageDescriptor};
   operationsStub: Promise<{[method: string]: Function}>;

--- a/gax/test/unit/regapic.ts
+++ b/gax/test/unit/regapic.ts
@@ -24,13 +24,11 @@ import * as stream from 'stream';
 import echoProtoJson = require('../fixtures/echo.json');
 import {GrpcClient} from '../../src/fallback';
 import * as transcoding from '../../src/transcoding';
-import {GoogleAuth, PassThroughClient} from 'google-auth-library';
+import {PassThroughClient} from 'google-auth-library';
 import {StreamArrayParser} from '../../src/streamArrayParser';
 
 const opts = {
-  auth: new GoogleAuth({
-    authClient: new PassThroughClient({}),
-  }),
+  authClient: new PassThroughClient(),
   fallback: 'rest', // enabling REGAPIC
 };
 

--- a/gax/test/unit/regapic.ts
+++ b/gax/test/unit/regapic.ts
@@ -24,7 +24,7 @@ import * as stream from 'stream';
 import echoProtoJson = require('../fixtures/echo.json');
 import {GrpcClient} from '../../src/fallback';
 import * as transcoding from '../../src/transcoding';
-import {OAuth2Client} from 'google-auth-library';
+import {AuthClient} from 'google-auth-library';
 import {GrpcClientOptions} from '../../src';
 import {StreamArrayParser} from '../../src/streamArrayParser';
 
@@ -43,7 +43,7 @@ const authStub = {
 const opts = {
   auth: authStub,
   fallback: 'rest', // enabling REGAPIC
-} as unknown as (GrpcClientOptions | {auth: OAuth2Client}) & {
+} as unknown as (GrpcClientOptions | {auth: AuthClient}) & {
   fallback?: boolean | 'rest' | 'proto';
 };
 

--- a/gax/test/unit/regapic.ts
+++ b/gax/test/unit/regapic.ts
@@ -24,27 +24,14 @@ import * as stream from 'stream';
 import echoProtoJson = require('../fixtures/echo.json');
 import {GrpcClient} from '../../src/fallback';
 import * as transcoding from '../../src/transcoding';
-import {AuthClient} from 'google-auth-library';
-import {GrpcClientOptions} from '../../src';
+import {GoogleAuth, PassThroughClient} from 'google-auth-library';
 import {StreamArrayParser} from '../../src/streamArrayParser';
 
-const authClient = {
-  async getRequestHeaders() {
-    return {Authorization: 'Bearer SOME_TOKEN'};
-  },
-};
-
-const authStub = {
-  async getClient() {
-    return authClient;
-  },
-};
-
 const opts = {
-  auth: authStub,
+  auth: new GoogleAuth({
+    authClient: new PassThroughClient({}),
+  }),
   fallback: 'rest', // enabling REGAPIC
-} as unknown as (GrpcClientOptions | {auth: AuthClient}) & {
-  fallback?: boolean | 'rest' | 'proto';
 };
 
 describe('REGAPIC', () => {


### PR DESCRIPTION
Currently `OAuth2Client` and `JSONClient` are the only supported `AuthClient`s, which can lead to issues in the future for those looking to use other `AuthClient`s. This PR opens the functionality up to other `AuthClient`s.

This can be further cleaned up in the future with the following upstream FRs:
- https://github.com/googleapis/google-auth-library-nodejs/issues/1677

🦕