### PR TITLE
feat: expose a static method for cached loading of protos from JSON and update protobuf.js to 7.5.2

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -20,7 +20,7 @@
     "node-fetch": "^3.3.2",
     "object-hash": "^3.0.0",
     "proto3-json-serializer": "^3.0.0",
-    "protobufjs": "^7.5.1",
+    "protobufjs": "^7.5.2",
     "retry-request": "^8.0.0"
   },
   "devDependencies": {

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -156,6 +156,16 @@ export class GrpcClient {
   }
 
   loadProtoJSON(json: protobuf.INamespace, ignoreCache = false) {
+    return GrpcClient.protobufFromJSON(json, ignoreCache);
+  }
+
+  /**
+   * Loads the protobuf root object from a JSON object created from a proto file.
+   * By default, this is cached in a global cache and the results should not be mutated.
+   * @param {Object} jsonObject - A JSON version of a protofile created usin protobuf.js
+   * @returns {Object} Root namespace of proto JSON
+   */
+  static protobufFromJSON(json: {}, ignoreCache = false) {
     const hash = objectHash(JSON.stringify(json)).toString();
     const cached = GrpcClient.protoCache.get(hash);
     if (cached && !ignoreCache) {

--- a/gax/src/fallback.ts
+++ b/gax/src/fallback.ts
@@ -373,6 +373,8 @@ export class GrpcClient {
   }
 }
 
+export const protobufFromJSON = GrpcClient.protobufFromJSON;
+
 /**
  * gRPC-fallback version of lro
  *

--- a/gax/src/index.ts
+++ b/gax/src/index.ts
@@ -90,6 +90,8 @@ export * as protobufMinimal from 'protobufjs/minimal';
 import * as fallback from './fallback';
 export {fallback};
 
+export const protobufFromJSON = fallback.GrpcClient.protobufFromJSON;
+
 export {
   APICallback,
   GRPCCallResult,

--- a/gax/src/index.ts
+++ b/gax/src/index.ts
@@ -90,7 +90,7 @@ export * as protobufMinimal from 'protobufjs/minimal';
 import * as fallback from './fallback';
 export {fallback};
 
-export const protobufFromJSON = fallback.GrpcClient.protobufFromJSON;
+export const protobufFromJSON = fallback.protobufFromJSON;
 
 export {
   APICallback,


### PR DESCRIPTION
This will allow for more optimized loads instead of calling `protobuf.Root.fromJSON` directly in generated client code