### PR TITLE
chore: clean up 4.6.1 release

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,8 +1,3 @@
 handleGHRelease: true
 manifest: true
 tagPullRequestNumber: true
-branches:
-  - handleGHRelease: true
-    manifest: true
-    tagPullRequestNumber: true
-    branch: 4.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -19,26 +19,6 @@ branchProtectionRules:
       - windows-gax
       - windows-tools
       - OwlBot Post Processor
-  - pattern: 4.x
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: true
-    requiredStatusCheckContexts:
-      - 'ci/kokoro: Samples test'
-      - 'ci/kokoro: System test'
-      - 'ci/kokoro: Browser test'
-      - docs
-      - lint-gax
-      - lint-tools
-      - test-gax (18)
-      - test-gax (16)
-      - test-tools (18)
-      - test-tools (16)
-      - cla/google
-      - windows-gax
-      - windows-tools
-      - OwlBot Post Processor
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/gax/CHANGELOG.md
+++ b/gax/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://www.npmjs.com/package/gax-nodejs?activeTab=versions
 
+
+## [4.6.1](https://github.com/googleapis/gax-nodejs/compare/google-gax-v4.6.0...google-gax-v4.6.1) (2025-05-15)
+
+
+### Bug Fixes
+
+* remove debug statements ([#1692](https://github.com/googleapis/gax-nodejs/issues/1692)) ([5fb359f](https://github.com/googleapis/gax-nodejs/commit/5fb359fba1c549cea29c9048c6172031e071e1bd))
+
 ## [4.6.0](https://github.com/googleapis/gax-nodejs/compare/google-gax-v4.5.0...google-gax-v4.6.0) (2024-12-19)
 
 


### PR DESCRIPTION
Removes things added in #1755 that aren't needed anymore, adds 4.6.1 to the Changelog manually given that it was a manual release