### PR TITLE
feat:  support custom error types in grpc

### DIFF
--- a/gax/src/googleError.ts
+++ b/gax/src/googleError.ts
@@ -28,7 +28,6 @@ const ANY_PROTO_TYPE_NAME = 'google.protobuf.Any';
 const UNKNOWN_TYPE_ENCONDED_ERROR_PREFIX = 'Unknown type encoded in';
 const UNKNOWN_TYPE_NO_SUCH_TYPE = 'no such type';
 
-
 const NUM_OF_PARTS_IN_PROTO_TYPE_NAME = 2;
 
 export class GoogleError extends Error {
@@ -230,7 +229,6 @@ const buildUnknownProtoAsAny = (
     value: unknownProto.value,
   });
 };
-
 
 // Given a protobuf with rpc status protos and a json response value, generate ErrorDetails.
 // Function will traverse trough all the details of the json value and split them based on ErrorDetails.

--- a/gax/src/util.ts
+++ b/gax/src/util.ts
@@ -126,3 +126,16 @@ export const getProtoNameFromFullName = (fullTypeName: string): string => {
   }
   return parts[1];
 };
+
+// Given a proto Any and a set of protos, decode using the set of protos.
+export const decodeProtobufAny = (
+  anyValue: any,
+  protobuf: protobuf.Type,
+): protobuf.Message<{}> => {
+  if (anyValue.type_url === '') {
+    throw new Error('Any type_url is not set');
+  }
+  const typeName: string = getProtoNameFromFullName(anyValue.type_url);
+  const type: protobuf.Type = protobuf.lookupType(typeName);
+  return type.decode(anyValue.value);
+};

--- a/gax/src/util.ts
+++ b/gax/src/util.ts
@@ -139,3 +139,25 @@ export const decodeProtobufAny = (
   const type: protobuf.Type = protobuf.lookupType(typeName);
   return type.decode(anyValue.value);
 };
+
+// Given list of protos, if any of them are Any proto try to decode them with protos in given protobuf.
+export const decodeAnyProtosInArray = (
+  protoList: Array<{}>,
+  protobuf: protobuf.Type,
+): Array<{}> => {
+  const protoListDecoded: Array<{}> = [];
+  for (const proto of protoList) {
+    if (proto.constructor.name === 'Any') {
+      try {
+        // Proto is Any we try to decode with protos in protobuf.
+        const decodedAnyProto = decodeProtobufAny(proto, protobuf);
+        protoListDecoded.push(decodedAnyProto);
+      } catch (e: any) {
+        // Skip we can't process it.
+      }
+      continue;
+    }
+    protoListDecoded.push(proto);
+  }
+  return protoListDecoded;
+};

--- a/gax/src/util.ts
+++ b/gax/src/util.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+const PROTO_TYPE_PREFIX = 'type.googleapis.com/';
+const NUM_OF_PARTS_IN_PROTO_TYPE_NAME = 2;
+
 const randomUUID = () =>
   globalThis.crypto?.randomUUID() || require('crypto').randomUUID();
 
@@ -113,3 +117,12 @@ export function toLowerCamelCase(str: string) {
 export function makeUUID() {
   return randomUUID();
 }
+
+// Get proto type name removing the prefix. For example full type name: type.googleapis.com/google.rpc.Help, the function returns google.rpc.Help.
+export const getProtoNameFromFullName = (fullTypeName: string): string => {
+  const parts = fullTypeName.split(PROTO_TYPE_PREFIX);
+  if (parts.length !== NUM_OF_PARTS_IN_PROTO_TYPE_NAME) {
+    throw Error("Can't get proto name");
+  }
+  return parts[1];
+};

--- a/gax/test/unit/googleError.ts
+++ b/gax/test/unit/googleError.ts
@@ -519,3 +519,67 @@ describe('http error decoding return resource info for unknown proto-error', () 
     ]);
   });
 });
