### PR TITLE
fix: add missing export path for generator

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -51,7 +51,6 @@
     "ncp": "^2.0.0",
     "null-loader": "^4.0.1",
     "pdfmake": "^0.2.18",
-    "protobufjs-cli": "^1.1.3",
     "proxyquire": "^2.1.3",
     "pumpify": "^2.0.1",
     "sinon": "^19.0.2",
@@ -96,7 +95,8 @@
     ".": "./build/src/index.js",
     "./fallback": "./build/src/fallback.js",
     "./gax": "./build/src/gax.js",
-    "./build/src/protobuf": "./build/src/protobuf.js"
+    "./build/src/protobuf": "./build/src/protobuf.js",
+    "./build/src/index.js": "./build/src/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
see failure https://github.com/googleapis/gapic-generator-typescript/actions/runs/14117976928/job/39552537783?pr=1710