### PR TITLE
fix!: allow 204 responses in REST fallback mode

### DIFF
--- a/gax/src/fallbackServiceStub.ts
+++ b/gax/src/fallbackServiceStub.ts
@@ -241,9 +241,6 @@ export function generateServiceStub(
                     }
                   }
                 }
-                // If we reach here, it's a cancelled AbortError
-                // return to make sure TS doesn't get mad
-                return;
               });
           }
         })

--- a/gax/src/fallbackServiceStub.ts
+++ b/gax/src/fallbackServiceStub.ts
@@ -142,7 +142,7 @@ export function generateServiceStub(
         headers.set(key, options[key][0]);
       }
       const streamArrayParser = new StreamArrayParser(rpc);
-      let response204Ok = false;       
+      let response204Ok = false;
       const fetchRequest: gaxios.GaxiosOptions = {
         headers: headers,
         body: fetchParameters.body,
@@ -165,12 +165,12 @@ export function generateServiceStub(
           // There is a legacy Apiary configuration that some services
           // use which allows 204 empty responses on success instead of
           // a 200 OK. This most commonly is seen in delete RPCs,
-          // but does occasionally show up in other endpoints. We 
-          // need to allow this behavior so that these clients do not throw an error 
+          // but does occasionally show up in other endpoints. We
+          // need to allow this behavior so that these clients do not throw an error
           // when the call actually succeeded
           // See b/411675301 for more context
-          if(response.status === 204 && response.ok){
-            response204Ok = true; 
+          if (response.status === 204 && response.ok) {
+            response204Ok = true;
           }
           if (response.ok && rpc.responseStream) {
             pipeline(
@@ -207,23 +207,28 @@ export function generateServiceStub(
                     }
                     streamArrayParser.emit('error', err);
                   } else if (callback) {
-                    // This supports a legacy Apiary behavior that allows 
+                    // This supports a legacy Apiary behavior that allows
                     // empty 204 responses. If we do not intercept this potential error
                     // from decodeResponse in fallbackRest
                     // it will cause libraries to erroneously throw an
                     // error when the call succeeded. This error cannot be checked in
                     // fallbackRest.ts because decodeResponse does not have the necessary
                     // context about the response to validate the status code + ok-ness
-                    if(!response204Ok){
+                    if (!response204Ok) {
                       callback(err);
-                      return  // Explicitly return otherwise TS will ha
-                    }
-                    else{
+                      return; // Explicitly return otherwise TS will ha
+                    } else {
                       // format the empty response the same way we format non-empty responses in fallbackRest.ts
-                      const emptyMessage = serializer.fromProto3JSON(rpc.resolvedResponseType!, JSON.parse('{}'))
-                      const resp = rpc.resolvedResponseType!.toObject(emptyMessage!, defaultToObjectOptions)
-                      callback(null, resp)
-                      return // Explicitly return otherwise TS will have issues
+                      const emptyMessage = serializer.fromProto3JSON(
+                        rpc.resolvedResponseType!,
+                        JSON.parse('{}'),
+                      );
+                      const resp = rpc.resolvedResponseType!.toObject(
+                        emptyMessage!,
+                        defaultToObjectOptions,
+                      );
+                      callback(null, resp);
+                      return; // Explicitly return otherwise TS will have issues
                     }
                   } else {
                     // This supports a legacy Apiary behavior that allows
@@ -233,13 +238,19 @@ export function generateServiceStub(
                     // error when the call succeeded. This error cannot be checked in
                     // fallbackRest.ts because decodeResponse does not have the necessary
                     // context about the response to validate the status code + ok-ness
-                    if(!response204Ok){
-                      throw err
+                    if (!response204Ok) {
+                      throw err;
                     }
                     // format the empty response the same way we format non-empty responses in fallbackRest.ts
-                    const emptyMessage = serializer.fromProto3JSON(rpc.resolvedResponseType!, JSON.parse('{}'))
-                    const resp = rpc.resolvedResponseType!.toObject(emptyMessage!, defaultToObjectOptions)
-                    return resp
+                    const emptyMessage = serializer.fromProto3JSON(
+                      rpc.resolvedResponseType!,
+                      JSON.parse('{}'),
+                    );
+                    const resp = rpc.resolvedResponseType!.toObject(
+                      emptyMessage!,
+                      defaultToObjectOptions,
+                    );
+                    return resp;
                   }
                 }
                 // If we reach here, it's a cancelled AbortError

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -350,7 +350,7 @@ describe('grpc-fallback', () => {
     });
   });
 
-  it('should handle a null response from the API with a 204 ', done => {
+  it('service stub should handle a null response from the API with a 204 ', done => {
     const requestObject = {content: 'test-content'};
 
     const emptyResponse = {

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -349,6 +349,30 @@ describe('grpc-fallback', () => {
       });
     });
   });
+
+  it('should handle a null response from the API with a 204 ', done => {
+    const requestObject = {content: 'test-content'};
+
+    const emptyResponse = {
+      content: '',
+    };
+    setMockFallbackResponse(gaxGrpc, new Response(null, {status: 204}));
+
+    void gaxGrpc.createStub(echoService, stubOptions).then(echoStub => {
+      echoStub.echo(requestObject, {}, {}, (err?: Error, resp?: {}) => {
+        try {
+          assert.strictEqual(err, null);
+          assert.strictEqual(
+            JSON.stringify(resp),
+            JSON.stringify(emptyResponse),
+          );
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+  });
   it('should handle a null response from the API ', done => {
     const requestObject = {content: 'test-content'};
     const expectedMessage = 'Received null response from RPC Echo';

--- a/gax/test/unit/grpc.ts
+++ b/gax/test/unit/grpc.ts
@@ -19,7 +19,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import assert from 'assert';
-import * as os from 'os';
 import * as path from 'path';
 import proxyquire from 'proxyquire';
 import * as sinon from 'sinon';

--- a/gax/test/unit/regapic.ts
+++ b/gax/test/unit/regapic.ts
@@ -15,7 +15,7 @@
  */
 
 import assert from 'assert';
-import {describe, it, afterEach, before} from 'mocha';
+import {describe, it, afterEach} from 'mocha';
 import * as protobuf from 'protobufjs';
 import * as path from 'path';
 import * as sinon from 'sinon';


### PR DESCRIPTION
This has the implementation for allowing 204s in REST fallback 
I am not able to add tests to the test application because the Sequence service does not allow us to pass in a sequence of HTTP statuses - only gRPC and in gRPC world, 200 and 204 are both considered success. Additionally, I don't believe I could specify the "error" code of 204 in the Echo service, because 204 isn't an error - it's just empty. 

UPDATE: I was able to add tests based on the example given in #1766. When I did a `strictEqual` on my example empty response and the response I'm getting from the service, I did see `Values have same structure but are not reference-equal` - I chose to compare the JSON stringified versions as one option of comparing, but I'm open to alternatives if we have something that feels a little less janky!

Technically a breaking change but only to two APIs, Bigquery and Compute. And, the breakage is that where they would have returned an error for a 2xx and an empty object, now they will return a success (so actually making it work).

I touched two other tests to remove imports that weren't used, but if you want me to take those out, I can!