### PR TITLE
fix: remove .js file in protobuf export

### DIFF
--- a/tools/src/compileProtos.ts
+++ b/tools/src/compileProtos.ts
@@ -170,7 +170,7 @@ function fixJsFile(js: string): string {
   // depend on protobufjs, so we re-export it from google-gax
   js = js.replace(
     'import * as $protobuf from "protobufjs/minimal"',
-    'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf.js"',
+    'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf"',
   );
 
   // 1. fix protobufjs require: we don't want the libraries to

--- a/tools/test/compileProtos.ts
+++ b/tools/test/compileProtos.ts
@@ -160,7 +160,7 @@ describe('compileProtos tool', () => {
       js
         .toString()
         .includes(
-          'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf.js"',
+          'import {protobufMinimal  as $protobuf} from "google-gax/build/src/protobuf"',
         ),
     );
     assert(!js.toString().includes('require("protobufjs/minimal")'));


### PR DESCRIPTION
Now that gax uses subpaths for exports, we need this to conform to the correct subpath: https://github.com/googleapis/gax-nodejs/blob/96b3c130c4fbf3260f25c2a968293ea639aee166/gax/package.json#L98