+
+describe('http error decoding dont break if there is a custom detail', () => {
+  const errorInfo = {
+    '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+    reason: 'SERVICE_DISABLED',
+    domain: 'googleapis.com',
+    metadata: {
+      service: 'translate.googleapis.com',
+      consumer: 'projects/123',
+    },
+  };
+  const help = {
+    '@type': 'type.googleapis.com/google.rpc.Help',
+    links: [
+      {
+        description: 'Google developers console API activation',
+        url: 'https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361',
+      },
+    ],
+  };
+  const custom = {
+    '@type': 'type.googleapis.com/Custom',
+  };
+  const json = {
+    error: {
+      code: 403,
+      message:
+        'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
+      status: 'PERMISSION_DENIED',
+      details: [help, errorInfo, custom],
+    },
+  };
+  it('should promote ErrorInfo if exist in http error', () => {
+    const error = GoogleError.parseHttpError(json);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length,
+    );
+    assert.deepStrictEqual(error.message, json['error']['message']);
+    assert.deepStrictEqual(error.reason, errorInfo.reason);
+    assert.deepStrictEqual(error.domain, errorInfo.domain);
+    assert.deepStrictEqual(
+      JSON.stringify(error.errorInfoMetadata),
+      JSON.stringify(errorInfo.metadata),
+    );
+  });
+
+  it('should support http error in array', () => {
+    const error = GoogleError.parseHttpError([json]);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length,
+    );
+    assert.deepStrictEqual(error.message, json['error']['message']);
+    assert.deepStrictEqual(error.reason, errorInfo.reason);
+    assert.deepStrictEqual(error.domain, errorInfo.domain);
+    assert.deepStrictEqual(
+      JSON.stringify(error.errorInfoMetadata),
+      JSON.stringify(errorInfo.metadata),
+    );
+  });
+});

--- a/gax/test/unit/googleError.ts
+++ b/gax/test/unit/googleError.ts
@@ -116,7 +116,7 @@ describe('gRPC-google error decoding', () => {
     );
   });
 
-  it('DecodeRpcStatusDetails does not fail when unknown type is encoded', () => {
+  it('DecodeRpcStatusDetails does not fail when unknown type is encoded and return it as any', () => {
     const any = {type_url: 'noMatch', value: new Uint8Array()};
     const status = {code: 3, message: 'test', details: [any]};
     const Status = root.lookupType('google.rpc.Status');
@@ -126,10 +126,13 @@ describe('gRPC-google error decoding', () => {
     const gRPCStatusDetailsObj = decoder.decodeGRPCStatusDetails([
       status_buffer,
     ]);
-
+    const unknownTypeDetail = {
+      type_url: 'noMatch',
+      value: '',
+    };
     assert.strictEqual(
       JSON.stringify(gRPCStatusDetailsObj.details),
-      JSON.stringify([]),
+      JSON.stringify([unknownTypeDetail]),
     );
   });
 
@@ -209,7 +212,7 @@ describe('parse grpc status details with ErrorInfo from grpc metadata', () => {
     );
   });
 
-  it('metadata contains key grpc-status-details-bin with ErrorInfo and other unknow type', async () => {
+  it('metadata contains key grpc-status-details-bin with ErrorInfo and other unknown type', async () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const errorProtoJson = require('../../protos/status.json');
     const root = protobuf.Root.fromJSON(errorProtoJson);
@@ -237,9 +240,13 @@ describe('parse grpc status details with ErrorInfo from grpc metadata', () => {
     );
     const decodedError = GoogleError.parseGRPCStatusDetails(grpcError);
     assert(decodedError instanceof GoogleError);
+    const unknownTypeDetail = {
+      type_url: 'unknown_type',
+      value: '',
+    };
     assert.strictEqual(
       JSON.stringify(decodedError.statusDetails),
-      JSON.stringify([errorInfoObj]),
+      JSON.stringify([errorInfoObj, unknownTypeDetail]),
     );
     assert.strictEqual(decodedError.domain, errorInfoObj.domain);
     assert.strictEqual(decodedError.reason, errorInfoObj.reason);

--- a/gax/test/unit/googleError.ts
+++ b/gax/test/unit/googleError.ts
@@ -386,3 +386,67 @@ describe('http error decoding', () => {
     );
   });
 });
+
+describe('http error decoding dont break if there is a custom detail', () => {
+  const errorInfo = {
+    '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+    reason: 'SERVICE_DISABLED',
+    domain: 'googleapis.com',
+    metadata: {
+      service: 'translate.googleapis.com',
+      consumer: 'projects/123',
+    },
+  };
+  const help = {
+    '@type': 'type.googleapis.com/google.rpc.Help',
+    links: [
+      {
+        description: 'Google developers console API activation',
+        url: 'https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361',
+      },
+    ],
+  };
+  const custom = {
+    '@type': 'type.googleapis.com/Custom',
+  };
+  const json = {
+    error: {
+      code: 403,
+      message:
+        'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
+      status: 'PERMISSION_DENIED',
+      details: [help, errorInfo, custom],
+    },
+  };
+  it('should promote ErrorInfo if exist in http error', () => {
+    const error = GoogleError.parseHttpError(json);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length,
+    );
+    assert.deepStrictEqual(error.message, json['error']['message']);
+    assert.deepStrictEqual(error.reason, errorInfo.reason);
+    assert.deepStrictEqual(error.domain, errorInfo.domain);
+    assert.deepStrictEqual(
+      JSON.stringify(error.errorInfoMetadata),
+      JSON.stringify(errorInfo.metadata),
+    );
+  });
+
+  it('should support http error in array', () => {
+    const error = GoogleError.parseHttpError([json]);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length,
+    );
+    assert.deepStrictEqual(error.message, json['error']['message']);
+    assert.deepStrictEqual(error.reason, errorInfo.reason);
+    assert.deepStrictEqual(error.domain, errorInfo.domain);
+    assert.deepStrictEqual(
+      JSON.stringify(error.errorInfoMetadata),
+      JSON.stringify(errorInfo.metadata),
+    );
+  });
+});

--- a/gax/test/unit/googleError.ts
+++ b/gax/test/unit/googleError.ts
@@ -583,3 +583,30 @@ describe('http error decoding dont break if there is a custom detail', () => {
     );
   });
 });
