### PR TITLE
fix: remove debug statements

### DIFF
--- a/gax/src/paginationCalls/pagedApiCaller.ts
+++ b/gax/src/paginationCalls/pagedApiCaller.ts
@@ -153,7 +153,6 @@ export class PagedApiCaller implements APICaller {
       ongoingCall.call(apiCall, request);
       return;
     }
-    console.log('155', request, settings);
     if (request.pageSize && settings.autoPaginate) {
       warn(
         'autoPaginate true',
@@ -161,7 +160,6 @@ export class PagedApiCaller implements APICaller {
         'AutopaginateTrueWarning'
       );
     }
-    console.log(request.pageSize && settings.autoPaginate);
 
     const maxResults = settings.maxResults || -1;
 


### PR DESCRIPTION
Some silly goose (me) accidentally left some debug statements in the pagination code so I'm cleaning them up! 🪿 
