### PR TITLE
fix: add dependency to fix tests

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -51,6 +51,7 @@
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",
     "null-loader": "^4.0.0",
+    "pdfmake": "0.2.12",
     "protobufjs-cli": "1.1.3",
     "proxyquire": "^2.0.1",
     "pumpify": "^2.0.0",
@@ -63,11 +64,7 @@
     "webpack": "^4.0.0",
     "webpack-cli": "^4.0.0"
   },
-  "overrides": {
-    "@compodoc/compodoc": {
-      "pdfmake": "0.2.12"
-    }
-  },
+
   "scripts": {
     "docs": "compodoc src/",
     "pretest": "npm run prepare",

--- a/gax/package.json
+++ b/gax/package.json
@@ -63,6 +63,11 @@
     "webpack": "^4.0.0",
     "webpack-cli": "^4.0.0"
   },
+  "overrides": {
+    "@compodoc/compodoc": {
+      "pdfmake": "0.2.12"
+    }
+  },
   "scripts": {
     "docs": "compodoc src/",
     "pretest": "npm run prepare",


### PR DESCRIPTION
Per our discussion in the JS team meeting, add pdfmake as a direct dependency to fix googleapis/google-cloud-node-core#202