### PR TITLE
Revert "chore(deps): update dependency node to v22"

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -14,8 +14,8 @@
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@octokit/rest": "^21.0.0",
+        "@octokit/rest": "^19.0.0",
         "mocha": "^10.0.0",
-        "sinon": "^21.0.0"
+        "sinon": "^18.0.0"
     }
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -14,8 +14,8 @@
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@octokit/rest": "^19.0.0",
+        "@octokit/rest": "^21.0.0",
         "mocha": "^10.0.0",
-        "sinon": "^18.0.0"
+        "sinon": "^21.0.0"
     }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd gax; npm install
       - run: cd gax; npm test
         env:
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd tools; npm install
       - run: cd tools; npm test
         env:
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd logging-utils; npm install
       - run: cd logging-utils; npm test
         env:
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd gax; npm install
       - run: cd gax; npm run lint
   lint-tools:
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd tools; npm install
       - run: cd tools; npm run lint
   lint-logging-utils:
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd logging-utils; npm install
       - run: cd logging-utils; npm run lint
   docs:
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: cd gax; npm install
       - run: cd gax; npm run docs
       - uses: JustinBeckwith/linkinator-action@v1

--- a/.github/workflows/response.yaml
+++ b/.github/workflows/response.yaml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
           script: |
@@ -27,7 +27,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Reverts googleapis/gax-nodejs#1791

I think we want to run tests on node 18 since we're not ready to migrate yet!