### PR TITLE
chore: deprecate unsafe client options

### DIFF
--- a/gax/src/clientInterface.ts
+++ b/gax/src/clientInterface.ts
@@ -32,6 +32,66 @@ export interface ClientOptions
   extends GrpcClientOptions,
     GoogleAuthOptions,
     ClientStubOptions {
+  /**
+   * @deprecated This option is being deprecated because of a potential security risk.
+   *
+   * This option does not validate the credential configuration. The security
+   * risk occurs when a credential configuration is accepted from a source that
+   * is not under your control and used without validation on your side.
+   *
+   * The recommended way to provide credentials is to create an `auth` object
+   * using `google-auth-library` and pass it to the client constructor.
+   * This will ensure that unexpected credential types with potential for
+   * malicious intent are not loaded unintentionally. For example:
+   * ```
+   * const {GoogleAuth} = require('google-auth-library');
+   * const auth = new GoogleAuth({
+   *   // Scopes can be specified either as an array or as a single, space-delimited string.
+   *   scopes: 'https://www.googleapis.com/auth/cloud-platform'
+   * });
+   * const client = new MyClient({ auth: auth });
+   * ```
+   *
+   * If you are loading your credential configuration from an untrusted source and have
+   * not mitigated the risks (e.g. by validating the configuration yourself), make
+   * these changes as soon as possible to prevent security risks to your environment.
+   *
+   * Regardless of the method used, it is always your responsibility to validate
+   * configurations received from external sources.
+   *
+   * For more details, see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials.
+   */
+  credentials?: {};
+  /**
+   * @deprecated This option is being deprecated because of a potential security risk.
+   *
+   * This option does not validate the credential configuration. The security
+   * risk occurs when a credential configuration is accepted from a source that
+   * is not under your control and used without validation on your side.
+   *
+   * The recommended way to provide credentials is to create an `auth` object
+   * using `google-auth-library` and pass it to the client constructor.
+   * This will ensure that unexpected credential types with potential for
+   * malicious intent are not loaded unintentionally. For example:
+   * ```
+   * const {GoogleAuth} = require('google-auth-library');
+   * const auth = new GoogleAuth({
+   *   // Scopes can be specified either as an array or as a single, space-delimited string.
+   *   scopes: 'https://www.googleapis.com/auth/cloud-platform'
+   * });
+   * const client = new MyClient({ auth: auth });
+   * ```
+   *
+   * If you are loading your credential configuration from an untrusted source and have
+   * not mitigated the risks (e.g. by validating the configuration yourself), make
+   * these changes as soon as possible to prevent security risks to your environment.
+   *
+   * Regardless of the method used, it is always your responsibility to validate
+   * configurations received from external sources.
+   *
+   * For more details, see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials.
+   */
+  keyFilename?: string;
   libName?: string;
   libVersion?: string;
   clientConfig?: gax.ClientConfig;


### PR DESCRIPTION
## Description

Deprecates the keyFilename and credentials constructor options in ClientOptions to mitigate a security vulnerability. This change adds detailed JSDoc warnings guiding users to adopt a safer, explicit credential loading pattern by creating an auth object via google-auth-library before passing it to a client constructor.

## Impact

Users relying on the keyFilename or credentials options will now see deprecation warnings in their IDEs and potentially in logs, encouraging them to migrate to the more secure credential handling mechanism.

## Testing

No new tests or changed tests.

## Checklist

   - [x]  b/437993913
   - [x] Ensure the tests and linter pass
   - [x] Code coverage does not decrease
   - [x] Appropriate docs were updated
   - [x] Appropriate comments were added, particularly in complex areas or
      places that require background
   - [x] No new warnings or issues will be generated from this change

Fixes b/437993913