### PR TITLE
feat: allow users to turn on logging without the environment variable

### DIFF
--- a/logging-utils/README.md
+++ b/logging-utils/README.md
@@ -1,0 +1,73 @@
+# Google Logging Tools
+
+## About
+This package defines an ad-hoc debug logger utility that can be used as a lightweight alternative to "printf debugging" via `console.log`, and provides more, and more structured information. It is based largely on the ideas of the Node `util.debuglog` function, and the `debug` npm package.
+
+## Contracts
+These are logging utilities meant primarily for use as an "adhoc debug logger" inside Google libraries. It's possible to use this outside of that context, but it is currently not supported. (You're on your own.)
+
+Additionally, everything about the debug logging is not intended to be a stable interface - you can't rely on messages to remain the same, or to continue to exist from one version to the next. For now, it is meant to be a tool for local usage by users, to get the equivalent of "printf debugging" output. In the future, it may tie into more things (OpenTelemetry Logging, etc). Structured log output is possible for vacuuming into Cloud Logging.
+
+This npm package itself is intended to follow semver standards for its own interfaces, but no guarantees are made for supported time windows, etc.
+
+## Usage
+The user interface for this logging is very similar to Node's built-in logging. The primary unit of logging is called a "system", and some libraries may have sub-units called "subsystems". You separate the system and subsystem with a colon, like "pubsub:leasing" or similar. Wildcards may be used (e.g. "pubsub:*"), and multiple of these system/system:subsystem pairs may be listed out, separated by commas. For generated GAPIC libraries, the "system" will generally be the part of the package name specific to the library (e.g. `@google-cloud/translate` will be `translate`).
+
+The environment variable for activating logging is `GOOGLE_SDK_NODE_LOGGING`. So you could run your application similarly to this:
+
+```
+GOOGLE_SDK_NODE_LOGGING=translate node yourApp.js
+```
+
+Or even enable everything, though you might end up with a firehose if you have multiple libraries as dependencies:
+
+```
+GOOGLE_SDK_NODE_LOGGING=* node yourApp.js
+```
+
+## Logging
+Logging functions are created by calling the `log()` function. You pass a system or system:subsystem identifier, and a function is returned. This function may be called directly:
+
+```
+const logger = log('test');
+logger({other:{metadata: 'foo'}}, 'format string %j', {formatted: 'parameter'});
+```
+
+You may also call shorthands that set the `severity` metadata field, and use defaults for the metadata object generally:
+
+```
+logger.debug('format string %s', 'string');
+logger.info('format string %s', 'string');
+logger.warn('format string %s', 'string');
+logger.error('format string %s', 'string');
+```
+
+Finally, the logger function may be used to create a "sub-log", i.e. adding a sub-system to a system:
+
+```
+const sublogger = logger.sublog('specific');
+logger.info('big one');
+sublogger.info('specific!');
+```
+
+This will output two logs, filed under `test` and `test:specific`, respectively.
+
+## Backends
+Additionally, there is a concept of a logging backend. You can manually set where you want logs to go, by default, and how you want them processed. The `setBackend()` function lets you set a backend manually. `undefined` (reset to defaults) and `null` (disable logging) are also possible options.
+
+The package provides several built-in options:
+
+* `getNodeBackend()` This is the default that comes with setting the environment variable. It detects the possibility of coloration in the terminal and formats outputs using `util.format()`.
+* `getDebugBackend(debugpkg)` This interfaces with the `debug` npm package. You'd essentially do something like `setBackend(getDebugBackend(require('debug')))`.
+* `getStructuredBackend(upstream?)`. This converts log output into structured log JSON objects, suitable for feeding into Cloud Logging. An optional `upstream` parameter lets you funnel the output through another backend instead of `console.log`.
+
+## Hooking logs
+The log objects you receive from calling `log()` can be hooked as event emitters, like so:
+
+```
+loggingFunc.on('log', (fields: LogFields, args: unknown[]) => {
+  // Process logs as you like.
+});
+```
+
+This will not prevent normal log output, and system/system:subsystem identifiers will be cached to make sure that all logs of the same name will output to the same event handlers.

--- a/logging-utils/package.json
+++ b/logging-utils/package.json
@@ -28,9 +28,11 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.9.1",
+    "@types/sinon": "^17.0.3",
     "c8": "^9.0.0",
     "gts": "^5.3.1",
     "mocha": "^9.0.0",
