### PR TITLE
fix: re-export logging utils from gax

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -16,7 +16,7 @@
     "abort-controller": "^3.0.0",
     "duplexify": "^4.1.3",
     "google-auth-library": "^10.0.0-rc.1",
-    "google-logging-utils": "^1.1.0",
+    "google-logging-utils": "^1.1.1",
     "node-fetch": "^3.3.2",
     "object-hash": "^3.0.0",
     "proto3-json-serializer": "^3.0.0",

--- a/gax/package.json
+++ b/gax/package.json
@@ -16,6 +16,7 @@
     "abort-controller": "^3.0.0",
     "duplexify": "^4.1.3",
     "google-auth-library": "^10.0.0-rc.1",
+    "google-logging-utils": "^1.1.0",
     "node-fetch": "^3.3.2",
     "object-hash": "^3.0.0",
     "proto3-json-serializer": "^3.0.0",

--- a/gax/src/index.ts
+++ b/gax/src/index.ts
@@ -25,6 +25,8 @@ import * as routingHeader from './routingHeader';
 export {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 export * as googleAuthLibrary from 'google-auth-library';
 
+export * as loggingUtils from 'google-logging-utils';
+
 export {grpc};
 export {CancellablePromise, OngoingCall} from './call';
 export {createApiCall} from './createApiCall';


### PR DESCRIPTION
Export the logging package from gax so gapics can use it without adding to their package.json.
