### PR TITLE
perf: remove abort controller polyfill

### DIFF
--- a/gax/package.json
+++ b/gax/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.12.6",
     "@grpc/proto-loader": "^0.8.0",
-    "abort-controller": "^3.0.0",
     "duplexify": "^4.1.3",
     "google-auth-library": "^10.1.0",
     "google-logging-utils": "^1.1.1",

--- a/gax/src/fallbackServiceStub.ts
+++ b/gax/src/fallbackServiceStub.ts
@@ -15,12 +15,11 @@
  */
 
 import type {Response as NodeFetchResponse} from 'node-fetch' with {'resolution-mode': 'import'};
-import {AbortController as NodeAbortController} from 'abort-controller';
 
 import {AuthClient, GoogleAuth, gaxios} from 'google-auth-library';
 import * as serializer from 'proto3-json-serializer';
 
-import {hasAbortController, isNodeJS} from './featureDetection';
+import {isNodeJS} from './featureDetection';
 import {StreamArrayParser} from './streamArrayParser';
 import {defaultToObjectOptions} from './fallback';
 import {pipeline, PipelineSource} from 'stream';
@@ -146,9 +145,7 @@ export function generateServiceStub(
         };
       }
 
-      const cancelController = hasAbortController()
-        ? new AbortController()
-        : new NodeAbortController();
+      const cancelController = new AbortController();
       const cancelSignal = cancelController.signal as AbortSignal;
       let cancelRequested = false;
       const url = fetchParameters.url;

--- a/gax/src/featureDetection.ts
+++ b/gax/src/featureDetection.ts
@@ -26,7 +26,6 @@ const features = {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   textDecoder: typeof TextDecoder !== 'undefined',
   nodeJS: typeof process !== 'undefined' && process?.versions?.node,
-  abortController: typeof AbortController !== 'undefined',
 };
 
 export function hasWindowFetch() {
@@ -35,8 +34,4 @@ export function hasWindowFetch() {
 
 export function isNodeJS() {
   return features.nodeJS;
-}
-
-export function hasAbortController() {
-  return features.abortController;
 }

--- a/gax/src/streamArrayParser.ts
+++ b/gax/src/streamArrayParser.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import {AbortController as NodeAbortController} from 'abort-controller';
 import {Transform} from 'stream';
 
 import {decodeResponse} from './fallbackRest';
-import {hasAbortController} from './featureDetection';
 
 export class StreamArrayParser extends Transform {
   private _done: boolean;
@@ -27,7 +25,7 @@ export class StreamArrayParser extends Transform {
   private _isSkipped: boolean;
   private _level: number;
   rpc: protobuf.Method;
-  cancelController: AbortController | NodeAbortController;
+  cancelController: AbortController;
   cancelSignal: AbortSignal;
   cancelRequested: boolean;
   /**
@@ -59,9 +57,7 @@ export class StreamArrayParser extends Transform {
     this._isSkipped = false;
     this._level = 0;
     this.rpc = rpc;
-    this.cancelController = hasAbortController()
-      ? new AbortController()
-      : new NodeAbortController();
+    this.cancelController = new AbortController()
     this.cancelSignal = this.cancelController.signal as AbortSignal;
     this.cancelRequested = false;
   }

--- a/gax/src/streamArrayParser.ts
+++ b/gax/src/streamArrayParser.ts
@@ -57,7 +57,7 @@ export class StreamArrayParser extends Transform {
     this._isSkipped = false;
     this._level = 0;
     this.rpc = rpc;
-    this.cancelController = new AbortController()
+    this.cancelController = new AbortController();
     this.cancelSignal = this.cancelController.signal as AbortSignal;
     this.cancelRequested = false;
   }

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -185,7 +185,7 @@ describe('grpc-fallback', () => {
     };
 
     class FakeAbortController extends savedAbortController {
-      abortCalled: boolean = false;
+      abortCalled = false;
 
       constructor() {
         super();

--- a/gax/test/unit/grpc-fallback.ts
+++ b/gax/test/unit/grpc-fallback.ts
@@ -19,7 +19,6 @@
 
 import assert from 'assert';
 import {describe, it, beforeEach, afterEach, after} from 'mocha';
-import * as abortController from 'abort-controller';
 import * as protobuf from 'protobufjs';
 import * as sinon from 'sinon';
 import echoProtoJson = require('../fixtures/echo.json');
@@ -27,9 +26,6 @@ import {GrpcClient} from '../../src/fallback';
 import {ClientStubOptions, GoogleAuth, GoogleError} from '../../src';
 import {PassThroughClient} from 'google-auth-library';
 import {setMockFallbackResponse} from './utils';
-
-// @ts-ignore
-const hasAbortController = typeof AbortController !== 'undefined';
 
 let authClient = new PassThroughClient();
 let opts = {
@@ -171,11 +167,8 @@ describe('grpc-fallback', () => {
     protos: protobuf.NamespaceBase,
     echoService: protobuf.Service,
     stubOptions: ClientStubOptions;
-  const createdAbortControllers: string[] = [];
-  // @ts-ignore
-  const savedAbortController = hasAbortController
-    ? AbortController
-    : abortController.AbortController;
+  const createdAbortControllers: AbortController[] = [];
+  const savedAbortController = AbortController;
 
   beforeEach(() => {
     stubOptions = {
@@ -191,24 +184,21 @@ describe('grpc-fallback', () => {
       port: 443,
     };
 
-    const FakeAbortController = function () {
-      // @ts-ignore
-      this.abort = function () {
-        // @ts-ignore
-        this.abortCalled = true;
-      };
-      // @ts-ignore
-      createdAbortControllers.push(this);
-    };
+    class FakeAbortController extends savedAbortController {
+      abortCalled: boolean = false;
 
-    if (hasAbortController) {
-      // @ts-ignore
-      // eslint-disable-next-line no-global-assign
-      AbortController = FakeAbortController;
-    } else {
-      // @ts-ignore
-      abortController.AbortController = FakeAbortController;
+      constructor() {
+        super();
+        createdAbortControllers.push(this);
+      }
+      abort(reason?: unknown) {
+        super.abort(reason);
+        this.abortCalled = true;
+      }
     }
+
+    // eslint-disable-next-line no-global-assign
+    AbortController = FakeAbortController;
   });
 
   beforeEach(() => {
@@ -220,14 +210,8 @@ describe('grpc-fallback', () => {
   });
 
   after(() => {
-    if (hasAbortController) {
-      // @ts-ignore
-      // eslint-disable-next-line no-global-assign
-      AbortController = savedAbortController;
-    } else {
-      // @ts-ignore
-      abortController.AbortController = savedAbortController;
-    }
+    // eslint-disable-next-line no-global-assign
+    AbortController = savedAbortController;
   });
 
   it('should send grpc-web version in the header', () => {


### PR DESCRIPTION
All platforms support this now, so we don't need it anymore.

Replaces #1788.

## Testing

- Existing tests should cover this and have been updated

## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gax-nodejs/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change