+    "sinon": "^19.0.2",
     "typescript": "^5.1.6"
   },
   "engines": {

--- a/logging-utils/src/logging-utils.ts
+++ b/logging-utils/src/logging-utils.ts
@@ -137,11 +137,19 @@ export class AdhocDebugLogger extends EventEmitter {
   invoke(fields: LogFields, ...args: unknown[]): void {
     // Push out any upstream logger first.
     if (this.upstream) {
-      this.upstream(fields, ...args);
+      try {
+        this.upstream(fields, ...args);
+      } catch (e) {
+        // Swallow exceptions to avoid interfering with other logging.
+      }
     }
 
     // Emit sink events.
-    this.emit('log', fields, args);
+    try {
+      this.emit('log', fields, args);
+    } catch (e) {
+      // Swallow exceptions to avoid interfering with other logging.
+    }
   }
 
   invokeSeverity(severity: LogSeverity, ...args: unknown[]): void {

--- a/logging-utils/src/logging-utils.ts
+++ b/logging-utils/src/logging-utils.ts
@@ -485,7 +485,7 @@ let cachedBackend: DebugLogBackend | null | undefined = undefined;
  *
  * @param backend Results from one of the get*Backend() functions.
  */
-export function setBackend(backend: DebugLogBackend | null) {
+export function setBackend(backend: DebugLogBackend | null | undefined) {
   cachedBackend = backend;
   loggerCache.clear();
 }
@@ -504,10 +504,14 @@ export function log(
   namespace: string,
   parent?: AdhocDebugLogFunction
 ): AdhocDebugLogFunction {
-  // If the enable flag isn't set, do nothing.
-  const enablesFlag = process.env[env.nodeEnables];
-  if (!enablesFlag) {
-    return placeholder;
+  // If the enable environment variable isn't set, do nothing. The user
+  // can still choose to set a backend of their choice using the manual
+  // `setBackend()`.
+  if (!cachedBackend) {
+    const enablesFlag = process.env[env.nodeEnables];
+    if (!enablesFlag) {
+      return placeholder;
+    }
   }
 
   // This might happen mostly if the typings are dropped in a user's code,

--- a/logging-utils/src/logging-utils.ts
+++ b/logging-utils/src/logging-utils.ts
@@ -415,11 +415,11 @@ class StructuredBackend extends DebugLogBackendBase {
 
   constructor(upstream?: DebugLogBackend) {
     super();
-    this.upstream = (upstream as DebugLogBackendBase) ?? new NodeBackend();
+    this.upstream = (upstream as DebugLogBackendBase) ?? undefined;
   }
 
   makeLogger(namespace: string): AdhocDebugLogCallable {
-    const debugLogger = this.upstream.makeLogger(namespace);
+    const debugLogger = this.upstream?.makeLogger(namespace);
     return (fields: LogFields, ...args: unknown[]) => {
       const severity = fields.severity ?? LogSeverity.INFO;
       const json = Object.assign(
@@ -429,14 +429,18 @@ class StructuredBackend extends DebugLogBackendBase {
         },
         fields
       );
-      const jsonString = JSON.stringify(json);
 
-      debugLogger(fields, jsonString);
+      const jsonString = JSON.stringify(json);
+      if (debugLogger) {
+        debugLogger(fields, jsonString);
+      } else {
+        console.log('%s', jsonString);
+      }
     };
   }
 
   setFilters(): void {
-    this.upstream.setFilters();
+    this.upstream?.setFilters();
   }
 }
 

--- a/logging-utils/test/logging-utils.ts
+++ b/logging-utils/test/logging-utils.ts
@@ -46,12 +46,8 @@ describe('adhoc-logging', () => {
   describe('Disabled', () => {
     const system = 'disabled';
 
-    beforeEach(() => {
-      al.setBackend(sink);
-      sink.reset();
-    });
-
     it('obeys a lack of global enable', () => {
+      al.setBackend(undefined);
       delete process.env[al.env.nodeEnables];
       const logger = al.log(system);
       logger({}, 'foo');
@@ -59,6 +55,9 @@ describe('adhoc-logging', () => {
     });
 
     it('obeys "all" as an alias for "*"', () => {
+      al.setBackend(sink);
+      sink.reset();
+
       process.env[al.env.nodeEnables] = 'all';
       const logger = al.log(system);
       logger({}, 'foo');
@@ -67,6 +66,30 @@ describe('adhoc-logging', () => {
           namespace: system,
           fields: {},
           args: ['foo'],
+        },
+      ]);
+    });
+  });
+
+  describe('Manually enabled', () => {
+    let logger: al.AdhocDebugLogFunction;
+    const system = 'basic';
+
+    beforeEach(() => {
+      al.setBackend(sink);
+      sink.reset();
+
+      delete process.env[al.env.nodeEnables];
+      logger = al.log(system);
+    });
+
+    it('logs in spite of no environment variable', () => {
+      logger({}, 'test log', 5, {other: 'foo'});
+      assert.deepStrictEqual(sink.logs, [
+        {
+          namespace: system,
+          fields: {},
+          args: ['test log', 5, {other: 'foo'}],
         },
       ]);
     });

--- a/logging-utils/test/logging-utils.ts
+++ b/logging-utils/test/logging-utils.ts
@@ -14,6 +14,7 @@
 
 import {describe, it} from 'mocha';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 
 import * as al from '../src/logging-utils';
 
@@ -211,6 +212,22 @@ describe('adhoc-logging', () => {
       process.env[al.env.nodeEnables] = system;
 
       logger = al.log(system);
+    });
+
+    it('logs to console.log by default', () => {
+      al.setBackend(al.getStructuredBackend());
+      logger = al.log(system);
+      const sandbox = sinon.createSandbox();
+      let called = false;
+      sandbox.stub(console, 'log').callsFake((message, ...params) => {
+        assert.strictEqual(message, '%s');
+        assert.deepStrictEqual(params, [
+          '{"severity":"INFO","message":"test info"}',
+        ]);
+        called = true;
+      });
+      logger.info('test info');
+      assert.strictEqual(called, true);
     });
 
     it('logs with severity', () => {


### PR DESCRIPTION
This is a missed piece of the logger spec, that users have a way to enable the logging without having to use an environment variable (i.e. from code). A few other fixes are part of this as well:

* A README.md file Fixes googleapis/google-cloud-node-core#197 
* Removing formatting from around structured logs