+
+describe('http error decoding return resource info for unknown proto-error', () => {
+  const custom = {
+    '@type': 'type.googleapis.com/Custom',
+  };
+  const json = {
+    error: {
+      code: 403,
+      message:
+        'Cloud Translation API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/translate.googleapis.com/overview?project=455411330361 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
+      status: 'PERMISSION_DENIED',
+      details: [custom],
+    },
+  };
+  it('should support http custom errors', () => {
+    const error = GoogleError.parseHttpError([json]);
+    assert.deepStrictEqual(error.code, rpcCodeFromHttpStatusCode(403));
+    assert.deepStrictEqual(
+      error.statusDetails?.length,
+      json['error']['details'].length,
+    );
+    assert.deepEqual(error.statusDetails[0], {
+      resourceType: 'type.googleapis.com/Custom',
+      description: JSON.stringify(custom),
+    });
+  });
+});

--- a/gax/test/unit/util.ts
+++ b/gax/test/unit/util.ts
@@ -21,6 +21,7 @@ import {
   camelToSnakeCase,
   toLowerCamelCase,
   makeUUID,
+  getProtoNameFromFullName,
 } from '../../src/util';
 
 describe('util.ts', () => {
@@ -83,5 +84,18 @@ describe('util.ts', () => {
 
   it('returns UUID', () => {
     assert.match(makeUUID(), /[a-z0-9-]{36}/);
+  });
+
+  it('test getProtoNameFromFullName success', () => {
+    const fullName = 'type.googleapis.com/google.rpc.Help';
+    assert.strictEqual(getProtoNameFromFullName(fullName), 'google.rpc.Help');
+  });
+
+  it('test getProtoNameFromFullName fail due to incompatible/wrong fullName', () => {
+    const fullName = 'wrongfullname';
+    assert.throws(
+      () => getProtoNameFromFullName(fullName),
+      new Error("Can't get proto name"),
+    );
   });
 });


### PR DESCRIPTION
## Description

Instead of ignoring unknown proto types during `statusDetails` decoding, this change introduces custom errors wrapped in an `Any` proto. This allows clients with knowledge of the specific custom error type to decode it.
More information in go/custom-error-details-in-node-rpc.

## Impact

Support custom errors instead of ignoring them.

## Testing

Added tests here and tested with internal instructions for custom errors.

## Checklist

- [ x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ x] Ensure the tests and linter pass
- [ x] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ x] Appropriate comments were added, particularly in complex areas or places that require background
- [ x] No new warnings or issues will be generated from this change
